### PR TITLE
Explicitly Include `stdexcept`

### DIFF
--- a/MParT/MonotoneComponent.h
+++ b/MParT/MonotoneComponent.h
@@ -18,8 +18,8 @@ namespace mpart{
 /**
 @brief Defines a function \f$T:R^N\rightarrow R\f$ such that \f$\partial T / \partial x_N >0\f$ is strictly positive.
 
-@details 
-The function \f$T\f$ is based on another (generally non-monotone) function \f$f : R^N\rightarrow R\f$ and a strictly positve function 
+@details
+The function \f$T\f$ is based on another (generally non-monotone) function \f$f : R^N\rightarrow R\f$ and a strictly positve function
 \f$g : R\rightarrow R_{>0}\f$.   Together, these functions define the monotone component $T$ through
 
 $$
@@ -28,7 +28,7 @@ $$
 
 @tparam ExpansionType A class defining the function \f$f\f$.  It must satisfy the cached parameterization concept.
 @tparam PosFuncType A class defining the function \f$g\f$.  This class must have `Evaluate` and `Derivative` functions accepting a double and returning a double.  The MParT::SoftPlus and MParT::Exp classes in PositiveBijectors.h are examples of classes defining this interface.
-@tparam QuadratureType A class defining the integration scheme used to approximate \f$\int_0^{x_N}  g\left( \frac{\partial f}{\partial x_d}(x_1,x_2,..., x_{N-1}, t) \right) dt\f$.  The type must have a function `Integrate(f,lb,ub)` that accepts a functor `f`, a double lower bound `lb`, a double upper bound `ub`, and returns a double with an estimate of the integral.   The MParT::AdaptiveSimpson and MParT::RecursiveQuadrature classes provide this interface. 
+@tparam QuadratureType A class defining the integration scheme used to approximate \f$\int_0^{x_N}  g\left( \frac{\partial f}{\partial x_d}(x_1,x_2,..., x_{N-1}, t) \right) dt\f$.  The type must have a function `Integrate(f,lb,ub)` that accepts a functor `f`, a double lower bound `lb`, a double upper bound `ub`, and returns a double with an estimate of the integral.   The MParT::AdaptiveSimpson and MParT::RecursiveQuadrature classes provide this interface.
 */
 template<class ExpansionType, class PosFuncType, class QuadratureType>
 class MonotoneComponent
@@ -36,19 +36,19 @@ class MonotoneComponent
 
 public:
 
-    MonotoneComponent(ExpansionType  const& expansion, 
+    MonotoneComponent(ExpansionType  const& expansion,
                       QuadratureType const& quad) : _expansion(expansion), _quad(quad){};
 
 
     /**
        @brief Evaluates the monotone function \f$T(x_1,\ldots,x_D)\f$ at multiple points.
-       
+
      * @param[in] pts A \f$D\times N\f$ array containing the \f$N\f$ points in \f$\mathbb{R}^D\f$ where we want to evaluate the monotone component.  Each column is a point.
      * @param[in] coeffs The coefficients in the expansion defining \f$f\f$.  The length of this array must be the same as the number of terms in the multiindex set passed to the constructor.
      * @param[out] output Kokkos::View<double*> An array containing the evaluattions \f$T(x^{(i)}_1,\ldots,x^{(i)}_D)\f$ for each \f$i\in\{0,\ldots,N\}\f$.
      */
 
-    void Evaluate(Kokkos::View<double**> const& pts, 
+    void Evaluate(Kokkos::View<double**> const& pts,
                   Kokkos::View<double*>  const& coeffs,
                   Kokkos::View<double*>       & output)
     {
@@ -68,8 +68,8 @@ public:
         Kokkos::parallel_for(policy, KOKKOS_LAMBDA (auto team_member) {
 
             unsigned int ptInd = team_member.league_rank();
-            
-            // Create a subview containing only the current point 
+
+            // Create a subview containing only the current point
             auto pt = Kokkos::subview(pts, Kokkos::ALL(), ptInd);
 
             // Get a pointer to the shared memory that Kokkos set up for this team
@@ -78,31 +78,31 @@ public:
             // Fill in entries in the cache that are independent of x_d.  By passing DerivativeFlags::None, we are telling the expansion that no derivatives with wrt x_1,...x_{d-1} will be needed.
             _expansion.FillCache1(cache, pt, DerivativeFlags::None);
 
-            // Compute the integral \int_0^1 g( \partial_D f(x_1,...,x_{D-1},t*x_d)) dt 
-            MonotoneIntegrand<ExpansionType, PosFuncType, decltype(pt)> integrand(cache, 
+            // Compute the integral \int_0^1 g( \partial_D f(x_1,...,x_{D-1},t*x_d)) dt
+            MonotoneIntegrand<ExpansionType, PosFuncType, decltype(pt)> integrand(cache,
                                                                     _expansion,
                                                                     pt,
-                                                                    coeffs, 
+                                                                    coeffs,
                                                                     DerivativeFlags::None);
             output(ptInd) = _quad.Integrate(integrand, 0, 1)(0);
-           
+
             // Finish filling in the cache for an evaluation of the expansion with x_d=0
             _expansion.FillCache2(cache, pt, 0.0, DerivativeFlags::None);
-            output(ptInd) += _expansion.Evaluate(cache, coeffs);   
-                   
+            output(ptInd) += _expansion.Evaluate(cache, coeffs);
+
         });
     }
 
     /**
        @brief Evaluates the monotone function \f$T(x_1,\ldots,x_D)\f$ at multiple points.
-       
+
      * @param[in] pts A \f$D\times N\f$ array containing the \f$N\f$ points in \f$\mathbb{R}^D\f$ where we want to evaluate the monotone component.  Each column is a point.
      * @param[in] coeffs The coefficients in the expansion defining \f$f\f$.  The length of this array must be the same as the number of terms in the multiindex set passed to the constructor.
      * @return Kokkos::View<double*> An array containing the evaluattions \f$T(x^{(i)}_1,\ldots,x^{(i)}_D)\f$ for each \f$i\in\{0,\ldots,N\}\f$.
      */
-    Kokkos::View<double*> Evaluate(Kokkos::View<double**> const& pts, 
+    Kokkos::View<double*> Evaluate(Kokkos::View<double**> const& pts,
                                    Kokkos::View<double*> const& coeffs)
-    {   
+    {
         const unsigned int numPts = pts.extent(1);
         Kokkos::View<double*> output("Monotone Component Evaluations", numPts);
 
@@ -111,7 +111,7 @@ public:
         return output;
     }
 
-    
+
 
     /**
        @brief Approximates the "continuous derivative" \f$\frac{\partial T}{\partial x_D}\f$ derived from the exact integral form of the transport map.
@@ -122,12 +122,12 @@ public:
 
         @see DiscreteDerivative
      */
-    Kokkos::View<double*>  ContinuousDerivative(Kokkos::View<double**> const& pts, 
+    Kokkos::View<double*>  ContinuousDerivative(Kokkos::View<double**> const& pts,
                                               Kokkos::View<double*>  const& coeffs)
-    {   
+    {
         const unsigned int numPts = pts.extent(1);
         Kokkos::View<double*> derivs("Monotone Component Derivatives", numPts);
-        
+
         ContinuousDerivative(pts,coeffs, derivs);
 
         return derivs;
@@ -143,10 +143,10 @@ public:
 
         @see DiscreteDerivative
      */
-    void ContinuousDerivative(Kokkos::View<double**> const& pts, 
+    void ContinuousDerivative(Kokkos::View<double**> const& pts,
                               Kokkos::View<double*>  const& coeffs,
                               Kokkos::View<double*>       & derivs)
-    {   
+    {
         const unsigned int numPts = pts.extent(1);
         const unsigned int numTerms = coeffs.extent(0);
         const unsigned int dim = pts.extent(0);
@@ -159,11 +159,11 @@ public:
 
         // Paralel loop over each point computing T(x_1,...,x_D) for that point
         Kokkos::parallel_for(policy, KOKKOS_LAMBDA (auto team_member) {
-            
+
             // The index of the for loop
             unsigned int ptInd = team_member.league_rank();
 
-            // Create a subview containing only the current point 
+            // Create a subview containing only the current point
             auto pt = Kokkos::subview(pts, Kokkos::ALL(), ptInd);
 
             // Evaluate the orthgonal polynomials in each direction (except the last) for all possible orders
@@ -192,13 +192,13 @@ public:
 
         @see ContinuousDerivative
     */
-    Kokkos::View<double*>  DiscreteDerivative(Kokkos::View<double**> const& pts, 
+    Kokkos::View<double*>  DiscreteDerivative(Kokkos::View<double**> const& pts,
                                               Kokkos::View<double*>  const& coeffs)
-    {   
+    {
         const unsigned int numPts = pts.extent(1);
         Kokkos::View<double*> evals("Component Evaluations", numPts);
         Kokkos::View<double*> derivs("Component Derivatives", numPts);
-        
+
         DiscreteDerivative(pts,coeffs, evals, derivs);
 
         return derivs;
@@ -214,11 +214,11 @@ public:
 
         @see ContinuousDerivative
      */
-    void  DiscreteDerivative(Kokkos::View<double**> const& pts, 
+    void  DiscreteDerivative(Kokkos::View<double**> const& pts,
                              Kokkos::View<double*>  const& coeffs,
-                             Kokkos::View<double*>       & evals, 
+                             Kokkos::View<double*>       & evals,
                              Kokkos::View<double*>       & derivs)
-    {   
+    {
         const unsigned int numPts = pts.extent(1);
         const unsigned int numTerms = coeffs.extent(0);
         const unsigned int dim = pts.extent(0);
@@ -235,21 +235,21 @@ public:
 
         // Paralel loop over each point computing T(x_1,...,x_D) for that point
         Kokkos::parallel_for(policy, KOKKOS_LAMBDA (auto team_member) {
-            
+
             unsigned int ptInd = team_member.league_rank();
 
-            // Create a subview containing only the current point 
+            // Create a subview containing only the current point
             auto pt = Kokkos::subview(pts, Kokkos::ALL(), ptInd);
 
             // Get a pointer to the shared memory Kokkos is managing for the cache
             double* cache = (double*) team_member.team_shmem().get_shmem(cacheSize*sizeof(double));
-            
+
             // Fill in the cache with anything that doesn't depend on x_d
             _expansion.FillCache1(cache, pt, DerivativeFlags::None);
-            
+
             // Create the integrand g( \partial_D f(x_1,...,x_{D-1},t))
             MonotoneIntegrand<ExpansionType, PosFuncType, decltype(pt)> integrand(cache, _expansion, pt, coeffs, DerivativeFlags::Diagonal);
-            
+
             // Compute \int_0^x g( \partial_D f(x_1,...,x_{D-1},t)) dt
             Eigen::VectorXd both = _quad.Integrate(integrand, 0, 1);
             evals(ptInd) = both(0);
@@ -258,25 +258,25 @@ public:
             // Add f(x_1,x_2,...,x_{d-1},0) to the evaluation output
             _expansion.FillCache2(cache, pt, 0.0, DerivativeFlags::None);
             evals(ptInd) += _expansion.Evaluate(cache, coeffs);
-            
+
         });
     }
 
     /** @brief Returns the gradient of the map with respect to the parameters \f$\mathbf{w}\f$ at multiple points.
 
-        @details 
-        Consider \f$N\f$ points \f$\{\mathbf{x}^{(1)},\ldots,\mathbf{x}^{(N)}\}\f$ and let 
+        @details
+        Consider \f$N\f$ points \f$\{\mathbf{x}^{(1)},\ldots,\mathbf{x}^{(N)}\}\f$ and let
         \f$y_d^{(i)} = T_d(\mathbf{x}^{(i)}; \mathbf{w})\f$.   This function computes \f$\nabla_{\mathbf{w}} y_d^{(i)}\f$
         for each output \f$y_d^{(i)}\f$.
-        
+
         @param[in] pts A \f$D\times N\f$ matrix containing the points \f$x^{(1)},\ldots,x^{(N)}\f$.  Each column is a point.
         @param[in] coeffs A vector of coefficients defining the function \f$f(\mathbf{x}; \mathbf{w})\f$.
         @param[out] evaluations A vector containing the \f$N\f$ predictions \f$y_d^{(i)}\f$.  The vector must be preallocated and have \f$N\f$ components when passed to this function.  An assertion will be thrown in this vector is not the correct size.
         @param[out] jacobian A matrix containing the \f$N\times M\f$ Jacobian matrix, where \f$M\f$ is the length of the parameter vector \f$\mathbf{w}\f$.  This matrix must be sized correctly or an assertion will be thrown.
-        
+
         @see CoeffGradient
     */
-    void CoeffJacobian(Kokkos::View<double**> const& pts, 
+    void CoeffJacobian(Kokkos::View<double**> const& pts,
                        Kokkos::View<double*>  const& coeffs,
                        Kokkos::View<double*>       & evaluations,
                        Kokkos::View<double**>      & jacobian)
@@ -298,10 +298,10 @@ public:
 
         // Paralel loop over each point computing T(x_1,...,x_D) for that point
         Kokkos::parallel_for(policy, KOKKOS_LAMBDA (auto team_member) {
-            
+
             unsigned int ptInd = team_member.league_rank();
 
-            // Create a subview containing only the current point 
+            // Create a subview containing only the current point
             auto pt = Kokkos::subview(pts, Kokkos::ALL(), ptInd);
             auto jacView = Kokkos::subview(jacobian, ptInd, Kokkos::ALL());
 
@@ -310,13 +310,13 @@ public:
 
             // Fill in the cache with anything that doesn't depend on x_d
             _expansion.FillCache1(cache, pt, DerivativeFlags::None);
-            
+
             // Create the integrand g( \partial_D f(x_1,...,x_{D-1},t))
             MonotoneIntegrand<ExpansionType, PosFuncType, decltype(pt)> integrand(cache, _expansion, pt, coeffs, DerivativeFlags::Parameters);
-            
+
             // Compute \int_0^x g( \partial_D f(x_1,...,x_{D-1},t)) dt as well as the gradient of this term wrt the coefficients of f
             Eigen::VectorXd integral = _quad.Integrate(integrand, 0, 1);
-            
+
             evaluations(ptInd) = integral(0);
 
             _expansion.FillCache2(cache, pt,  0.0, DerivativeFlags::None);
@@ -325,15 +325,15 @@ public:
             // Add the Integral to the coefficient gradient
             for(unsigned int termInd=0; termInd<numTerms; ++termInd)
                 jacView(termInd) += integral(termInd+1);
-            
+
         });
     }
 
 
-    void ContinuousMixedJacobian(Kokkos::View<double**> const& pts, 
+    void ContinuousMixedJacobian(Kokkos::View<double**> const& pts,
                                  Kokkos::View<double*>  const& coeffs,
                                  Kokkos::View<double**>      & jacobian)
-    {   
+    {
         const unsigned int numPts = pts.extent(1);
         const unsigned int numTerms = coeffs.extent(0);
         const unsigned int dim = pts.extent(0);
@@ -346,11 +346,11 @@ public:
 
         // Paralel loop over each point computing T(x_1,...,x_D) for that point
         Kokkos::parallel_for(policy, KOKKOS_LAMBDA (auto team_member) {
-            
+
             // The index of the for loop
             unsigned int ptInd = team_member.league_rank();
 
-            // Create a subview containing only the current point 
+            // Create a subview containing only the current point
             auto pt = Kokkos::subview(pts, Kokkos::ALL(), ptInd);
             auto jacView = Kokkos::subview(jacobian, ptInd, Kokkos::ALL());
 
@@ -374,10 +374,10 @@ public:
         });
     }
 
-    void DiscreteMixedJacobian(Kokkos::View<double**> const& pts, 
+    void DiscreteMixedJacobian(Kokkos::View<double**> const& pts,
                                Kokkos::View<double*>  const& coeffs,
                                Kokkos::View<double**>      & jacobian)
-    {   
+    {
         const unsigned int numPts = pts.extent(1);
         const unsigned int numTerms = coeffs.extent(0);
         const unsigned int dim = pts.extent(0);
@@ -394,10 +394,10 @@ public:
 
         // Paralel loop over each point computing T(x_1,...,x_D) for that point
         Kokkos::parallel_for(policy, KOKKOS_LAMBDA (auto team_member) {
-            
+
             unsigned int ptInd = team_member.league_rank();
 
-            // Create a subview containing only the current point 
+            // Create a subview containing only the current point
             auto pt = Kokkos::subview(pts, Kokkos::ALL(), ptInd);
             auto jacView = Kokkos::subview(jacobian, ptInd, Kokkos::ALL());
 
@@ -406,17 +406,17 @@ public:
 
             // Fill in the cache with anything that doesn't depend on x_d
             _expansion.FillCache1(cache, pt, DerivativeFlags::None);
-            
+
             // Create the integrand g( \partial_D f(x_1,...,x_{D-1},t))
             MonotoneIntegrand<ExpansionType, PosFuncType, decltype(pt)> integrand(cache, _expansion, pt, coeffs, DerivativeFlags::Mixed);
-            
+
             // Compute \int_0^x g( \partial_D f(x_1,...,x_{D-1},t)) dt as well as the gradient of this term wrt the coefficients of f
             Eigen::VectorXd integral = _quad.Integrate(integrand, 0, 1);
-            
+
             // Add the Integral to the coefficient gradient
             for(unsigned int termInd=0; termInd<numTerms; ++termInd)
                 jacView(termInd) += integral(termInd+1);
-            
+
         });
     }
 
@@ -426,4 +426,4 @@ private:
 };
 
 } // namespace mpart
-#endif 
+#endif

--- a/MParT/MonotoneIntegrand.h
+++ b/MParT/MonotoneIntegrand.h
@@ -1,6 +1,10 @@
 #ifndef MPART_MONOTONEINTEGRAND_H
 #define MPART_MONOTONEINTEGRAND_H
 
+#include <cmath>
+#include <sstream>
+#include <stdexcept>
+
 #include "MParT/DerivativeFlags.h"
 
 #include <Eigen/Core>
@@ -12,22 +16,22 @@ namespace mpart{
 
 /**
     @brief Computes the integrand  \f$g( \partial_d f(x_1,x_2,\ldots,x_{d-1},t) )\f$ used in a monotone component.
-      
+
     This class assumes f is given through an expansion containing a tensor product basis functions
     \f[
       f(x_1,x_2,\ldots,x_d) = \sum_\alpha c_{\alpha\in\mathcal{A}} \prod_{d=1^D} \phi_{\alpha_d}(x_d),
     \f]
-    where \f$\alpha\f$ is a multiindex in some set \f$\mathcal{A}\f$ and \f$\phi_{\alpha_d}\f$ is a univariate 
-    function with degree (or general index) \f$\alpha_d\f$.   The BasisEvaluatorType template argument defines 
-    the family of \f$\phi_{\alpha_d}\f$ functions.  When \f$\phi_{\alpha_d}\f$ is an orthongal polynomial, 
-    it is possible to efficiently evaluate all degrees less than \f$P\f$ using the three term recurrence 
-    relationship of the polynomial.  This is leveraged here to accelerate the evaluation of the integrand.  The 
-    components $x_1,x_2,\ldots,x_{d-1}$ are all known apriori, as are the maximum degrees in each of those 
-    directions.   The values of \f$\phi_{\alpha_d}(x_d)\f$ for \f$d<D\f$ can thus be precomputed and reused 
+    where \f$\alpha\f$ is a multiindex in some set \f$\mathcal{A}\f$ and \f$\phi_{\alpha_d}\f$ is a univariate
+    function with degree (or general index) \f$\alpha_d\f$.   The BasisEvaluatorType template argument defines
+    the family of \f$\phi_{\alpha_d}\f$ functions.  When \f$\phi_{\alpha_d}\f$ is an orthongal polynomial,
+    it is possible to efficiently evaluate all degrees less than \f$P\f$ using the three term recurrence
+    relationship of the polynomial.  This is leveraged here to accelerate the evaluation of the integrand.  The
+    components $x_1,x_2,\ldots,x_{d-1}$ are all known apriori, as are the maximum degrees in each of those
+    directions.   The values of \f$\phi_{\alpha_d}(x_d)\f$ for \f$d<D\f$ can thus be precomputed and reused
     during the integration of \f$g( f(x_1,x_2,\ldots,x_{d-1},t) )\f$.
-    
+
     After the constructor has been called, cache[startPos[d]][p] will contain \phi_p(x_d)
- 
+
    @tparam BasisEvaluatorType A class defining the family of 1d basis functions used to parameterize the function \f$f\f$.  The MParT::HermiteFunction and MParT::ProbabilistHermite classes are examples of types that implement the required interface.
    @tparam PosFuncType A class defining the function \f$g\f$.  This class must have `Evaluate` and `Derivative` functions accepting a double and returning a double.  The MParT::SoftPlus and MParT::Exp classes in PositiveBijectors.h are examples of classes defining this interface.
    @tparam PointType
@@ -36,12 +40,12 @@ template<class ExpansionType, class PosFuncType, class PointType>
 class MonotoneIntegrand{
 public:
 
-    
+
 
     /**
-      @param cache A pointer to memory storing evaluations of \phi_{i,p}(x_i) for each i.  These terms need to be evaluated outside this class for \f$i\in\{0,\ldots,D-1\}\f$. 
-      @param expansion 
-      @param xd 
+      @param cache A pointer to memory storing evaluations of \phi_{i,p}(x_i) for each i.  These terms need to be evaluated outside this class for \f$i\in\{0,\ldots,D-1\}\f$.
+      @param expansion
+      @param xd
       @param coeffs
       @param derivType
      */
@@ -55,18 +59,18 @@ public:
                                                                       _pt(pt),
                                                                       _coeffs(coeffs),
                                                                       _derivType(derivType)
-    {   
+    {
     }
 
     /**
-     Evaluates \f$g( \partial_d f(x_1,x_2,\ldots, x_d*t))\f$ using the cached values of \f$x\f$ given to the constructor 
+     Evaluates \f$g( \partial_d f(x_1,x_2,\ldots, x_d*t))\f$ using the cached values of \f$x\f$ given to the constructor
      and the value of \f$t\f$ passed to this function.  Note that we assume t ranges from [0,1].  The change of variables to x_d*t is
      taken care of inside this function.
     */
     Eigen::VectorXd operator()(double t) const
-    {   
+    {
         const unsigned int numTerms = _expansion.NumCoeffs();
-        
+
         unsigned int numOutputs = 1;
         if(_derivType==DerivativeFlags::Diagonal)
             numOutputs++;
@@ -82,7 +86,7 @@ public:
         }else{
             _expansion.FillCache2(_cache, _pt, t*_pt(_dim-1), DerivativeFlags::Diagonal);
         }
-        
+
         // Use the cache to evaluate \partial_d f and, optionally, the gradient of \partial_d f wrt the coefficients.
         double df = 0;
         if(_derivType==DerivativeFlags::Parameters){
@@ -108,7 +112,7 @@ public:
         }else{
             df = _expansion.DiagonalDerivative(_cache, _coeffs, 1);
         }
-        
+
         // First output is always the integrand itself
         double gf = PosFuncType::Evaluate(df);
         output(0) = _pt(_dim-1)*gf;
@@ -124,7 +128,7 @@ public:
 
         // Compute the derivative with respect to x_d
         if(_derivType==DerivativeFlags::Diagonal){
-            
+
             // Compute \partial^2_d f
             output(1) = _expansion.DiagonalDerivative(_cache, _coeffs, 2);
 

--- a/MParT/MultiIndices/MultiIndexLimiter.h
+++ b/MParT/MultiIndices/MultiIndexLimiter.h
@@ -1,9 +1,10 @@
 #ifndef MPART_MULTIINDEXLIMITER_H_
 #define MPART_MULTIINDEXLIMITER_H_
 
-#include <functional>
-
 #include "MParT/MultiIndices/MultiIndex.h"
+
+#include <functional>
+#include <vector>
 
 namespace mpart{
 namespace MultiIndexLimiter{
@@ -18,7 +19,7 @@ namespace MultiIndexLimiter{
     public:
 
         TotalOrder(unsigned int totalOrderIn) : totalOrder(totalOrderIn){};
-    
+
         bool operator()(MultiIndex const& multi){return (multi.Sum() <= totalOrder);};
 
     private:
@@ -37,7 +38,7 @@ namespace MultiIndexLimiter{
     public:
 
         Dimension(unsigned int lowerDimIn, unsigned int lengthIn) : lowerDim(lowerDimIn), length(lengthIn){};
-       
+
         bool operator()(MultiIndex const& multi) const;
 
     private:
@@ -82,7 +83,7 @@ namespace MultiIndexLimiter{
     public:
         MaxDegree(unsigned int maxDegreeIn, unsigned int length) : MaxDegree(std::vector<unsigned int>(length, maxDegreeIn)){};
         MaxDegree(std::vector<unsigned int> const& maxDegreesIn) : maxDegrees(maxDegreesIn){};
-        
+
         bool operator()(MultiIndex const& multi) const;
 
     private:
@@ -108,7 +109,7 @@ namespace MultiIndexLimiter{
  class And{
 
   public:
-    And(std::function<bool(MultiIndex const&)> limitA, 
+    And(std::function<bool(MultiIndex const&)> limitA,
         std::function<bool(MultiIndex const&)> limitB) : a(limitA), b(limitB){};
 
     bool operator()(MultiIndex const& multi) const {return (a(multi) && b(multi));};
@@ -127,9 +128,9 @@ namespace MultiIndexLimiter{
   class Or{
 
    public:
-     Or(std::function<bool(MultiIndex const&)> limitA, 
+     Or(std::function<bool(MultiIndex const&)> limitA,
         std::function<bool(MultiIndex const&)> limitB) : a(limitA), b(limitB){};
-        
+
     bool operator()(MultiIndex const& multi) const {return (a(multi) || b(multi));};
 
   private:
@@ -147,9 +148,9 @@ namespace MultiIndexLimiter{
 
   public:
   public:
-    Xor(std::function<bool(MultiIndex const&)> limitA, 
+    Xor(std::function<bool(MultiIndex const&)> limitA,
         std::function<bool(MultiIndex const&)> limitB) : a(limitA), b(limitB){};
-        
+
     bool operator()(MultiIndex const& multi) const {return (a(multi) ^ b(multi));};
 
   private:

--- a/MParT/MultiIndices/MultiIndexNeighborhood.h
+++ b/MParT/MultiIndices/MultiIndexNeighborhood.h
@@ -1,8 +1,9 @@
 #ifndef MPART_MULTIINDEXNEIGHBORHOOD_H
 #define MPART_MULTIINDEXNEIGHBORHOOD_H
 
-#include "MParT/MultiIndices/MultiIndex.h"
 #include <vector>
+
+#include "MParT/MultiIndices/MultiIndex.h"
 
 namespace mpart{
 
@@ -19,16 +20,16 @@ public:
 
     virtual bool IsForward(MultiIndex const& base, MultiIndex const& next) = 0;
     virtual bool IsBackward(MultiIndex const& base, MultiIndex const& next) = 0;
-    
-    
+
+
 };
 
 /**
- @brief Defines the standard graph connectivity for a MultiIndexSet.  
-  A multiindex \f$\mathbf{\alpha}\f$ is a **forward** neighbor of \f$\mathbf{\beta}\f$ if 
+ @brief Defines the standard graph connectivity for a MultiIndexSet.
+  A multiindex \f$\mathbf{\alpha}\f$ is a **forward** neighbor of \f$\mathbf{\beta}\f$ if
   \f$\|\mathbf{\alpha}-\mathbf{\beta}|_1==1\f$ and \f$\mathbf{\alpha}_i \geq \mathbf{\alpha}_i\f$ for all \f$i\f$.
 
-  A multiindex \f$\mathbf{\alpha}\f$ is a **backward** neighbor of \f$\mathbf{\beta}\f$ if 
+  A multiindex \f$\mathbf{\alpha}\f$ is a **backward** neighbor of \f$\mathbf{\beta}\f$ if
   \f$\|\mathbf{\alpha}-\mathbf{\beta}|_1==1\f$ and \f$\mathbf{\alpha}_i \leq \mathbf{\alpha}_i\f$ for all \f$i\f$.
  */
 class DefaultNeighborhood : public MultiIndexNeighborhood{
@@ -40,14 +41,14 @@ public:
 
     virtual std::vector<MultiIndex> BackwardNeighbors(MultiIndex const& multi) override;
 
-    virtual bool IsForward(MultiIndex const& base, 
+    virtual bool IsForward(MultiIndex const& base,
                            MultiIndex const& next) override;
 
-    virtual bool IsBackward(MultiIndex const& base, 
+    virtual bool IsBackward(MultiIndex const& base,
                             MultiIndex const& prev) override;
 };
 
 }
 
 
-#endif 
+#endif

--- a/MParT/OrthogonalPolynomial.h
+++ b/MParT/OrthogonalPolynomial.h
@@ -19,7 +19,7 @@ public:
                      double               x) const
     {
         output[0] = this->phi0(x);
-        
+
         if(maxOrder>0)
             output[1] = this->phi1(x);
 
@@ -32,14 +32,14 @@ public:
     */
     void EvaluateDerivatives(double*      derivs,
                              unsigned int maxDegree,
-                             double       x) const 
-    {   
+                             double       x) const
+    {
         double oldVal=0;
         double oldOldVal=0;
         double currVal;
         currVal = this->phi0(x);
         derivs[0] = 0.0;
-        
+
         if(maxDegree>0){
             oldVal = currVal;
             currVal = this->phi1(x);
@@ -66,11 +66,11 @@ public:
     void EvaluateDerivatives(double*      vals,
                            double*      derivs,
                            unsigned int maxOrder,
-                           double       x) const 
+                           double       x) const
     {
         vals[0] = this->phi0(x);
         derivs[0] = 0.0;
-        
+
         if(maxOrder>0){
             vals[1] = this->phi1(x);
             derivs[1] = this->phi1_deriv(x);
@@ -91,12 +91,12 @@ public:
                                    double*      derivs,
                                    double*      secondDerivs,
                                    unsigned int maxOrder,
-                                   double       x) const 
+                                   double       x) const
     {
         vals[0] = this->phi0(x);
         derivs[0] = 0.0;
         secondDerivs[0] = 0.0;
-        
+
         if(maxOrder>0){
             vals[1] = this->phi1(x);
             derivs[1] = this->phi1_deriv(x);
@@ -117,7 +117,7 @@ public:
 
 
 
-    double Evaluate(unsigned int const order, 
+    double Evaluate(unsigned int const order,
                     double const x) const
     {
         if(order==0){
@@ -140,7 +140,7 @@ public:
                 beta = -this->ck(k+2);
                 yk = alpha*yk1 + beta*yk2;
             }
-            
+
             beta = -this->ck(2);
             return yk1*this->phi1(x) + beta * this->phi0(x)*yk2;
         }
@@ -172,12 +172,12 @@ public:
                 lag1_val = next_val;
                 next_val = (ak*x + bk)*lag1_val - ck*lag2_val;
 
-                
+
                 lag2_deriv = lag1_deriv;
                 lag1_deriv = next_deriv;
                 next_deriv = ak*lag1_val + (ak*x + bk)*lag1_deriv - ck*lag2_deriv;
             }
-            
+
             return next_deriv;
         }
     }
@@ -206,7 +206,7 @@ public:
                 ak = this->ak(i);
                 bk = this->bk(i);
                 ck = this->ck(i);
-                
+
                 lag2_val = lag1_val;
                 lag1_val = next_val;
                 next_val = (ak*x + bk)*lag1_val- ck*lag2_val;

--- a/MParT/PositiveBijectors.h
+++ b/MParT/PositiveBijectors.h
@@ -1,7 +1,7 @@
 #ifndef MPART_POSITIVEBIJECTORS_H
 #define MPART_POSITIVEBIJECTORS_H
 
-#include <math.h>
+#include <cmath>
 
 namespace mpart{
 
@@ -27,7 +27,7 @@ public:
     static double Inverse(double x){
         return std::fmin(std::log(std::exp(x) - 1.0), x);
     }
-    
+
 };
 
 /**
@@ -56,4 +56,4 @@ public:
 
 } // namespace mpart
 
-#endif 
+#endif

--- a/src/MultiIndices/MultiIndexLimiter.cpp
+++ b/src/MultiIndices/MultiIndexLimiter.cpp
@@ -1,6 +1,7 @@
 #include "MParT/MultiIndices/MultiIndexLimiter.h"
 
-#include <math.h>
+#include <cmath>
+#include <stdexcept>
 
 using namespace mpart;
 using namespace mpart::MultiIndexLimiter;
@@ -23,7 +24,7 @@ bool Dimension::operator()(MultiIndex const& multi) const
 
 
 Anisotropic::Anisotropic(std::vector<double> const& weightsIn,
-                         double                     epsilonIn) : weights(weightsIn), 
+                         double                     epsilonIn) : weights(weightsIn),
                                                                  epsilon(epsilonIn)
 {
     // validate weight vector
@@ -40,20 +41,20 @@ Anisotropic::Anisotropic(std::vector<double> const& weightsIn,
 
 bool Anisotropic::operator()(MultiIndex const& multi) const
 {
-    
+
     if(multi.Length() != weights.size())
         return false;
 
     double prod = 1;
     for(unsigned int i=0; i<multi.Length(); ++i)
         prod *= pow(weights.at(i), (int)multi.Get(i));
-    
+
     return prod >= epsilon;
 }
 
 
 bool MaxDegree::operator()(MultiIndex const& multi) const
-{   
+{
     if(multi.Length() != maxDegrees.size())
         return false;
 

--- a/src/MultiIndices/MultiIndexNeighborhood.cpp
+++ b/src/MultiIndices/MultiIndexNeighborhood.cpp
@@ -3,7 +3,7 @@
 using namespace mpart;
 
 
-std::vector<MultiIndex> DefaultNeighborhood::ForwardNeighbors(MultiIndex const& multi) 
+std::vector<MultiIndex> DefaultNeighborhood::ForwardNeighbors(MultiIndex const& multi)
 {
     std::vector<MultiIndex> output;
     std::vector<unsigned int> vec = multi.Vector();
@@ -34,7 +34,7 @@ std::vector<MultiIndex> DefaultNeighborhood::BackwardNeighbors(MultiIndex const&
     return output;
 }
 
-bool DefaultNeighborhood::IsForward(MultiIndex const& base, 
+bool DefaultNeighborhood::IsForward(MultiIndex const& base,
                                     MultiIndex const& next)
 {
 
@@ -44,7 +44,7 @@ bool DefaultNeighborhood::IsForward(MultiIndex const& base,
     if((nextNnz>baseNnz+1) || (nextNnz<baseNnz))
         return false;
 
-    
+
     // Now check each dimension
     const unsigned int length = next.Length();
     unsigned int nextVal, baseVal;
@@ -64,7 +64,7 @@ bool DefaultNeighborhood::IsForward(MultiIndex const& base,
     return (diffSum==1);
 }
 
-bool DefaultNeighborhood::IsBackward(MultiIndex const& base, 
+bool DefaultNeighborhood::IsBackward(MultiIndex const& base,
                                      MultiIndex const& prev)
 {
     return IsForward(prev,base);


### PR DESCRIPTION
Fixes #23, and attempts to include all necessary STL headers that may or may not have been included, or included clearly. Some headers were likely included as part of `Eigen` or `Kokkos`, but depending on the implementation of those external library headers seems like a recipe for disaster if anything changes in those libraries.