### PR TITLE
Updated SetCoeffs() function in ConditionalMapBase to perform deep copy.

### DIFF
--- a/MParT/ConditionalMapBase.h
+++ b/MParT/ConditionalMapBase.h
@@ -48,7 +48,7 @@ namespace mpart {
 
             @param[in] coeffs A view to save internally.
         */
-        virtual void SetCoeffs(Kokkos::View<double*, Kokkos::HostSpace> coeffs){ this->savedCoeffs = coeffs; }
+        virtual void SetCoeffs(Kokkos::View<double*, Kokkos::HostSpace> coeffs);
 
         virtual void SetCoeffs(Eigen::Ref<Eigen::VectorXd> coeffs){ SetCoeffs(VecToKokkos<double>(coeffs)); }
         

--- a/src/ConditionalMapBase.cpp
+++ b/src/ConditionalMapBase.cpp
@@ -20,6 +20,23 @@ Eigen::RowMatrixXd ConditionalMapBase::Evaluate(Eigen::RowMatrixXd const& pts)
 }
 
 
+void ConditionalMapBase::SetCoeffs(Kokkos::View<double*, Kokkos::HostSpace> coeffs){ 
+
+    // If coefficients already exist, make sure the sizes match
+    if(this->savedCoeffs.is_allocated()){
+        if(coeffs.size() != this->savedCoeffs.size()){
+            std::stringstream msg;
+            msg << "Error in ConditionalMapBase::SetCoeffs.  Current coefficient vector has size " << this->savedCoeffs.size() << ", but new coefficients have size " << coeffs.size() << ".";
+            throw std::invalid_argument(msg.str());
+        }
+    }else{
+        
+        this->savedCoeffs = Kokkos::View<double*, Kokkos::HostSpace>("ConditionalMapBase Coefficients", coeffs.size());
+    }
+
+    Kokkos::deep_copy(this->savedCoeffs, coeffs); 
+}
+
 Kokkos::View<double*, Kokkos::HostSpace> ConditionalMapBase::LogDeterminant(Kokkos::View<const double**, Kokkos::HostSpace> const& pts)
 {
     Kokkos::View<double*, Kokkos::HostSpace> output("Log Determinants", pts.extent(1));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,5 +10,6 @@ set (TEST_SOURCES
      tests/Test_MonotoneComponent.cpp
      tests/Test_MultivariateExpansion.cpp
      tests/Test_ArrayConversions.cpp
+     tests/Test_ConditionalMapBase.cpp
      #tests/Test_TensorProductFunction.cpp
 PARENT_SCOPE) 


### PR DESCRIPTION
- Updated `SetCoeffs()` to allocate coefficient memory and perform deep copy.
- Updated `ConditionalMapBase` tests to check for new behavior.
- Added `ConditionalMapBase` tests to cmake, which was previously missing.

Closes #60 