### PR TITLE
Change Eigen versions of ConditionalMapBase functions to use ref.

### DIFF
--- a/MParT/ConditionalMapBase.h
+++ b/MParT/ConditionalMapBase.h
@@ -79,7 +79,7 @@ namespace mpart {
         */
         virtual Kokkos::View<double*, MemorySpace> LogDeterminant(Kokkos::View<const double**, MemorySpace> const& pts);
 
-        virtual Eigen::VectorXd LogDeterminant(Eigen::RowMatrixXd const& pts);
+        virtual Eigen::VectorXd LogDeterminant(Eigen::Ref<const Eigen::RowMatrixXd> const& pts);
 
         virtual void LogDeterminantImpl(Kokkos::View<const double**, MemorySpace> const& pts,
                                         Kokkos::View<double*, MemorySpace>             &output) = 0;
@@ -87,7 +87,7 @@ namespace mpart {
 
         virtual Kokkos::View<double**, MemorySpace> Evaluate(Kokkos::View<const double**, MemorySpace> const& pts);
 
-        virtual Eigen::RowMatrixXd Evaluate(Eigen::RowMatrixXd const& pts);
+        virtual Eigen::RowMatrixXd Evaluate(Eigen::Ref<const Eigen::RowMatrixXd> const& pts);
 
         virtual void EvaluateImpl(Kokkos::View<const double**, MemorySpace> const& pts,
                                   Kokkos::View<double**, MemorySpace>            & output) = 0;
@@ -99,7 +99,8 @@ namespace mpart {
         virtual Kokkos::View<double**, MemorySpace> Inverse(Kokkos::View<const double**, MemorySpace> const& x1,
                                                             Kokkos::View<const double**, MemorySpace> const& r);
 
-        virtual Eigen::RowMatrixXd Inverse(Eigen::RowMatrixXd const& x1, Eigen::RowMatrixXd const& r);
+        virtual Eigen::RowMatrixXd Inverse(Eigen::Ref<const Eigen::RowMatrixXd> const& x1, 
+                                           Eigen::Ref<const Eigen::RowMatrixXd> const& r);
 
         virtual void InverseImpl(Kokkos::View<const double**, MemorySpace> const& x1,
                                  Kokkos::View<const double**, MemorySpace> const& r,

--- a/bindings/python/src/ConditionalMapBase.cpp
+++ b/bindings/python/src/ConditionalMapBase.cpp
@@ -26,9 +26,9 @@ void mpart::binding::ConditionalMapBaseWrapper(py::module &m)
 
         .def("CoeffMap", &ConditionalMapBase<Kokkos::HostSpace>::CoeffMap)
         .def("SetCoeffs", py::overload_cast<Eigen::Ref<Eigen::VectorXd>>(&ConditionalMapBase<Kokkos::HostSpace>::SetCoeffs))
-        .def("Evaluate", py::overload_cast<Eigen::RowMatrixXd const&>(&ConditionalMapBase<Kokkos::HostSpace>::Evaluate))
-        .def("LogDeterminant", py::overload_cast<Eigen::RowMatrixXd const&>(&ConditionalMapBase<Kokkos::HostSpace>::LogDeterminant))
-        .def("Inverse", py::overload_cast<Eigen::RowMatrixXd const&, Eigen::RowMatrixXd const&>(&ConditionalMapBase<Kokkos::HostSpace>::Inverse))
+        .def("Evaluate", py::overload_cast<Eigen::Ref<const Eigen::RowMatrixXd> const&>(&ConditionalMapBase<Kokkos::HostSpace>::Evaluate))
+        .def("LogDeterminant", py::overload_cast<Eigen::Ref<const Eigen::RowMatrixXd> const&>(&ConditionalMapBase<Kokkos::HostSpace>::LogDeterminant))
+        .def("Inverse", py::overload_cast<Eigen::Ref<const Eigen::RowMatrixXd> const&, Eigen::Ref<const Eigen::RowMatrixXd> const&>(&ConditionalMapBase<Kokkos::HostSpace>::Inverse))
         .def_readonly("numCoeffs", &ConditionalMapBase<Kokkos::HostSpace>::numCoeffs)
         ;
 

--- a/src/ConditionalMapBase.cpp
+++ b/src/ConditionalMapBase.cpp
@@ -30,7 +30,7 @@ Kokkos::View<double**, MemorySpace> ConditionalMapBase<MemorySpace>::Evaluate(Ko
 }
 
 template<>
-Eigen::RowMatrixXd ConditionalMapBase<Kokkos::HostSpace>::Evaluate(Eigen::RowMatrixXd const& pts)
+Eigen::RowMatrixXd ConditionalMapBase<Kokkos::HostSpace>::Evaluate(Eigen::Ref<const Eigen::RowMatrixXd> const& pts)
 {
     Eigen::RowMatrixXd output(outputDim, pts.cols());
     Kokkos::View<const double**, Kokkos::HostSpace> ptsView = ConstRowMatToKokkos<double>(pts);
@@ -40,7 +40,7 @@ Eigen::RowMatrixXd ConditionalMapBase<Kokkos::HostSpace>::Evaluate(Eigen::RowMat
 }
 
 template<typename MemorySpace>
-Eigen::RowMatrixXd ConditionalMapBase<MemorySpace>::Evaluate(Eigen::RowMatrixXd const& pts)
+Eigen::RowMatrixXd ConditionalMapBase<MemorySpace>::Evaluate(Eigen::Ref<const Eigen::RowMatrixXd> const& pts)
 {
     CheckDeviceMismatch("Evaluate(Eigen::RowMatrixXd const& pts)");
 
@@ -89,7 +89,7 @@ Kokkos::View<double*, MemorySpace> ConditionalMapBase<MemorySpace>::LogDetermina
 }
 
 template<>
-Eigen::VectorXd ConditionalMapBase<Kokkos::HostSpace>::LogDeterminant(Eigen::RowMatrixXd const& pts)
+Eigen::VectorXd ConditionalMapBase<Kokkos::HostSpace>::LogDeterminant(Eigen::Ref<const Eigen::RowMatrixXd> const& pts)
 {   
     CheckDeviceMismatch("LogDeterminant(Eigen::RowMatrixXd const& pts)");
 
@@ -101,7 +101,7 @@ Eigen::VectorXd ConditionalMapBase<Kokkos::HostSpace>::LogDeterminant(Eigen::Row
 }
 
 template<typename MemorySpace>
-Eigen::VectorXd ConditionalMapBase<MemorySpace>::LogDeterminant(Eigen::RowMatrixXd const& pts)
+Eigen::VectorXd ConditionalMapBase<MemorySpace>::LogDeterminant(Eigen::Ref<const Eigen::RowMatrixXd> const& pts)
 {   
     CheckDeviceMismatch("LogDeterminant(Eigen::RowMatrixXd const& pts)");
 
@@ -126,7 +126,7 @@ Kokkos::View<double**, MemorySpace> ConditionalMapBase<MemorySpace>::Inverse(Kok
 }
 
 template<>
-Eigen::RowMatrixXd ConditionalMapBase<Kokkos::HostSpace>::Inverse(Eigen::RowMatrixXd const& x1, Eigen::RowMatrixXd const& r)
+Eigen::RowMatrixXd ConditionalMapBase<Kokkos::HostSpace>::Inverse(Eigen::Ref<const Eigen::RowMatrixXd> const& x1, Eigen::Ref<const Eigen::RowMatrixXd> const& r)
 {   
     CheckDeviceMismatch("Inverse(Eigen::RowMatrixXd const& x1, Eigen::RowMatrixXd const& r)");
 
@@ -142,7 +142,7 @@ Eigen::RowMatrixXd ConditionalMapBase<Kokkos::HostSpace>::Inverse(Eigen::RowMatr
 
 
 template<typename MemorySpace>
-Eigen::RowMatrixXd ConditionalMapBase<MemorySpace>::Inverse(Eigen::RowMatrixXd const& x1, Eigen::RowMatrixXd const& r)
+Eigen::RowMatrixXd ConditionalMapBase<MemorySpace>::Inverse(Eigen::Ref<const Eigen::RowMatrixXd> const& x1, Eigen::Ref<const Eigen::RowMatrixXd> const& r)
 {   
     CheckDeviceMismatch("Inverse(Eigen::RowMatrixXd const& x1, Eigen::RowMatrixXd const& r)");
 


### PR DESCRIPTION
Changed Eigen versions of ConditionalMapBase functions to use Eigen::Ref<Eigen::RowMatrixXd> instead of Eigen::RowMatrixXd.