### PR TITLE
Fix compiler warnings generated by -Wall -Wextra

### DIFF
--- a/MParT/MonotoneComponent.h
+++ b/MParT/MonotoneComponent.h
@@ -109,7 +109,6 @@ public:
                       Kokkos::View<double*,MemorySpace>       & output)
     {
         const unsigned int numPts = pts.extent(1);
-        const unsigned int numTerms = coeffs.extent(0);
 
         assert(output.extent(0)==numPts);
 
@@ -227,9 +226,6 @@ public:
         const unsigned int numPts = ys.extent(0);
         const unsigned int numXs = xs.extent(1); // The number of input points
 
-        const unsigned int numTerms = coeffs.extent(0);
-        const unsigned int dim = xs.extent(0);
-
         // Check to make sure the output and and input have the right sizes.
         if((numXs!=1)&&(numXs!=numPts)){
             std::stringstream msg;
@@ -319,7 +315,6 @@ public:
                               Kokkos::View<double*,MemorySpace>       & derivs)
     {
         const unsigned int numPts = pts.extent(1);
-        const unsigned int numTerms = coeffs.extent(0);
         const unsigned int dim = pts.extent(0);
 
         // Ask the expansion how much memory it would like for it's one-point cache
@@ -415,7 +410,6 @@ public:
     {
         const unsigned int numPts = pts.extent(1);
         const unsigned int numTerms = coeffs.extent(0);
-        const unsigned int dim = pts.extent(0);
 
         assert(coeffs.extent(0)==numTerms);
 
@@ -496,7 +490,6 @@ public:
     {
         const unsigned int numPts = pts.extent(1);
         const unsigned int numTerms = coeffs.extent(0);
-        const unsigned int dim = pts.extent(0);
 
         assert(jacobian.extent(0)==numPts);
         assert(jacobian.extent(1)==numTerms);
@@ -600,7 +593,6 @@ public:
     {
         const unsigned int numPts = pts.extent(1);
         const unsigned int numTerms = coeffs.extent(0);
-        const unsigned int dim = pts.extent(0);
 
         assert(jacobian.extent(0)==numPts);
         assert(jacobian.extent(1)==numTerms);

--- a/MParT/MultiIndices/FixedMultiIndexSet.h
+++ b/MParT/MultiIndices/FixedMultiIndexSet.h
@@ -14,16 +14,16 @@ class FixedMultiIndexSet
 public:
 
     /** @brief Construct a fixed multiindex set in dense form.
-        
-        All components of the multiindex are stored.  This requires more memory for high 
-        dimensional problems, but might be easier to work with for some families of 
+
+        All components of the multiindex are stored.  This requires more memory for high
+        dimensional problems, but might be easier to work with for some families of
         basis functions.
     */
     FixedMultiIndexSet(unsigned int                             _dim,
                        Kokkos::View<unsigned int*, MemorySpace> _orders);
 
-    /** @brief Construct a fixed multiindex set in compressed form.  
-    
+    /** @brief Construct a fixed multiindex set in compressed form.
+
         Only nonzero orders are stored in this representation.   For multivariate polynomials,
         the compressed representation can yield faster polynomial evaluations.
     */
@@ -34,7 +34,7 @@ public:
     /*
     Constructs a total order limited multiindex set
     */
-    FixedMultiIndexSet(unsigned int _dim, 
+    FixedMultiIndexSet(unsigned int _dim,
                        unsigned int _maxOrder);
 
     // Returns the maximum degree in the dimension dim
@@ -55,7 +55,7 @@ public:
         }else{
             return nzOrders.extent(0) / dim;
         }
-    } 
+    }
 
     const unsigned int dim;
 
@@ -73,31 +73,31 @@ public:
     Kokkos::View<unsigned int*, MemorySpace> nzDims;
     Kokkos::View<unsigned int*, MemorySpace> nzOrders;
     Kokkos::View<unsigned int*, MemorySpace> maxDegrees; // The maximum multiindex value (i.e., degree) in each dimension
-    
+
 private:
 
     void SetupTerms();
 
     void CalculateMaxDegrees();
-    
+
     // Computes the number of terms in the multiindexset as well as the total number of nonzero components
     std::pair<unsigned int, unsigned int> TotalOrderSize(unsigned int maxOrder, unsigned int currDim);
 
     /**
-     * @brief 
-     * 
+     * @brief
+     *
      * @param maxOrder The maximum total order (sum of powers) to include in multiindex set.
      * @param currDim The "top" dimension currently being filled in recursive calls to this function.  Starts at 0.
-     * @param currNz The current index into the nzDims and nzOrders arrays. 
+     * @param currNz The current index into the nzDims and nzOrders arrays.
      */
     void FillTotalOrder(unsigned int maxOrder,
-                        std::vector<unsigned int> &workspace, 
-                        unsigned int currDim, 
+                        std::vector<unsigned int> &workspace,
+                        unsigned int currDim,
                         unsigned int &currTerm,
                         unsigned int &currNz);
 
 
-    
+
 
 }; // class MultiIndexSet
 

--- a/MParT/MultiIndices/MultiIndexLimiter.h
+++ b/MParT/MultiIndices/MultiIndexLimiter.h
@@ -98,7 +98,7 @@ namespace MultiIndexLimiter{
    */
  class None{
   public:
-    bool operator()(MultiIndex const& multi) const {return true;};
+    bool operator()(MultiIndex const&) const {return true;};
   };
 
   /** @class And

--- a/MParT/MultivariateExpansion.h
+++ b/MParT/MultivariateExpansion.h
@@ -16,8 +16,7 @@ struct MultivariateExpansionMaxDegreeFunctor {
 
     MultivariateExpansionMaxDegreeFunctor(unsigned int dim, Kokkos::View<unsigned int*, MemorySpace> startPos, Kokkos::View<const unsigned int*, MemorySpace> maxDegrees) : dim(dim), startPos(startPos), maxDegrees(maxDegrees) {};
 
-    KOKKOS_FUNCTION void operator()(const int i, unsigned int& update, const bool final) const{
-        const unsigned int val_i = startPos(i);
+    KOKKOS_FUNCTION void operator()(const unsigned int i, unsigned int& update, const bool final) const{
         if(final)
             startPos(i) = update;
 
@@ -38,7 +37,7 @@ struct CacheSizeFunctor{
 
     CacheSizeFunctor(Kokkos::View<unsigned int*, MemorySpace> startPosIn, Kokkos::View<unsigned int*, MemorySpace> cacheSizeIn) : startPos_(startPosIn), cacheSize_(cacheSizeIn){};
 
-    KOKKOS_INLINE_FUNCTION void operator()(const int i) const{cacheSize_(0) = startPos_(startPos_.extent(0)-1);};
+    KOKKOS_INLINE_FUNCTION void operator()(const int) const{cacheSize_(0) = startPos_(startPos_.extent(0)-1);};
 
     Kokkos::View<unsigned int*, MemorySpace> startPos_;
     Kokkos::View<unsigned int*, MemorySpace> cacheSize_;
@@ -129,7 +128,7 @@ public:
     template<typename PointType>
     KOKKOS_FUNCTION void FillCache1(double*          polyCache,
                                     PointType const& pt,
-                                    DerivativeFlags::DerivativeType   derivType) const
+                                    DerivativeFlags::DerivativeType) const
     {
         // Evaluate all degrees of all 1d polynomials except the last dimension, which will be evaluated inside the integrand
         for(unsigned int d=0; d<dim_-1; ++d)
@@ -150,7 +149,7 @@ public:
 
     template<typename PointType>
     KOKKOS_FUNCTION void FillCache2(double*          polyCache,
-                                    PointType const& pt,
+                                    PointType const&,
                                     double           xd,
                                     DerivativeFlags::DerivativeType derivType) const
     {

--- a/MParT/OrthogonalPolynomial.h
+++ b/MParT/OrthogonalPolynomial.h
@@ -252,12 +252,12 @@ public:
 
 protected:
 
-    KOKKOS_INLINE_FUNCTION double ak(unsigned int) const {return 2.0;}
-    KOKKOS_INLINE_FUNCTION double bk(unsigned int) const {return 0.0;}
+    KOKKOS_INLINE_FUNCTION double ak(unsigned) const {return 2.0;}
+    KOKKOS_INLINE_FUNCTION double bk(unsigned) const {return 0.0;}
     KOKKOS_INLINE_FUNCTION double ck(unsigned int k) const {return 2.0*(k-1.0);}
-    KOKKOS_INLINE_FUNCTION double phi0(double x) const {return 1.0;}
+    KOKKOS_INLINE_FUNCTION double phi0(double) const {return 1.0;}
     KOKKOS_INLINE_FUNCTION double phi1(double x) const {return 2.0*x;}
-    KOKKOS_INLINE_FUNCTION double phi1_deriv(double x) const {return 2.0;};
+    KOKKOS_INLINE_FUNCTION double phi1_deriv(double) const {return 2.0;};
 };
 
 typedef OrthogonalPolynomial<PhysicistHermiteMixer> PhysicistHermite;

--- a/MParT/Quadrature.h
+++ b/MParT/Quadrature.h
@@ -362,38 +362,39 @@ protected:
                                        double      & tol) const
     {
         double relRefVal;
-        if(errorMetric_==QuadError::First){
-            error = fabs(fineVal[0]-coarseVal[0]);
-            relRefVal = fabs(coarseVal[0]);
-        }else if(errorMetric_==QuadError::NormInf){
-            error = 0;
-            relRefVal = 0;
-            for(unsigned int i=0; i<this->fdim_; ++i){
-                error = fmax(error, fabs(fineVal[i]-coarseVal[i]));
-                relRefVal = fmax(relRefVal, fabs(coarseVal[i]));
-            }
-
-        }else if(errorMetric_==QuadError::Norm2){
-
-            error = 0;
-            relRefVal = 0;
-            for(unsigned int i=0; i<this->fdim_; ++i){
-                error += (fineVal[i]-coarseVal[i])*(fineVal[i]-coarseVal[i]);
-                relRefVal += coarseVal[i]*coarseVal[i];
-            }
-            error = sqrt(error);
-            relRefVal = sqrt(relRefVal);
-
-        }else if(errorMetric_==QuadError::Norm1){
-
-            error = 0;
-            relRefVal = 0;
-            for(unsigned int i=0; i<this->fdim_; ++i){
-                error += fabs(fineVal[i]-coarseVal[i]);
-                relRefVal += fabs(coarseVal[i]);
-            }
-
+        switch(errorMetric_){
+            case QuadError::First:
+                error = fabs(fineVal[0]-coarseVal[0]);
+                relRefVal = fabs(coarseVal[0]);
+                break;
+            case QuadError::NormInf:
+                error = 0;
+                relRefVal = 0;
+                for(unsigned int i=0; i<this->fdim_; ++i){
+                    error = fmax(error, fabs(fineVal[i]-coarseVal[i]));
+                    relRefVal = fmax(relRefVal, fabs(coarseVal[i]));
+                }
+                break;
+            case QuadError::Norm2:
+                error = 0;
+                relRefVal = 0;
+                for(unsigned int i=0; i<this->fdim_; ++i){
+                    error += (fineVal[i]-coarseVal[i])*(fineVal[i]-coarseVal[i]);
+                    relRefVal += coarseVal[i]*coarseVal[i];
+                }
+                error = sqrt(error);
+                relRefVal = sqrt(relRefVal);
+                break;
+            default: // Norm1 is default
+                error = 0;
+                relRefVal = 0;
+                for(unsigned int i=0; i<this->fdim_; ++i){
+                    error += fabs(fineVal[i]-coarseVal[i]);
+                    relRefVal += fabs(coarseVal[i]);
+                }
+                break;
         }
+
         tol = std::fmax( relTol_*relRefVal, absTol_);
     }
 

--- a/bindings/python/src/MultiIndex.cpp
+++ b/bindings/python/src/MultiIndex.cpp
@@ -26,11 +26,11 @@ void mpart::binding::MultiIndexWrapper(py::module &m)
         .def(py::init<unsigned int>())
         .def(py::init<unsigned int, unsigned int>())
         .def(py::init<std::vector<unsigned int> const&>())
-        
+
         .def("tolist",&MultiIndex::Vector)
         .def("sum", &MultiIndex::Sum)
         .def("max", &MultiIndex::Max)
-        
+
         .def("__setitem__", &MultiIndex::Set)
         .def("__getitem__", &MultiIndex::Get)
         .def("count_nonzero", &MultiIndex::NumNz)
@@ -44,8 +44,8 @@ void mpart::binding::MultiIndexWrapper(py::module &m)
         .def("__gt__", &MultiIndex::operator>)
         .def("__le__", &MultiIndex::operator<=)
         .def("__ge__", &MultiIndex::operator>=);
-        
-    
+
+
     // MultiIndexSet
     py::class_<MultiIndexSet, KokkosCustomPointer<MultiIndexSet>>(m, "MultiIndexSet")
         .def(py::init<const unsigned int>())
@@ -61,7 +61,7 @@ void mpart::binding::MultiIndexWrapper(py::module &m)
 
         .def("union", &MultiIndexSet::Union)
         .def("SetLimiter",&MultiIndexSet::SetLimiter)
-        .def("GetLimiter", &MultiIndexSet::GetLimiter)   
+        .def("GetLimiter", &MultiIndexSet::GetLimiter)
         .def("IndexToMulti",&MultiIndexSet::IndexToMulti)
         .def("MultiToIndex", &MultiIndexSet::MultiToIndex)
         .def("MaxOrders", &MultiIndexSet::MaxOrders)
@@ -90,35 +90,35 @@ void mpart::binding::MultiIndexWrapper(py::module &m)
         .def("__call__", &MultiIndexLimiter::TotalOrder::operator())
     ;
 
-    
+
     //Dimension
     py::class_<MultiIndexLimiter::Dimension, KokkosCustomPointer<MultiIndexLimiter::Dimension>>(m, "Dimension")
         .def(py::init<unsigned int, unsigned int>())
         .def("__call__", &MultiIndexLimiter::Dimension::operator())
     ;
 
-    
+
     //Anisotropic
     py::class_<MultiIndexLimiter::Anisotropic, KokkosCustomPointer<MultiIndexLimiter::Anisotropic>>(m, "Anisotropic")
         .def(py::init<std::vector<double> const&, double>())
         .def("__call__", &MultiIndexLimiter::Anisotropic::operator())
     ;
 
-    
+
     //MaxDegree
     py::class_<MultiIndexLimiter::MaxDegree, KokkosCustomPointer<MultiIndexLimiter::MaxDegree>>(m, "MaxDegree")
         .def(py::init<unsigned int, unsigned int>())
         .def("__call__", &MultiIndexLimiter::MaxDegree::operator())
     ;
 
-    
+
     //None
     py::class_<MultiIndexLimiter::None, KokkosCustomPointer<MultiIndexLimiter::None>>(m, "NoneLim")
         .def(py::init<>())
         .def("__call__", &MultiIndexLimiter::None::operator())
     ;
 
-    
+
     //And
     py::class_<MultiIndexLimiter::And, KokkosCustomPointer<MultiIndexLimiter::And>>(m, "And")
         .def(py::init<std::function<bool(MultiIndex const&)>,std::function<bool(MultiIndex const&)>>())
@@ -142,20 +142,20 @@ void mpart::binding::MultiIndexWrapper(py::module &m)
 
     py::class_<FixedMultiIndexSet<Kokkos::HostSpace>, KokkosCustomPointer<FixedMultiIndexSet<Kokkos::HostSpace>>>(m, "FixedMultiIndexSet")
 
-        .def(py::init( [](unsigned int dim, 
+        .def(py::init( [](unsigned int dim,
                           Eigen::Matrix<unsigned int, Eigen::Dynamic, 1> &orders)
         {
             return new FixedMultiIndexSet<Kokkos::HostSpace>(dim, VecToKokkos<unsigned int>(orders));
         }))
 
-        .def(py::init( [](unsigned int dim, 
+        .def(py::init( [](unsigned int dim,
                           Eigen::Matrix<unsigned int, Eigen::Dynamic, 1> &nzStarts,
                           Eigen::Matrix<unsigned int, Eigen::Dynamic, 1> &nzDims,
                           Eigen::Matrix<unsigned int, Eigen::Dynamic, 1> &nzOrders)
         {
-            return new FixedMultiIndexSet<Kokkos::HostSpace>(dim, 
-                                          VecToKokkos<unsigned int>(nzStarts), 
-                                          VecToKokkos<unsigned int>(nzDims), 
+            return new FixedMultiIndexSet<Kokkos::HostSpace>(dim,
+                                          VecToKokkos<unsigned int>(nzStarts),
+                                          VecToKokkos<unsigned int>(nzDims),
                                           VecToKokkos<unsigned int>(nzOrders));
         }))
 
@@ -165,7 +165,7 @@ void mpart::binding::MultiIndexWrapper(py::module &m)
         {
             auto maxDegrees = set.MaxDegrees(); // auto finds the type, but harder to read (because you don't tell reader the type)
             Eigen::Matrix<unsigned int, Eigen::Dynamic, 1> maxDegreesEigen(maxDegrees.extent(0));
-            for (int i = 0; i < maxDegrees.extent(0); i++)
+            for (unsigned int i = 0; i < maxDegrees.extent(0); i++)
             {
                 maxDegreesEigen(i) = maxDegrees(i);
             }

--- a/src/ConditionalMapBase.cpp
+++ b/src/ConditionalMapBase.cpp
@@ -5,13 +5,13 @@
 using namespace mpart;
 
 template<>
-void ConditionalMapBase<Kokkos::HostSpace>::CheckDeviceMismatch(std::string functionName) const
-{   
+void ConditionalMapBase<Kokkos::HostSpace>::CheckDeviceMismatch(std::string) const
+{
 }
 
 template<typename MemorySpace>
 void ConditionalMapBase<MemorySpace>::CheckDeviceMismatch(std::string functionName) const
-{   
+{
     std::stringstream msg;
     msg << "Error in call to \"" << functionName << "\".  This function is only valid on the host space,";
     msg << " but called on a DeviceSpace ConditionalMapBase object.   You must manually copy the input";
@@ -71,12 +71,12 @@ void ConditionalMapBase<MemorySpace>::SetCoeffs(Kokkos::View<double*, MemorySpac
 
 template<>
 void ConditionalMapBase<Kokkos::HostSpace>::SetCoeffs(Eigen::Ref<Eigen::VectorXd> coeffs){
-     SetCoeffs(VecToKokkos<double>(coeffs)); 
+     SetCoeffs(VecToKokkos<double>(coeffs));
 }
 
 template<typename MemorySpace>
 void ConditionalMapBase<MemorySpace>::SetCoeffs(Eigen::Ref<Eigen::VectorXd> coeffs){
-     CheckDeviceMismatch("SetCoeffs(Eigen::Ref<Eigen::VectorXd> coeffs)"); 
+     CheckDeviceMismatch("SetCoeffs(Eigen::Ref<Eigen::VectorXd> coeffs)");
 }
 
 
@@ -90,7 +90,7 @@ Kokkos::View<double*, MemorySpace> ConditionalMapBase<MemorySpace>::LogDetermina
 
 template<>
 Eigen::VectorXd ConditionalMapBase<Kokkos::HostSpace>::LogDeterminant(Eigen::Ref<const Eigen::RowMatrixXd> const& pts)
-{   
+{
     CheckDeviceMismatch("LogDeterminant(Eigen::RowMatrixXd const& pts)");
 
     Eigen::VectorXd output(pts.cols());
@@ -102,7 +102,7 @@ Eigen::VectorXd ConditionalMapBase<Kokkos::HostSpace>::LogDeterminant(Eigen::Ref
 
 template<typename MemorySpace>
 Eigen::VectorXd ConditionalMapBase<MemorySpace>::LogDeterminant(Eigen::Ref<const Eigen::RowMatrixXd> const& pts)
-{   
+{
     CheckDeviceMismatch("LogDeterminant(Eigen::RowMatrixXd const& pts)");
 
     Eigen::VectorXd output;
@@ -127,7 +127,7 @@ Kokkos::View<double**, MemorySpace> ConditionalMapBase<MemorySpace>::Inverse(Kok
 
 template<>
 Eigen::RowMatrixXd ConditionalMapBase<Kokkos::HostSpace>::Inverse(Eigen::Ref<const Eigen::RowMatrixXd> const& x1, Eigen::Ref<const Eigen::RowMatrixXd> const& r)
-{   
+{
     CheckDeviceMismatch("Inverse(Eigen::RowMatrixXd const& x1, Eigen::RowMatrixXd const& r)");
 
     Eigen::RowMatrixXd output(inputDim, r.cols());
@@ -143,7 +143,7 @@ Eigen::RowMatrixXd ConditionalMapBase<Kokkos::HostSpace>::Inverse(Eigen::Ref<con
 
 template<typename MemorySpace>
 Eigen::RowMatrixXd ConditionalMapBase<MemorySpace>::Inverse(Eigen::Ref<const Eigen::RowMatrixXd> const& x1, Eigen::Ref<const Eigen::RowMatrixXd> const& r)
-{   
+{
     CheckDeviceMismatch("Inverse(Eigen::RowMatrixXd const& x1, Eigen::RowMatrixXd const& r)");
 
     Eigen::RowMatrixXd output;
@@ -152,13 +152,13 @@ Eigen::RowMatrixXd ConditionalMapBase<MemorySpace>::Inverse(Eigen::Ref<const Eig
 
 template<>
 Eigen::Map<Eigen::VectorXd> ConditionalMapBase<Kokkos::HostSpace>::CoeffMap()
-{   
+{
     return KokkosToVec(this->savedCoeffs);
 }
 
 template<typename MemorySpace>
 Eigen::Map<Eigen::VectorXd> ConditionalMapBase<MemorySpace>::CoeffMap()
-{   
+{
     CheckDeviceMismatch("CoeffMap()");
     double *dummy = nullptr;
     return Eigen::Map<Eigen::VectorXd>(dummy, 0);

--- a/src/MapFactory.cpp
+++ b/src/MapFactory.cpp
@@ -24,9 +24,9 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> mpart::MapFactory::CreateCompon
 
             switch(opts.posFuncType) {
                 case PosFuncTypes::SoftPlus:
-                    output = std::make_shared<MonotoneComponent<decltype(expansion), SoftPlus, decltype(quad), MemorySpace>>(mset, quad);
+                    output = std::make_shared<MonotoneComponent<decltype(expansion), SoftPlus, decltype(quad), MemorySpace>>(mset, quad); break;
                 case PosFuncTypes::Exp:
-                    output = std::make_shared<MonotoneComponent<decltype(expansion), Exp, decltype(quad), MemorySpace>>(mset, quad);
+                    output = std::make_shared<MonotoneComponent<decltype(expansion), Exp, decltype(quad), MemorySpace>>(mset, quad); break;
             }
 
             output->Coeffs() = Kokkos::View<double*,MemorySpace>("Component Coefficients", mset.Size());
@@ -39,9 +39,9 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> mpart::MapFactory::CreateCompon
 
             switch(opts.posFuncType) {
                 case PosFuncTypes::SoftPlus:
-                    output = std::make_shared<MonotoneComponent<decltype(expansion), SoftPlus, decltype(quad), MemorySpace>>(mset, quad);
+                    output = std::make_shared<MonotoneComponent<decltype(expansion), SoftPlus, decltype(quad), MemorySpace>>(mset, quad); break;
                 case PosFuncTypes::Exp:
-                    output = std::make_shared<MonotoneComponent<decltype(expansion), Exp, decltype(quad), MemorySpace>>(mset, quad);
+                    output = std::make_shared<MonotoneComponent<decltype(expansion), Exp, decltype(quad), MemorySpace>>(mset, quad); break;
             }
 
             output->Coeffs() = Kokkos::View<double*,MemorySpace>("Component Coefficients", mset.Size());

--- a/src/MultiIndices/FixedMultiIndexSet.cpp
+++ b/src/MultiIndices/FixedMultiIndexSet.cpp
@@ -72,11 +72,11 @@ namespace mpart{
 
 
 template<typename MemorySpace>
-FixedMultiIndexSet<MemorySpace>::FixedMultiIndexSet(unsigned int                dim,
-                                       Kokkos::View<unsigned int*, MemorySpace> nzOrders) : dim(dim),
+FixedMultiIndexSet<MemorySpace>::FixedMultiIndexSet(unsigned int                dimen,
+                                       Kokkos::View<unsigned int*, MemorySpace> nonzeroOrders) : dim(dimen),
                                                                                             isCompressed(false),
-                                                                                            nzOrders(nzOrders),
-                                                                                            nzDims("Nonzero dims", nzOrders.extent(0))
+                                                                                            nzDims("Nonzero dims", nonzeroOrders.extent(0)),
+                                                                                            nzOrders(nonzeroOrders)
 {
     SetupTerms();
     CalculateMaxDegrees();
@@ -265,17 +265,17 @@ void FixedMultiIndexSet<MemorySpace>::Print() const
 {
     if(isCompressed){
         std::cout << "Starts:\n";
-        for(int i=0; i<nzStarts.extent(0); ++i)
+        for(unsigned int i=0; i<nzStarts.extent(0); ++i)
             std::cout << nzStarts(i) << "  ";
         std::cout << std::endl;
 
         std::cout << "\nDims:\n";
-        for(int i=0; i<nzDims.extent(0); ++i)
+        for(unsigned int i=0; i<nzDims.extent(0); ++i)
             std::cout << nzDims(i) << "  ";
         std::cout << std::endl;
 
         std::cout << "\nOrders:\n";
-        for(int i=0; i<nzOrders.extent(0); ++i)
+        for(unsigned int i=0; i<nzOrders.extent(0); ++i)
             std::cout << nzOrders(i) << "  ";
         std::cout << std::endl;
     }
@@ -333,7 +333,7 @@ void FixedMultiIndexSet<MemorySpace>::FillTotalOrder(unsigned int maxOrder,
 
             // Copy the multiindex into the compressed format
             nzStarts(currTerm) = currNz;
-            for(int i=0; i<dim; ++i){
+            for(unsigned int i=0; i<dim; ++i){
                 if(workspace[i]>0){
                     nzDims(currNz) = i;
                     nzOrders(currNz) = workspace[i];

--- a/src/MultiIndices/MultiIndex.cpp
+++ b/src/MultiIndices/MultiIndex.cpp
@@ -190,7 +190,7 @@ bool MultiIndex::operator<(const MultiIndex &b) const{
     return false;
   }else{
 
-    for(int i=0; i<std::min<unsigned int>(length, b.length); ++i){
+    for(unsigned int i=0; i<std::min<unsigned int>(length, b.length); ++i){
       if(Get(i)<b.Get(i)){
         return true;
       }else if(Get(i)>b.Get(i)){
@@ -215,7 +215,7 @@ bool MultiIndex::operator<=(const MultiIndex &b) const{
 
 std::string MultiIndex::String() const {
   std::string out;
-  for(int i=0; i<Length(); ++i){
+  for(unsigned int i=0; i<Length(); ++i){
     if (i > 0)
       out += " ";
     out += std::to_string(Get(i));

--- a/src/MultiIndices/MultiIndexLimiter.cpp
+++ b/src/MultiIndices/MultiIndexLimiter.cpp
@@ -28,7 +28,7 @@ Anisotropic::Anisotropic(std::vector<double> const& weightsIn,
                                                                  epsilon(epsilonIn)
 {
     // validate weight vector
-  for(int i = 0; i < weights.size(); ++i){
+  for(unsigned int i = 0; i < weights.size(); ++i){
     if((weights.at(i) > 1.0) || (weights.at(i) < 0.0))
       throw std::invalid_argument("AnisotropicLimiter requires all weights have to be in [0,1]. Got weight " + std::to_string(weights[i]));
   }

--- a/src/MultiIndices/MultiIndexNeighborhood.cpp
+++ b/src/MultiIndices/MultiIndexNeighborhood.cpp
@@ -22,7 +22,6 @@ std::vector<MultiIndex> DefaultNeighborhood::BackwardNeighbors(MultiIndex const&
     std::vector<MultiIndex> output;
     std::vector<unsigned int> vec = multi.Vector();
 
-    bool isZero;
     for(unsigned int i=0; i<vec.size(); ++i){
         if(vec.at(i)!=0){
             vec.at(i)--;

--- a/src/MultiIndices/MultiIndexSet.cpp
+++ b/src/MultiIndices/MultiIndexSet.cpp
@@ -50,11 +50,11 @@ void MultiIndexSet::RecursiveTotalOrderFill(unsigned int   maxOrder,
     for(unsigned int i=0; i<currDim; ++i)
         currOrder += base.at(i);
 
-    const int length = base.size();
+    const unsigned int length = base.size();
 
     if(currDim==length-1)
     {
-        for(int i=0; i<=maxOrder-currOrder; ++i)
+        for(unsigned int i=0; i<=maxOrder-currOrder; ++i)
         {
             base.at(length-1) = i;
             MultiIndex newTerm(base);
@@ -63,7 +63,7 @@ void MultiIndexSet::RecursiveTotalOrderFill(unsigned int   maxOrder,
         }
 
     }else{
-        for(int i=0; i<=maxOrder-currOrder; ++i)
+        for(unsigned int i=0; i<=maxOrder-currOrder; ++i)
         {
             for(unsigned int k=currDim+1; k<length; ++k)
                 base.at(k) = 0;
@@ -81,11 +81,11 @@ void MultiIndexSet::RecursiveTensorFill(unsigned int   maxDegree,
                                         std::vector<unsigned int> &base,
                                         LimiterType const& limiter)
 {
-    const int length = base.size();
+    const unsigned int length = base.size();
 
     if(currDim==length-1)
     {
-        for(int i=0; i<=maxDegree; ++i)
+        for(unsigned int i=0; i<=maxDegree; ++i)
         {
             base.at(length-1) = i;
             MultiIndex newTerm(base);
@@ -94,7 +94,7 @@ void MultiIndexSet::RecursiveTensorFill(unsigned int   maxDegree,
         }
 
     }else{
-        for(int i=0; i<=maxDegree; ++i)
+        for(unsigned int i=0; i<=maxDegree; ++i)
         {
             for(unsigned int k=currDim+1; k<length; ++k)
                 base.at(k) = 0;
@@ -109,15 +109,18 @@ void MultiIndexSet::RecursiveTensorFill(unsigned int   maxDegree,
 
 MultiIndexSet::MultiIndexSet(const unsigned int lengthIn,
                              LimiterType const& limiterIn,
-                             std::shared_ptr<MultiIndexNeighborhood> neigh) : maxOrders(lengthIn,0),
+                             std::shared_ptr<MultiIndexNeighborhood> neigh) : limiter(limiterIn),
                                                                               length(lengthIn),
-                                                                              limiter(limiterIn),
+                                                                              maxOrders(lengthIn,0),
                                                                               neighborhood(neigh)
 {
 };
 
 
-MultiIndexSet::MultiIndexSet(Eigen::Ref<const Eigen::MatrixXi> const& multis) : maxOrders(multis.cols(),0), length(multis.cols()), limiter(MultiIndexLimiter::None()), neighborhood(std::make_shared<DefaultNeighborhood>()){
+MultiIndexSet::MultiIndexSet(Eigen::Ref<const Eigen::MatrixXi> const& multis) :
+          limiter(MultiIndexLimiter::None()), length(multis.cols()),
+          maxOrders(multis.cols(),0),
+          neighborhood(std::make_shared<DefaultNeighborhood>()) {
 
     for(unsigned int i=0; i<multis.rows(); ++i){
         (*this) += MultiIndex(multis.row(i));
@@ -183,7 +186,7 @@ void MultiIndexSet::SetLimiter(LimiterType const& newLimiter){
 
   //  make sure no active terms in the set currently obey the new limiter.
   //  If a term is inactive, remove all edges tied to it
-  for(int globalInd=0; globalInd<allMultis.size(); ++globalInd)
+  for(unsigned int globalInd=0; globalInd<allMultis.size(); ++globalInd)
   {
     if(IsActive(globalInd)){
       if(!newLimiter(allMultis.at(globalInd))){
@@ -299,7 +302,7 @@ bool MultiIndexSet::IsAdmissible(unsigned int globalIndex) const
     return true;
 
   // count the number of input edges that are coming from active indices
-  int numAdmiss = 0;
+  unsigned int numAdmiss = 0;
   for(int inNode : inEdges.at(globalIndex)){
     if(IsActive(inNode))
       numAdmiss++;
@@ -398,8 +401,9 @@ void MultiIndexSet::AddForwardNeighbors(unsigned int globalIndex, bool addInacti
 
 void MultiIndexSet::Visualize(std::ostream &out) const
 {
-
-  for(int i=maxOrders.at(1)+1; i>=0; --i){
+  unsigned int max_ord = maxOrders.at(1) + 1;
+  for(unsigned int order = 0; order <= maxOrders.at(1) + 1; order++) {
+    unsigned int i=max_ord - order;
 
     if(i<10)
       out << " ";
@@ -704,7 +708,7 @@ unsigned int MultiIndexSet::Union(const MultiIndexSet& rhs)
 {
   int oldTerms = Size();
 
-  for(int i = 0; i < rhs.allMultis.size(); ++i) {
+  for(unsigned int i = 0; i < rhs.allMultis.size(); ++i) {
 
     auto newMulti = rhs.allMultis.at(i);
     if(limiter(newMulti)){

--- a/tests/MultiIndices/Test_MultiIndex.cpp
+++ b/tests/MultiIndices/Test_MultiIndex.cpp
@@ -47,7 +47,7 @@ TEST_CASE( "Testing MultiIndex", "[MultiIndex]" ) {
     REQUIRE( multi.Sum() == 1);
 
     dense = multi.Vector();
-    for(int i=0; i<dense.size(); ++i){
+    for(unsigned int i=0; i<dense.size(); ++i){
         if(i!=2){
             REQUIRE( dense[i] == 0);
         }else{
@@ -102,7 +102,7 @@ TEST_CASE( "Testing MultiIndex", "[MultiIndex]" ) {
 
 TEST_CASE("Multiindex from Eigen", "[MultiIndexFromEigen]")
 {
-    Eigen::VectorXi multi(3);
+    Eigen::Matrix<unsigned int,3,1> multi;
     multi << 2,3,4;
 
     MultiIndex a(multi);

--- a/tests/MultiIndices/Test_MultiIndexSet.cpp
+++ b/tests/MultiIndices/Test_MultiIndexSet.cpp
@@ -39,7 +39,6 @@ TEST_CASE("MultiIndexSet from Eigen", "[MultiIndexSetFromEigen]")
 TEST_CASE( "Testing the FixedMultiIndexSet class with anisotropic degrees", "[AnisotropicFixedMultiIndexSet]" ) {
 
     const unsigned int dim = 2;
-    const unsigned int maxOrder = 5;
 
     // Set multiindices to [0,1], [5,2], [4,3]
     Kokkos::View<unsigned int*, Kokkos::HostSpace> degrees("Degrees", 3*dim);
@@ -73,7 +72,7 @@ TEST_CASE( "Testing the FixedMultiIndexSet class copy to device", "[FixedMultiIn
     FixedMultiIndexSet<Kokkos::DefaultExecutionSpace::memory_space> deviceSet = mset.ToDevice();
 
 }
-#endif 
+#endif
 
 
 
@@ -141,7 +140,7 @@ TEST_CASE("Testing the MultiIndexSet class", "[MultiIndexSet]" ) {
 
         bool isAdmiss = indexFamily.IsAdmissible(multi);
         // Check the result of IsAdmissable().
-        REQUIRE( indexFamily.IsAdmissible(multi) );
+        REQUIRE( isAdmiss );
     }
 
     SECTION("Visualize")
@@ -357,12 +356,12 @@ TEST_CASE("Testing the MultiIndexSet class", "[MultiIndexSet]" ) {
         // Add forward admissible neighbor to index (1,1) using ForciblyExpand.
         MultiIndex newIndex{1,0};
 
-        int oldSize = indexFamily.Size();
+        unsigned int oldSize = indexFamily.Size();
         REQUIRE(oldSize==4);
 
         int activeIndex = indexFamily.MultiToIndex(newIndex);
         REQUIRE(activeIndex>=0);
-        
+
         indexFamily.Expand(activeIndex);
         REQUIRE( (oldSize+1) == indexFamily.Size());
 
@@ -374,37 +373,37 @@ TEST_CASE("Testing the MultiIndexSet class", "[MultiIndexSet]" ) {
     }
 
     /*
-        We start with a multiindex set that looks like 
+        We start with a multiindex set that looks like
         4 | 0
-        3 | x                   
-        2 | x                 
-        1 | x   x               
-        0 | x   x   x   x   0     
-            -----------------    
-            0   1   2   3   4    
+        3 | x
+        2 | x
+        1 | x   x
+        0 | x   x   x   x   0
+            -----------------
+            0   1   2   3   4
 
        The only admissible inactive extensions are [4,0] and [0,4] because we construct this set by
-        "limiting" a total order multiindex so that the largest mixed term is [1,1].  Then we 
-        remove the limiter to end up with a set that looks like 
+        "limiting" a total order multiindex so that the largest mixed term is [1,1].  Then we
+        remove the limiter to end up with a set that looks like
 
-        4 | o  
-        3 | x   o  
-        2 | x   o  
-        1 | x   x   o   o  
-        0 | x   x   x   x   o  
+        4 | o
+        3 | x   o
+        2 | x   o
+        1 | x   x   o   o
+        0 | x   x   x   x   o
            ------------------
             0   1   2   3   4
 
-        The active indices are the same, but the "Frontier" of expandable multiindices is now much larger.  
+        The active indices are the same, but the "Frontier" of expandable multiindices is now much larger.
     */
     SECTION("Frontier")
-    {   
+    {
         auto limiter = [](MultiIndex const& multi){ return ( (multi.Get(0)==0)||(multi.Get(1)==0)||((multi.Get(0)<2)&&(multi.Get(1)<2)));};
 
         REQUIRE(limiter(MultiIndex{2,0}) );
-        
+
         MultiIndexSet set = MultiIndexSet::CreateTotalOrder(2, 3, limiter);
-        
+
         std::vector<unsigned int> inds = set.Frontier();
         REQUIRE( inds.size()==2);
         REQUIRE( set.at(inds.at(0)) == MultiIndex{0,3} );
@@ -414,12 +413,12 @@ TEST_CASE("Testing the MultiIndexSet class", "[MultiIndexSet]" ) {
         REQUIRE( inds.size()==2);
         REQUIRE( set.at(inds.at(0)) == MultiIndex{0,3} );
         REQUIRE( set.at(inds.at(1)) == MultiIndex{3,0} );
-        
-        // Now remove the limiter, which should allow more multiindices in the 
+
+        // Now remove the limiter, which should allow more multiindices in the
         set.SetLimiter( MultiIndexLimiter::None() );
-        
+
         inds = set.Frontier();
-        
+
         REQUIRE( inds.size() == 5);
         REQUIRE( set.at(inds.at(0)) == MultiIndex{0,2} );
         REQUIRE( set.at(inds.at(1)) == MultiIndex{0,3} );

--- a/tests/RunTests.cpp
+++ b/tests/RunTests.cpp
@@ -23,7 +23,7 @@ int main( int argc, char* argv[] ) {
   if( returnCode != 0 ) // Indicates a command line error
       return returnCode;
 
-  int result = session.run();
+  session.run();
 
   Kokkos::finalize();
 }

--- a/tests/Test_ConditionalMapBase.cpp
+++ b/tests/Test_ConditionalMapBase.cpp
@@ -15,13 +15,13 @@ public:
     virtual void EvaluateImpl(Kokkos::View<const double**, Kokkos::HostSpace> const& pts,
                             Kokkos::View<double**, Kokkos::HostSpace>      &output) override{Kokkos::deep_copy(output,pts);};
 
-    virtual void LogDeterminantImpl(Kokkos::View<const double**, Kokkos::HostSpace> const& pts,
+    virtual void LogDeterminantImpl(Kokkos::View<const double**, Kokkos::HostSpace> const&,
                                     Kokkos::View<double*, Kokkos::HostSpace>             &output) override{
         for(unsigned int i=0; i<output.size(); ++i)
             output(i)=0.0;
     }
 
-    virtual void InverseImpl(Kokkos::View<const double**, Kokkos::HostSpace> const& x1,
+    virtual void InverseImpl(Kokkos::View<const double**, Kokkos::HostSpace> const&,
                             Kokkos::View<const double**, Kokkos::HostSpace> const& r,
                             Kokkos::View<double**, Kokkos::HostSpace>      & output) override{Kokkos::deep_copy(output,r);};
 };


### PR DESCRIPTION
Fixes #48. Most of these are unsigned and signed comparisons, some just removing unused arguments, and a lot of the rest being `-Wreorder` errors. A few were genuinely concerning but are now fixed.