### PR TITLE
default kokkos-threads set to max #cpus for Python

### DIFF
--- a/.github/workflows/build-external-lib-tests.yml
+++ b/.github/workflows/build-external-lib-tests.yml
@@ -70,7 +70,7 @@ jobs:
         shell: bash -l {0}
         run: |
           cd $GITHUB_WORKSPACE/mpart/build
-          ./RunTests --kokkos-threads=2 --reporter junit -o test-results-external.xml
+          ./RunTests --reporter junit -o test-results-external.xml
 
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1

--- a/.github/workflows/build-external-lib-tests.yml
+++ b/.github/workflows/build-external-lib-tests.yml
@@ -70,7 +70,7 @@ jobs:
         shell: bash -l {0}
         run: |
           cd $GITHUB_WORKSPACE/mpart/build
-          ./RunTests
+          ./RunTests --kokkos-threads=2
 
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1

--- a/.github/workflows/build-external-lib-tests.yml
+++ b/.github/workflows/build-external-lib-tests.yml
@@ -70,7 +70,7 @@ jobs:
         shell: bash -l {0}
         run: |
           cd $GITHUB_WORKSPACE/mpart/build
-          ./RunTests --reporter junit -o test-results-external.xml
+          ./RunTests
 
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1

--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: cd build; make
 
       - name: Run Tests
-        run: cd build; ./RunTests --kokkos-threads=2 --reporter junit -o test-results.xml
+        run: cd build; ./RunTests --reporter junit -o test-results.xml
 
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1

--- a/bindings/python/package/__init__.py
+++ b/bindings/python/package/__init__.py
@@ -1,5 +1,7 @@
 import sys
 from .pympart import *
+import multiprocessing
 
-kokkos_init = Initialize({})
+ncpus = multiprocessing.cpu_count()
+kokkos_init = Initialize({"kokkos-threads": ncpus})
 sys.modules[__name__] = sys.modules['mpart']


### PR DESCRIPTION
When specifying no options to Kokkos:initialize, the default number of threads is set to 1. I changed the __init.py__ file such that python binding will use by default the number of cpus of the machine as the number of threads for Kokkos. 

This feature use the multiprocessing package the number of cpus.

Feel free to decline the request if this new default behavior is not wanted.
might 

In the future we probably want the user to choose the number of threads at the beginning of the session.