### PR TITLE
Hermite functions

### DIFF
--- a/MParT/HermiteFunction.h
+++ b/MParT/HermiteFunction.h
@@ -15,13 +15,16 @@ public:
                      unsigned int         maxOrder,
                      double               x) const
     {   
+        
         // Evaluate all of the physicist hermite polynomials
-        polyBase.EvaluateAll(output, maxOrder, x);
+        output[0] = std::pow(M_PI, -0.25) * std::exp(-0.5*x*x);
 
-        // Add the scaling 
-        const double baseScaling = std::pow(M_PI, -0.25) * std::exp(-0.5*x*x);
-        for(unsigned int i=0; i<=maxOrder; ++i)
-            output[i] *= (baseScaling * std::pow( std::pow(2, i) * std::tgamma(i+1), -0.5) );
+        if(maxOrder>0){
+            output[1] = std::sqrt(2.0) * x * output[0];
+
+            for(unsigned int i=2; i<=maxOrder; ++i)
+                output[i] = (x*output[i-1]  - std::sqrt(0.5*(i-1))*output[i-2])/std::sqrt(0.5*i);
+        }
     }
 
    KOKKOS_INLINE_FUNCTION  void EvaluateDerivatives(double*              vals,
@@ -29,14 +32,23 @@ public:
                              unsigned int         maxOrder,
                              double               x) const
     {   
+
         // Evaluate all of the physicist hermite polynomials
         polyBase.EvaluateDerivatives(vals, derivs, maxOrder, x);
 
         // Add the scaling 
         const double baseScaling = std::pow(M_PI, -0.25) * std::exp(-0.5*x*x);
         double scale;
-        for(unsigned int i=0; i<=maxOrder; ++i){
-            scale = baseScaling * std::pow( std::pow(2, i) * std::tgamma(i+1), -0.5);
+        double currFactorial = 1;
+
+        scale = baseScaling;
+        derivs[0] -= x*vals[0];
+        derivs[0] *= scale;
+        vals[0] *= scale;
+
+        for(unsigned int i=1; i<=maxOrder; ++i){
+            currFactorial *= i;
+            scale = baseScaling * std::pow( std::pow(2, i) * currFactorial, -0.5);
             derivs[i] -= x*vals[i];
             derivs[i] *= scale;
             vals[i] *= scale;
@@ -62,7 +74,7 @@ public:
     KOKKOS_INLINE_FUNCTION double Evaluate(unsigned int const order, 
                     double const x) const
     {
-        const double scaling = std::pow( std::pow(2, order) * std::tgamma(order+1) *std::sqrt(M_PI), -0.5);
+        const double scaling = std::pow( std::pow(2, order) * Factorial(order) *std::sqrt(M_PI), -0.5);
 
         return scaling * std::exp(-0.5*x*x) * polyBase.Evaluate(order, x);
 
@@ -71,7 +83,7 @@ public:
     KOKKOS_INLINE_FUNCTION double Derivative(unsigned int const order, 
                       double const x) const 
     {
-        const double scaling = std::pow( std::pow(2, order) * std::tgamma(order+1) *std::sqrt(M_PI), -0.5);
+        const double scaling = std::pow( std::pow(2, order) * Factorial(order) *std::sqrt(M_PI), -0.5);
         const double expPart = std::exp(-0.5*x*x);
         return scaling * ( -x*expPart*polyBase.Evaluate(order, x) + expPart * polyBase.Derivative(order,x) );
     }
@@ -85,6 +97,13 @@ public:
 private:
     PhysicistHermite polyBase;
 
+    KOKKOS_INLINE_FUNCTION unsigned int Factorial(unsigned int d) const{
+        unsigned int out = 1;
+        for(unsigned int i=2; i<=d; ++i)
+            out *= i;
+        return out;
+    }
+    
 }; // class HermiteFunction
 
 }

--- a/MParT/HermiteFunction.h
+++ b/MParT/HermiteFunction.h
@@ -12,46 +12,62 @@ class HermiteFunction
 public:
 
     KOKKOS_INLINE_FUNCTION void EvaluateAll(double*              output,
-                     unsigned int         maxOrder,
-                     double               x) const
+                                            unsigned int         maxOrder,
+                                            double               x) const
     {   
         
-        // Evaluate all of the physicist hermite polynomials
-        output[0] = std::pow(M_PI, -0.25) * std::exp(-0.5*x*x);
+        output[0] = 1.0;
 
         if(maxOrder>0){
-            output[1] = std::sqrt(2.0) * x * output[0];
+            output[1] = x;
+            
+            if(maxOrder>1){
+                // Evaluate all of the physicist hermite polynomials
+                output[2] = std::pow(M_PI, -0.25) * std::exp(-0.5*x*x);
 
-            for(unsigned int i=2; i<=maxOrder; ++i)
-                output[i] = (x*output[i-1]  - std::sqrt(0.5*(i-1))*output[i-2])/std::sqrt(0.5*i);
+                if(maxOrder>2){
+                    output[3] = std::sqrt(2.0) * x * output[0];
+                    for(unsigned int i=2; i<=maxOrder-2; ++i)
+                        output[i+2] = (x*output[i+1]  - std::sqrt(0.5*(i-1))*output[i])/std::sqrt(0.5*i);
+                }
+            }
         }
     }
 
    KOKKOS_INLINE_FUNCTION  void EvaluateDerivatives(double*              vals,
-                             double*              derivs,
-                             unsigned int         maxOrder,
-                             double               x) const
+                                                    double*              derivs,
+                                                    unsigned int         maxOrder,
+                                                    double               x) const
     {   
+        vals[0] = 1.0;
+        derivs[0] = 0.0;
 
-        // Evaluate all of the physicist hermite polynomials
-        polyBase.EvaluateDerivatives(vals, derivs, maxOrder, x);
+        if(maxOrder>0){
+            vals[0] = x;
+            derivs[1] = 1.0;
 
-        // Add the scaling 
-        const double baseScaling = std::pow(M_PI, -0.25) * std::exp(-0.5*x*x);
-        double scale;
-        double currFactorial = 1;
+            if(maxOrder>1){
+                // Evaluate all of the physicist hermite polynomials
+                polyBase.EvaluateDerivatives(&vals[2], &derivs[2], maxOrder-2, x);
 
-        scale = baseScaling;
-        derivs[0] -= x*vals[0];
-        derivs[0] *= scale;
-        vals[0] *= scale;
+                // Add the scaling 
+                const double baseScaling = std::pow(M_PI, -0.25) * std::exp(-0.5*x*x);
+                double scale;
+                double currFactorial = 1;
 
-        for(unsigned int i=1; i<=maxOrder; ++i){
-            currFactorial *= i;
-            scale = baseScaling * std::pow( std::pow(2, i) * currFactorial, -0.5);
-            derivs[i] -= x*vals[i];
-            derivs[i] *= scale;
-            vals[i] *= scale;
+                scale = baseScaling;
+                derivs[2] -= x*vals[2];
+                derivs[2] *= scale;
+                vals[2] *= scale;
+
+                for(unsigned int i=1; i<=maxOrder-2; ++i){
+                    currFactorial *= i;
+                    scale = baseScaling * std::pow( std::pow(2, i) * currFactorial, -0.5);
+                    derivs[i+2] -= x*vals[i+2];
+                    derivs[i+2] *= scale;
+                    vals[i+2] *= scale;
+                }
+            }
         }
     }
 
@@ -65,33 +81,56 @@ public:
         // Evaluate all of the physicist hermite polynomials
         EvaluateDerivatives(vals, derivs, maxOrder, x);
 
-        // Add the scaling 
-        for(unsigned int i=0; i<=maxOrder; ++i)
-            derivs2[i] = -(2.0*i + 1.0 - x*x)*vals[i];
+        derivs2[0] = 0.0;
+        
+        if(maxOrder>0){
+            derivs2[1] = 0.0;
+
+            if(maxOrder>1){
+        
+                // Add the scaling 
+                for(unsigned int i=0; i<=maxOrder-2; ++i)
+                    derivs2[i+2] = -(2.0*i + 1.0 - x*x)*vals[i+2];
+            }
+        }
     }
 
 
     KOKKOS_INLINE_FUNCTION double Evaluate(unsigned int const order, 
-                    double const x) const
+                                           double const x) const
     {
-        const double scaling = std::pow( std::pow(2, order) * Factorial(order) *std::sqrt(M_PI), -0.5);
-
-        return scaling * std::exp(-0.5*x*x) * polyBase.Evaluate(order, x);
-
+        if(order==0){
+            return 1.0;
+        }else if(order==1){
+            return x;
+        }else{
+            const double scaling = std::pow( std::pow(2, order-2) * Factorial(order-2) *std::sqrt(M_PI), -0.5);
+            return scaling * std::exp(-0.5*x*x) * polyBase.Evaluate(order-2, x);
+        }
     }
 
     KOKKOS_INLINE_FUNCTION double Derivative(unsigned int const order, 
-                      double const x) const 
-    {
-        const double scaling = std::pow( std::pow(2, order) * Factorial(order) *std::sqrt(M_PI), -0.5);
-        const double expPart = std::exp(-0.5*x*x);
-        return scaling * ( -x*expPart*polyBase.Evaluate(order, x) + expPart * polyBase.Derivative(order,x) );
+                                             double const x) const 
+    {   
+        if(order==0){
+            return 0.0;
+        }else if(order==1){
+            return 1.0;
+        }else{
+            const double scaling = std::pow( std::pow(2, order-2) * Factorial(order-2) *std::sqrt(M_PI), -0.5);
+            const double expPart = std::exp(-0.5*x*x);
+            return scaling * ( -x*expPart*polyBase.Evaluate(order-2, x) + expPart * polyBase.Derivative(order-2,x) );
+        }
     }
 
     KOKKOS_INLINE_FUNCTION double SecondDerivative(unsigned int const order, 
                             double const x) const
-    {
-        return -(2.0*order+1.0-x*x)*Evaluate(order, x);
+    {   
+        if(order<2){
+            return 0; 
+        }else{
+            return -(2.0*order+1.0-x*x)*Evaluate(order-2, x);
+        }
     }
 
 private:

--- a/tests/Test_HermiteFunctions.cpp
+++ b/tests/Test_HermiteFunctions.cpp
@@ -13,69 +13,91 @@ TEST_CASE( "Testing Hermite functions", "[HermiteFunction]" ) {
     HermiteFunction poly;
 
     std::vector<double> xs{-1.0, -0.5, 0.0, 0.1, 1.0};
-    std::vector<double> allvals(5);
-    std::vector<double> allderivs(5);
-    std::vector<double> allderivs2(5);
+    std::vector<double> allvals(7);
+    std::vector<double> allderivs(7);
+    std::vector<double> allderivs2(7);
 
     double truth;
 
     for(auto& x : xs){
-        poly.EvaluateAll(&allvals[0], 4, x);
+        poly.EvaluateAll(&allvals[0], 6, x);
         
-        truth = std::pow(M_PI, -0.25) * std::exp(-0.5*x*x);
-        CHECK( poly.Evaluate(0, x) == Approx(truth).epsilon(floatTol) ); 
+        truth = 1.0;
+        CHECK(poly.Evaluate(0,x) == Approx(truth).epsilon(floatTol));
         CHECK( allvals[0] == Approx(truth).epsilon(floatTol));
-
-        truth = std::sqrt(2.0)*std::pow(M_PI, -0.25) * x*std::exp(-0.5*x*x);
-        CHECK( poly.Evaluate(1, x) == Approx(truth).epsilon(floatTol) ); 
-        CHECK( allvals[1] == Approx(truth).epsilon(floatTol));
         
+        truth = x;
+        CHECK(poly.Evaluate(1,x) == Approx(truth).epsilon(floatTol));
+        CHECK( allvals[1] == Approx(truth).epsilon(floatTol));
 
-        truth = std::pow(2.0, -0.5) * std::pow(M_PI, -0.25) * (2.0*x*x-1.0) * std::exp(-0.5*x*x);
+        truth = std::pow(M_PI, -0.25) * std::exp(-0.5*x*x);
         CHECK( poly.Evaluate(2, x) == Approx(truth).epsilon(floatTol) ); 
         CHECK( allvals[2] == Approx(truth).epsilon(floatTol));
-        
 
-        truth = std::pow(3.0, -0.5) * std::pow(M_PI, -0.25) * (2.0*x*x*x-3.0*x) * std::exp(-0.5*x*x);
+        truth = std::sqrt(2.0)*std::pow(M_PI, -0.25) * x*std::exp(-0.5*x*x);
         CHECK( poly.Evaluate(3, x) == Approx(truth).epsilon(floatTol) ); 
         CHECK( allvals[3] == Approx(truth).epsilon(floatTol));
         
 
-        truth = std::pow(24.0, -0.5) * std::pow(M_PI, -0.25) * (4.0*x*x*x*x - 12*x*x + 3.0) * std::exp(-0.5*x*x);
+        truth = std::pow(2.0, -0.5) * std::pow(M_PI, -0.25) * (2.0*x*x-1.0) * std::exp(-0.5*x*x);
         CHECK( poly.Evaluate(4, x) == Approx(truth).epsilon(floatTol) ); 
         CHECK( allvals[4] == Approx(truth).epsilon(floatTol));
-
-
-        poly.EvaluateDerivatives(&allvals[0], &allderivs[0], 4, x);
-        CHECK( allvals[0] == Approx(std::pow(M_PI, -0.25) * std::exp(-0.5*x*x)).epsilon(floatTol));
-        CHECK( allvals[1] == Approx(std::sqrt(2.0)*std::pow(M_PI, -0.25) * x*std::exp(-0.5*x*x)).epsilon(floatTol));
-        CHECK( allvals[2] == Approx(std::pow(2.0, -0.5) * std::pow(M_PI, -0.25) * (2.0*x*x-1.0) * std::exp(-0.5*x*x)).epsilon(floatTol));
-        CHECK( allvals[3] == Approx(std::pow(3.0, -0.5) * std::pow(M_PI, -0.25) * (2.0*x*x*x-3.0*x) * std::exp(-0.5*x*x)).epsilon(floatTol));
-        CHECK( allvals[4] == Approx(std::pow(24.0, -0.5) * std::pow(M_PI, -0.25) * (4.0*x*x*x*x - 12*x*x + 3.0) * std::exp(-0.5*x*x)).epsilon(floatTol));
-        CHECK( allderivs[0] == Approx(-x*std::pow(M_PI, -0.25) * std::exp(-0.5*x*x)).epsilon(floatTol));
-        CHECK( allderivs[1] == Approx(std::sqrt(2.0)*std::pow(M_PI, -0.25) * (std::exp(-0.5*x*x)*(1.0-x*x))).epsilon(floatTol));
-        CHECK( poly.Derivative(1,x) == Approx(std::sqrt(2.0)*std::pow(M_PI, -0.25) * (std::exp(-0.5*x*x)*(1.0-x*x))).epsilon(floatTol));
-        CHECK( allderivs[2] == Approx(std::pow(2.0, -0.5) * std::pow(M_PI, -0.25) * (4.0*x -x*(2.0*x*x-1.0) ) * std::exp(-0.5*x*x)).epsilon(floatTol));
-        CHECK( poly.Derivative(2,x) == Approx(std::pow(2.0, -0.5) * std::pow(M_PI, -0.25) * (4.0*x -x*(2.0*x*x-1.0) ) * std::exp(-0.5*x*x)).epsilon(floatTol));
-        CHECK( allderivs[3] == Approx(std::pow(3.0, -0.5) * std::pow(M_PI, -0.25) * ((6.0*x*x-3.0) -x*(2.0*x*x*x-3.0*x)) * std::exp(-0.5*x*x)).epsilon(floatTol));
-        CHECK( poly.Derivative(3,x) == Approx(std::pow(3.0, -0.5) * std::pow(M_PI, -0.25) * ((6.0*x*x-3.0) -x*(2.0*x*x*x-3.0*x)) * std::exp(-0.5*x*x)).epsilon(floatTol));
-        CHECK( allderivs[4] == Approx(std::pow(24.0, -0.5) * std::pow(M_PI, -0.25) * ((16.0*x*x*x - 24*x)-x*(4.0*x*x*x*x - 12*x*x + 3.0)) * std::exp(-0.5*x*x)).epsilon(floatTol));
-        CHECK( poly.Derivative(4,x) == Approx(std::pow(24.0, -0.5) * std::pow(M_PI, -0.25) * ((16.0*x*x*x - 24*x)-x*(4.0*x*x*x*x - 12*x*x + 3.0)) * std::exp(-0.5*x*x)).epsilon(floatTol));
-
-        poly.EvaluateSecondDerivatives(&allvals[0], &allderivs[0], &allderivs2[0], 4, x);
-        CHECK( allvals[0] == Approx(std::pow(M_PI, -0.25) * std::exp(-0.5*x*x)).epsilon(floatTol));
-        CHECK( allvals[1] == Approx(std::sqrt(2.0)*std::pow(M_PI, -0.25) * x*std::exp(-0.5*x*x)).epsilon(floatTol));
-        CHECK( allvals[2] == Approx(std::pow(2.0, -0.5) * std::pow(M_PI, -0.25) * (2.0*x*x-1.0) * std::exp(-0.5*x*x)).epsilon(floatTol));
-        CHECK( allvals[3] == Approx(std::pow(3.0, -0.5) * std::pow(M_PI, -0.25) * (2.0*x*x*x-3.0*x) * std::exp(-0.5*x*x)).epsilon(floatTol));
-        CHECK( allvals[4] == Approx(std::pow(24.0, -0.5) * std::pow(M_PI, -0.25) * (4.0*x*x*x*x - 12*x*x + 3.0) * std::exp(-0.5*x*x)).epsilon(floatTol));
-        CHECK( allderivs[0] == Approx(-x*std::pow(M_PI, -0.25) * std::exp(-0.5*x*x)).epsilon(floatTol));
-        CHECK( allderivs[1] == Approx(std::sqrt(2.0)*std::pow(M_PI, -0.25) * (std::exp(-0.5*x*x)*(1.0-x*x))).epsilon(floatTol));
-        CHECK( allderivs[2] == Approx(std::pow(2.0, -0.5) * std::pow(M_PI, -0.25) * (4.0*x -x*(2.0*x*x-1.0) ) * std::exp(-0.5*x*x)).epsilon(floatTol));
-        CHECK( allderivs[3] == Approx(std::pow(3.0, -0.5) * std::pow(M_PI, -0.25) * ((6.0*x*x-3.0) -x*(2.0*x*x*x-3.0*x)) * std::exp(-0.5*x*x)).epsilon(floatTol));
-        CHECK( allderivs[4] == Approx(std::pow(24.0, -0.5) * std::pow(M_PI, -0.25) * ((16.0*x*x*x - 24*x)-x*(4.0*x*x*x*x - 12*x*x + 3.0)) * std::exp(-0.5*x*x)).epsilon(floatTol));
         
+
+        truth = std::pow(3.0, -0.5) * std::pow(M_PI, -0.25) * (2.0*x*x*x-3.0*x) * std::exp(-0.5*x*x);
+        CHECK( poly.Evaluate(4, x) == Approx(truth).epsilon(floatTol) ); 
+        CHECK( allvals[4] == Approx(truth).epsilon(floatTol));
+        
+
+        truth = std::pow(24.0, -0.5) * std::pow(M_PI, -0.25) * (4.0*x*x*x*x - 12*x*x + 3.0) * std::exp(-0.5*x*x);
+        CHECK( poly.Evaluate(5, x) == Approx(truth).epsilon(floatTol) ); 
+        CHECK( allvals[5] == Approx(truth).epsilon(floatTol));
+
+
+        poly.EvaluateDerivatives(&allvals[0], &allderivs[0], 6, x);
+        CHECK( allvals[0] == Approx(1.0).epsilon(floatTol));
+        CHECK( allvals[1] == Approx(x).epsilon(floatTol));
+        CHECK( allvals[2] == Approx(std::pow(M_PI, -0.25) * std::exp(-0.5*x*x)).epsilon(floatTol));
+        CHECK( allvals[3] == Approx(std::sqrt(2.0)*std::pow(M_PI, -0.25) * x*std::exp(-0.5*x*x)).epsilon(floatTol));
+        CHECK( allvals[4] == Approx(std::pow(2.0, -0.5) * std::pow(M_PI, -0.25) * (2.0*x*x-1.0) * std::exp(-0.5*x*x)).epsilon(floatTol));
+        CHECK( allvals[5] == Approx(std::pow(3.0, -0.5) * std::pow(M_PI, -0.25) * (2.0*x*x*x-3.0*x) * std::exp(-0.5*x*x)).epsilon(floatTol));
+        CHECK( allvals[6] == Approx(std::pow(24.0, -0.5) * std::pow(M_PI, -0.25) * (4.0*x*x*x*x - 12*x*x + 3.0) * std::exp(-0.5*x*x)).epsilon(floatTol));
+        
+        CHECK( allderivs[0] == Approx(0.0).epsilon(floatTol));
+        CHECK( poly.Derivative(0,x) == Approx(0.0).epsilon(floatTol));
+        CHECK( allderivs[1] == Approx(1.0).epsilon(floatTol));
+        CHECK( poly.Derivative(1,x) == Approx(1.0).epsilon(floatTol));
+        CHECK( allderivs[2] == Approx(-x*std::pow(M_PI, -0.25) * std::exp(-0.5*x*x)).epsilon(floatTol));
+        CHECK( allderivs[3] == Approx(std::sqrt(2.0)*std::pow(M_PI, -0.25) * (std::exp(-0.5*x*x)*(1.0-x*x))).epsilon(floatTol));
+        CHECK( poly.Derivative(3,x) == Approx(std::sqrt(2.0)*std::pow(M_PI, -0.25) * (std::exp(-0.5*x*x)*(1.0-x*x))).epsilon(floatTol));
+        CHECK( allderivs[4] == Approx(std::pow(2.0, -0.5) * std::pow(M_PI, -0.25) * (4.0*x -x*(2.0*x*x-1.0) ) * std::exp(-0.5*x*x)).epsilon(floatTol));
+        CHECK( poly.Derivative(4,x) == Approx(std::pow(2.0, -0.5) * std::pow(M_PI, -0.25) * (4.0*x -x*(2.0*x*x-1.0) ) * std::exp(-0.5*x*x)).epsilon(floatTol));
+        CHECK( allderivs[5] == Approx(std::pow(3.0, -0.5) * std::pow(M_PI, -0.25) * ((6.0*x*x-3.0) -x*(2.0*x*x*x-3.0*x)) * std::exp(-0.5*x*x)).epsilon(floatTol));
+        CHECK( poly.Derivative(5,x) == Approx(std::pow(3.0, -0.5) * std::pow(M_PI, -0.25) * ((6.0*x*x-3.0) -x*(2.0*x*x*x-3.0*x)) * std::exp(-0.5*x*x)).epsilon(floatTol));
+        CHECK( allderivs[6] == Approx(std::pow(24.0, -0.5) * std::pow(M_PI, -0.25) * ((16.0*x*x*x - 24*x)-x*(4.0*x*x*x*x - 12*x*x + 3.0)) * std::exp(-0.5*x*x)).epsilon(floatTol));
+        CHECK( poly.Derivative(6,x) == Approx(std::pow(24.0, -0.5) * std::pow(M_PI, -0.25) * ((16.0*x*x*x - 24*x)-x*(4.0*x*x*x*x - 12*x*x + 3.0)) * std::exp(-0.5*x*x)).epsilon(floatTol));
+
+        poly.EvaluateSecondDerivatives(&allvals[0], &allderivs[0], &allderivs2[0], 6, x);
+        CHECK( allvals[0] == 1.0);
+        CHECK( allvals[1] == Approx(x).epsilon(floatTol));
+        CHECK( allvals[2] == Approx(std::pow(M_PI, -0.25) * std::exp(-0.5*x*x)).epsilon(floatTol));
+        CHECK( allvals[3] == Approx(std::sqrt(2.0)*std::pow(M_PI, -0.25) * x*std::exp(-0.5*x*x)).epsilon(floatTol));
+        CHECK( allvals[4] == Approx(std::pow(2.0, -0.5) * std::pow(M_PI, -0.25) * (2.0*x*x-1.0) * std::exp(-0.5*x*x)).epsilon(floatTol));
+        CHECK( allvals[5] == Approx(std::pow(3.0, -0.5) * std::pow(M_PI, -0.25) * (2.0*x*x*x-3.0*x) * std::exp(-0.5*x*x)).epsilon(floatTol));
+        CHECK( allvals[6] == Approx(std::pow(24.0, -0.5) * std::pow(M_PI, -0.25) * (4.0*x*x*x*x - 12*x*x + 3.0) * std::exp(-0.5*x*x)).epsilon(floatTol));
+        CHECK( allderivs[0] == 0.0);
+        CHECK( allderivs[1] == 1.0);
+        CHECK( allderivs[2] == Approx(-x*std::pow(M_PI, -0.25) * std::exp(-0.5*x*x)).epsilon(floatTol));
+        CHECK( allderivs[3] == Approx(std::sqrt(2.0)*std::pow(M_PI, -0.25) * (std::exp(-0.5*x*x)*(1.0-x*x))).epsilon(floatTol));
+        CHECK( allderivs[4] == Approx(std::pow(2.0, -0.5) * std::pow(M_PI, -0.25) * (4.0*x -x*(2.0*x*x-1.0) ) * std::exp(-0.5*x*x)).epsilon(floatTol));
+        CHECK( allderivs[5] == Approx(std::pow(3.0, -0.5) * std::pow(M_PI, -0.25) * ((6.0*x*x-3.0) -x*(2.0*x*x*x-3.0*x)) * std::exp(-0.5*x*x)).epsilon(floatTol));
+        CHECK( allderivs[6] == Approx(std::pow(24.0, -0.5) * std::pow(M_PI, -0.25) * ((16.0*x*x*x - 24*x)-x*(4.0*x*x*x*x - 12*x*x + 3.0)) * std::exp(-0.5*x*x)).epsilon(floatTol));
+        
+        CHECK(allderivs2[0] == 0.0);
+        CHECK(allderivs2[1] == 0.0);
+    
         for(unsigned int i=0; i<5; ++i)
-            CHECK( allderivs2[i] == Approx( -(2.0*i + 1 -x*x)*allvals[i] ).epsilon(floatTol));      
+            CHECK( allderivs2[i+2] == Approx( -(2.0*i + 1 -x*x)*allvals[i+2] ).epsilon(floatTol));      
         
         
     }


### PR DESCRIPTION
In practice, we seem to use Hermite functions with an extra constant and linear term.   This pull requests add those terms to the 1d Hermite function scalar basis class.    An order of `n=0` now gives a constant value.   `n=1` will result in `x` and orders greater than 2 will result in the Hermite function of order `n-2`.