### PR TITLE
Changed python bindings to use structure-based Kokkos init.

### DIFF
--- a/bindings/python/package/__init__.py
+++ b/bindings/python/package/__init__.py
@@ -1,5 +1,5 @@
 import sys
 from .pympart import *
 
-kokkos_init = Initialize({})
+kokkos_init = Initialize(dict())
 sys.modules[__name__] = sys.modules['mpart']

--- a/bindings/python/src/CommonPybindUtilities.cpp
+++ b/bindings/python/src/CommonPybindUtilities.cpp
@@ -44,4 +44,5 @@ void mpart::binding::Initialize(py::dict opts) {
 void mpart::binding::CommonUtilitiesWrapper(py::module &m)
 {   
     m.def("Initialize", py::overload_cast<py::dict>( &mpart::binding::Initialize ));
+    m.def("Concurrency", &Kokkos::DefaultExecutionSpace::concurrency);
 }

--- a/bindings/python/src/CommonPybindUtilities.cpp
+++ b/bindings/python/src/CommonPybindUtilities.cpp
@@ -3,6 +3,7 @@
 #include <pybind11/stl.h>
 #include <pybind11/eigen.h>
 
+#include "MParT/Initialization.h"
 #include <Kokkos_Core.hpp>
 
 #include <pybind11/pybind11.h>
@@ -13,23 +14,34 @@ using namespace mpart::binding;
 // Define a wrapper around Kokkos::Initialize that accepts a python dictionary instead of argc and argv.
 void mpart::binding::Initialize(py::dict opts) {
 
-    std::vector<std::string> args;
+    Kokkos::InitArguments args;
 
     pybind11::object keys = pybind11::list(opts.attr("keys")());
     std::vector<std::string> keysCpp = keys.cast<std::vector<std::string>>();
 
     for(auto& key : keysCpp){
-        std::string val = "--" + key + "=";
-        val += (std::string) pybind11::str(opts.attr("get")(key));
-        args.push_back(val);
+        
+        if((key=="num_threads")||(key=="kokkos-threads")){
+            args.num_threads = py::cast<int>(opts.attr("get")(key));
+        }else if(key=="num_numa"){
+            args.num_numa = py::cast<int>(opts.attr("get")(key));
+        }else if(key=="device_id"){
+            args.device_id = py::cast<int>(opts.attr("get")(key));
+        }else if(key=="ndevices"){
+            args.ndevices = py::cast<int>(opts.attr("get")(key));
+        }else if(key=="skip_device"){
+            args.skip_device = py::cast<int>(opts.attr("get")(key));
+        }else if(key=="disable_warnings"){
+            args.disable_warnings = py::cast<bool>(opts.attr("get")(key));
+        }else{
+            std::cout << "WARNING: Kokkos initialization argument \"" << key << "\" was not used." << std::endl;
+        }
     }
-    
-    mpart::binding::Initialize(args);
-};
 
+    mpart::Initialize(args);
+};
 
 void mpart::binding::CommonUtilitiesWrapper(py::module &m)
 {   
     m.def("Initialize", py::overload_cast<py::dict>( &mpart::binding::Initialize ));
-    m.def("Initialize", py::overload_cast<std::vector<std::string>>( &mpart::binding::Initialize ));
 }


### PR DESCRIPTION
According to the [Kokkos docs](https://github.com/kokkos/kokkos/wiki/Initialization), the Kokkos configuration can be set at runtime by constructing an instance of the`Kokkos::InitArguments` class.  Previously we were just passing in arguments like they were set on the command line, but the Kokkos documentation seems to imply that if negative values are passed to `Kokkos::InitArguments`, then the default behavior is to use `hwloc` to find the default number of threads.   

Also added ability to check the amount of concurrency that Kokkos can exploit (e.g., the number of threads) using `mpart.Concurrency()` in python.