### PR TITLE
Sphinx documentation updates: License and tutorial links

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -46,26 +46,21 @@ In bibtex, this is::
 License
 ---------
 
-MParT is release under the MIT License.
+MParT is release under the BSD license.
 
 .. epigraph::
 
-   Copyright (c) 2022 Trustees of Dartmouth College
+    BSD 3-Clause License
 
-   Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   copies of the Software, and to permit persons to whom the Software is
-   furnished to do so, subject to the following conditions:
+    Copyright (c) 2022, Massachusetts Institute of Technology
+    All rights reserved.
 
-   The above copyright notice and this permission notice shall be included in all
-   copies or substantial portions of the Software.
+    Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 
-   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-   SOFTWARE. 
+    1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+    3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/docs/source/tutorials/index.rst
+++ b/docs/source/tutorials/index.rst
@@ -15,7 +15,7 @@ Tutorials
 
     Construct a transport map using samples of a distribution.
 
-    .. link-button:: ./fromsamples.html
+    .. link-button:: https://github.com/MeasureTransport/SIAMannual22/blob/main/tutorial_code_AN22.ipynb
         :type: url
         :text: Learn more
         :classes: btn-secondary stretched-link
@@ -28,7 +28,7 @@ Tutorials
 
     Construct a transport map using density evaluations.
 
-    .. link-button:: ./fromdensity.html
+    .. link-button:: https://github.com/MeasureTransport/SIAMannual22/blob/main/tutorial_code_AN22.ipynb
         :type: url
         :text: Learn more
         :classes: btn-secondary stretched-link
@@ -41,7 +41,7 @@ Tutorials
 
     Fit data with a monotone function.
 
-    .. link-button:: ./regression.html
+    .. link-button:: https://github.com/MeasureTransport/SIAMannual22/blob/main/tutorial_code_AN22.ipynb
         :type: url
         :text: Learn more
         :classes: btn-secondary stretched-link


### PR DESCRIPTION
Fixed license in Sphinx documentation and added links to SIAM annual notebook as temporary fix for tutorials.