### PR TITLE
Update MParT::Initialize so that Kokkos can update argc.

### DIFF
--- a/.github/workflows/build-external-lib-tests.yml
+++ b/.github/workflows/build-external-lib-tests.yml
@@ -59,7 +59,7 @@ jobs:
         shell: bash -l {0}
         run: |
           cd $GITHUB_WORKSPACE/mpart/build
-          ./RunTests --kokkos-threads=2 --reporter junit -o test-results-external.xml
+          ./RunTests
 
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1

--- a/.github/workflows/build-external-lib-tests.yml
+++ b/.github/workflows/build-external-lib-tests.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Run Tests
         shell: bash -l {0}
-        run: cd $GITHUB_WORKSPACE/mpart/build; ./RunTests "[MultivariateExpansion]"
+        run: cd $GITHUB_WORKSPACE/mpart/build; ./RunTests --kokkos-threads=2 --reporter junit -o test-results.xml
 
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1

--- a/.github/workflows/build-external-lib-tests.yml
+++ b/.github/workflows/build-external-lib-tests.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Run Tests
         shell: bash -l {0}
-        run: cd $GITHUB_WORKSPACE/mpart/build; ./RunTests "*"
+        run: cd $GITHUB_WORKSPACE/mpart/build; ./RunTests "[MultivariateExpansion]"
 
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1

--- a/.github/workflows/build-external-lib-tests.yml
+++ b/.github/workflows/build-external-lib-tests.yml
@@ -22,24 +22,13 @@ jobs:
         with:
           path: mpart
 
-      - name: Cache Kokkos
-        id: cache-kokkos 
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-build-kokkos
-        with:
-          path: ${{ github.workspace }}/KOKKOS_INSTALL
-          key: ${{ runner.os }}-${{ env.cache-name }}
-
       - name: Checkout Kokkos
-        if: steps.cache-kokkos.outputs.cache-hit != 'true'
         uses: actions/checkout@v3
         with:
           repository: kokkos/kokkos
           path: kokkos
 
       - name: Install Kokkos
-        if: steps.cache-kokkos.outputs.cache-hit != 'true'
         run: |
           cd $GITHUB_WORKSPACE/kokkos
           mkdir build && cd build

--- a/.github/workflows/build-external-lib-tests.yml
+++ b/.github/workflows/build-external-lib-tests.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Run Tests
         shell: bash -l {0}
-        run: cd $GITHUB_WORKSPACE/mpart/build; ./RunTests
+        run: cd $GITHUB_WORKSPACE/mpart/build; ./RunTests "[SofPlus]"
 
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1

--- a/.github/workflows/build-external-lib-tests.yml
+++ b/.github/workflows/build-external-lib-tests.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Run Tests
         shell: bash -l {0}
-        run: cd $GITHUB_WORKSPACE/mpart/build; ./RunTests "[MonotoneComponent1d]"
+        run: cd $GITHUB_WORKSPACE/mpart/build; ./RunTests "*"
 
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1

--- a/.github/workflows/build-external-lib-tests.yml
+++ b/.github/workflows/build-external-lib-tests.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Run Tests
         shell: bash -l {0}
-        run: cd $GITHUB_WORKSPACE/mpart/build; ./RunTests --kokkos-threads=2 --reporter junit -o test-results.xml
+        run: cd $GITHUB_WORKSPACE/mpart/build; ./RunTests --kokkos-threads=2 --reporter junit -o test-results-external.xml
 
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1

--- a/.github/workflows/build-external-lib-tests.yml
+++ b/.github/workflows/build-external-lib-tests.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Run Tests
         shell: bash -l {0}
-        run: cd $GITHUB_WORKSPACE/mpart/build; ./RunTests "[SofPlus]"
+        run: cd $GITHUB_WORKSPACE/mpart/build; ./RunTests "[MonotoneComponent1d]"
 
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1

--- a/.github/workflows/build-external-lib-tests.yml
+++ b/.github/workflows/build-external-lib-tests.yml
@@ -57,9 +57,7 @@ jobs:
 
       - name: Run Tests
         shell: bash -l {0}
-        run: |
-          cd $GITHUB_WORKSPACE/mpart/build
-          ./RunTests
+        run: cd $GITHUB_WORKSPACE/mpart/build; ./RunTests
 
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1

--- a/MParT/Initialization.h
+++ b/MParT/Initialization.h
@@ -60,13 +60,13 @@ int main( int argc, char* argv[] ) {
      @tparam Arguments 
      @param args Parameters to be passed on to Kokkos::initialize.
      */
-    template<typename... Arguments>
-    void Initialize(Arguments... args)
+    template<typename FirstArgType, typename... Arguments>
+    void Initialize(FirstArgType& arg1, Arguments... args)
     {
         if(!GetInitializeStatusObject().Get()){
         
             // Initialize kokkos
-            Kokkos::initialize(args...);
+            Kokkos::initialize(arg1, args...);
 
             // Make sure Kokkos::finalize() is called at program exit.
             std::atexit(&mpart::Finalize);

--- a/MParT/MultivariateExpansion.h
+++ b/MParT/MultivariateExpansion.h
@@ -50,7 +50,7 @@ namespace mpart{
         //         workers.push_back( MultivariateExpansionWorker<BasisEvaluatorType, MemorySpace>(msets.at(i), basis1d) );
         // }
 
-        virtual ~MultivariateExpansion() = default;
+        virtual ~MultivariateExpansion(){std::cout << "In destructor..." << std::endl;};
 
 
         virtual void EvaluateImpl(Kokkos::View<const double**, MemorySpace> const& pts,

--- a/MParT/MultivariateExpansion.h
+++ b/MParT/MultivariateExpansion.h
@@ -7,8 +7,6 @@
 
 #include <algorithm>
 
-#include <Kokkos_Vector.hpp>
-
 namespace mpart{
 
     /**
@@ -27,47 +25,35 @@ namespace mpart{
         template<typename SetType>
         MultivariateExpansion(unsigned int              outDim, 
                               SetType            const& mset, 
-                              BasisEvaluatorType const& basis1d) : ParameterizedFunctionBase<MemorySpace>(mset.Length(), outDim, mset.Size()*outDim)
-        {   std::cout << "Here 0..." << std::endl;
-            workers.push_back( MultivariateExpansionWorker<BasisEvaluatorType, MemorySpace>(mset, basis1d) );
-            std::cout << "Here 1..." << std::endl;
+                              BasisEvaluatorType const& basis1d) : ParameterizedFunctionBase<MemorySpace>(mset.Length(), outDim, mset.Size()*outDim),
+                                                                   worker(mset, basis1d)
+        {   
         };
 
         template<typename ExpansionType>
         MultivariateExpansion(unsigned int  outDim, 
-                              ExpansionType expansion) : ParameterizedFunctionBase<MemorySpace>(expansion.InputSize(), outDim, expansion.NumCoeffs()*outDim)
+                              ExpansionType expansion) : ParameterizedFunctionBase<MemorySpace>(expansion.InputSize(), outDim, expansion.NumCoeffs()*outDim),
+                                                         worker(expansion)
         {
-            workers.push_back( expansion );
         };
 
-        // template<typename SetType>
-        // MultivariateExpansion(std::vector<SetType> const& msets, 
-        //                       BasisEvaluatorType   const& basis1d) : ParameterizedFunctionBase<MemorySpace>(msets.at(0).Length(),  // input dimension
-        //                                                                                        msets.size(),          // output dimension
-        //                                                                                        std::accumulate(msets.begin(), msets.end(), 0, [](size_t sum, const SetType& mset){ return sum + mset.Size(); })) // number of coefficients
-        // {
-        //     for(unsigned int i=0; i<msets.size(); ++i)
-        //         workers.push_back( MultivariateExpansionWorker<BasisEvaluatorType, MemorySpace>(msets.at(i), basis1d) );
-        // }
-
-        virtual ~MultivariateExpansion(){std::cout << "In destructor..." << std::endl;};
+        virtual ~MultivariateExpansion(){
+            std::cout << "End of destructor..." << std::endl;
+        };
 
 
         virtual void EvaluateImpl(Kokkos::View<const double**, MemorySpace> const& pts,
                                   Kokkos::View<double**, MemorySpace>            & output) override
         {
             using ExecutionSpace = typename MemoryToExecution<MemorySpace>::Space;
-            assert(workers.size()>0);
-
+            
             const unsigned int numPts = pts.extent(1);
 
             // Figure out how much memory we'll need in the cache
-            unsigned int cacheSize = workers[0].CacheSize();
-            for(unsigned int i=1; i<workers.size(); ++i)
-                cacheSize = std::max(cacheSize, workers[i].CacheSize());
+            unsigned int cacheSize = worker.CacheSize();
 
             // Define functor if there is a constant worker for all dimensions
-            auto functor1 = KOKKOS_CLASS_LAMBDA (typename Kokkos::TeamPolicy<ExecutionSpace>::member_type team_member) {
+            auto functor = KOKKOS_CLASS_LAMBDA (typename Kokkos::TeamPolicy<ExecutionSpace>::member_type team_member) {
 
                 unsigned int ptInd = team_member.league_rank () * team_member.team_size () + team_member.team_rank ();
 
@@ -80,52 +66,20 @@ namespace mpart{
                     Kokkos::View<double*,MemorySpace> cache(team_member.thread_scratch(1), cacheSize);
 
                     // Fill in entries in the cache that are independent of x_d.  By passing DerivativeFlags::None, we are telling the expansion that no derivatives with wrt x_1,...x_{d-1} will be needed.
-                    workers[0].FillCache1(cache.data(), pt, DerivativeFlags::None);
-                    workers[0].FillCache2(cache.data(), pt, pt(pt.size()-1), DerivativeFlags::None);
+                    worker.FillCache1(cache.data(), pt, DerivativeFlags::None);
+                    worker.FillCache2(cache.data(), pt, pt(pt.size()-1), DerivativeFlags::None);
 
                     unsigned int coeffStartInd = 0;
                     
                     for(unsigned int d=0; d<this->outputDim; ++d){
 
                         // Extract the coefficients for this output dimension
-                        auto coeffs = Kokkos::subview(this->savedCoeffs, std::make_pair(coeffStartInd, coeffStartInd+workers[0].NumCoeffs()));
+                        auto coeffs = Kokkos::subview(this->savedCoeffs, std::make_pair(coeffStartInd, coeffStartInd+worker.NumCoeffs()));
                          
                         // Evaluate the expansion
-                        output(d,ptInd) = workers[0].Evaluate(cache.data(), coeffs);
+                        output(d,ptInd) = worker.Evaluate(cache.data(), coeffs);
 
-                        coeffStartInd += workers[0].NumCoeffs();
-                    }
-                }
-            };
-
-            // Define functor for case where different workers are used in each dimension
-            auto functor2 = KOKKOS_CLASS_LAMBDA (typename Kokkos::TeamPolicy<ExecutionSpace>::member_type team_member) {
-
-                unsigned int ptInd = team_member.league_rank () * team_member.team_size () + team_member.team_rank ();
-
-                if(ptInd<numPts){
-
-                    // Create a subview containing only the current point
-                    auto pt = Kokkos::subview(pts, Kokkos::ALL(), ptInd);
-                    
-                    // Get a pointer to the shared memory that Kokkos set up for this team
-                    Kokkos::View<double*,MemorySpace> cache(team_member.thread_scratch(1), cacheSize);
-
-                    unsigned int coeffStartInd = 0;
-
-                    for(unsigned int d=0; d<this->outputDim; ++d){
-
-                        // Extract the coefficients for this output dimension
-                        auto coeffs = Kokkos::subview(this->savedCoeffs, std::make_pair(coeffStartInd, coeffStartInd+workers[d].NumCoeffs()));
-                         
-                        // Fill in entries in the cache that are independent of x_d.  By passing DerivativeFlags::None, we are telling the expansion that no derivatives with wrt x_1,...x_{d-1} will be needed.
-                        workers[d].FillCache1(cache.data(), pt, DerivativeFlags::None);
-                        workers[d].FillCache2(cache.data(), pt, pt(pt.size()-1), DerivativeFlags::None);
-
-                        // Evaluate the expansion
-                        output(d,ptInd) = workers[d].Evaluate(cache.data(), coeffs);
-
-                        coeffStartInd += workers[d].NumCoeffs();
+                        coeffStartInd += worker.NumCoeffs();
                     }
                 }
             };
@@ -134,24 +88,14 @@ namespace mpart{
             Kokkos::TeamPolicy<ExecutionSpace> policy;
             policy.set_scratch_size(1,Kokkos::PerTeam(0), Kokkos::PerThread(cacheBytes));
             
-            if(workers.size()==1){
-                const unsigned int threadsPerTeam = std::min<unsigned int>(numPts, policy.team_size_recommended(functor1, Kokkos::ParallelForTag()));
-                const unsigned int numTeams = std::ceil( double(numPts) / threadsPerTeam );
-                
-                policy = Kokkos::TeamPolicy<ExecutionSpace>(numTeams, threadsPerTeam).set_scratch_size(1,Kokkos::PerTeam(0), Kokkos::PerThread(cacheBytes));
+            const unsigned int threadsPerTeam = std::min<unsigned int>(numPts, policy.team_size_recommended(functor, Kokkos::ParallelForTag()));
+            const unsigned int numTeams = std::ceil( double(numPts) / threadsPerTeam );
+            
+            policy = Kokkos::TeamPolicy<ExecutionSpace>(numTeams, threadsPerTeam).set_scratch_size(1,Kokkos::PerTeam(0), Kokkos::PerThread(cacheBytes));
 
-                // Paralel loop over each point computing T(x_1,...,x_D) for that point
-                Kokkos::parallel_for(policy, functor1);
-            }else{
-                const unsigned int threadsPerTeam = std::min<unsigned int>(numPts, policy.team_size_recommended(functor2, Kokkos::ParallelForTag()));
-                const unsigned int numTeams = std::ceil( double(numPts) / threadsPerTeam );
-                
-                policy = Kokkos::TeamPolicy<ExecutionSpace>(numTeams, threadsPerTeam).set_scratch_size(1,Kokkos::PerTeam(0), Kokkos::PerThread(cacheBytes));
-
-                // Paralel loop over each point computing T(x_1,...,x_D) for that point
-                Kokkos::parallel_for(policy, functor2);
-            }
-
+            // Paralel loop over each point computing T(x_1,...,x_D) for that point
+            Kokkos::parallel_for(policy, functor);
+    
             Kokkos::fence();
         }
 
@@ -160,20 +104,15 @@ namespace mpart{
                            Kokkos::View<double**, MemorySpace>            & output) override
         {
             using ExecutionSpace = typename MemoryToExecution<MemorySpace>::Space;
-            assert(workers.size()>0);
-
+            
             const unsigned int numPts = pts.extent(1);
 
             // Figure out how much memory we'll need in the cache
-            unsigned int cacheSize = workers[0].CacheSize();
-            unsigned int maxParams = workers[0].NumCoeffs();
+            unsigned int cacheSize = worker.CacheSize();
+            unsigned int maxParams = worker.NumCoeffs();
 
-            for(unsigned int i=1; i<workers.size(); ++i){
-                cacheSize = std::max(cacheSize, workers[i].CacheSize());
-                maxParams = std::max(maxParams, workers[i].NumCoeffs());
-            }
 
-            auto functor1 = KOKKOS_CLASS_LAMBDA (typename Kokkos::TeamPolicy<ExecutionSpace>::member_type team_member) {
+            auto functor = KOKKOS_CLASS_LAMBDA (typename Kokkos::TeamPolicy<ExecutionSpace>::member_type team_member) {
 
                 unsigned int ptInd = team_member.league_rank () * team_member.team_size () + team_member.team_rank ();
 
@@ -187,91 +126,46 @@ namespace mpart{
                     Kokkos::View<double*,MemorySpace> grad(team_member.thread_scratch(1), maxParams);
 
                     // Fill in entries in the cache that are independent of x_d.  By passing DerivativeFlags::None, we are telling the expansion that no derivatives with wrt x_1,...x_{d-1} will be needed.
-                    workers[0].FillCache1(cache.data(), pt, DerivativeFlags::Parameters);
-                    workers[0].FillCache2(cache.data(), pt, pt(pt.size()-1), DerivativeFlags::Parameters);
+                    worker.FillCache1(cache.data(), pt, DerivativeFlags::Parameters);
+                    worker.FillCache2(cache.data(), pt, pt(pt.size()-1), DerivativeFlags::Parameters);
 
                     unsigned int coeffStartInd = 0;
 
                     for(unsigned int d=0; d<this->outputDim; ++d){
 
                         // Extract the coefficients for this output dimension
-                        auto coeffs = Kokkos::subview(this->savedCoeffs, std::make_pair(coeffStartInd, coeffStartInd+workers[0].NumCoeffs()));
+                        auto coeffs = Kokkos::subview(this->savedCoeffs, std::make_pair(coeffStartInd, coeffStartInd+worker.NumCoeffs()));
                          
                         // Evaluate the expansion
-                        workers[0].CoeffDerivative(cache.data(), coeffs, grad);
+                        worker.CoeffDerivative(cache.data(), coeffs, grad);
 
-                        for(unsigned int i=0; i<workers[0].NumCoeffs(); ++i)
+                        for(unsigned int i=0; i<worker.NumCoeffs(); ++i)
                             output(coeffStartInd + i, ptInd) = sens(d,ptInd) * grad(i);
 
-                        coeffStartInd += workers[0].NumCoeffs();
+                        coeffStartInd += worker.NumCoeffs();
                     }
                 }
             };
 
-            auto functor2 = KOKKOS_CLASS_LAMBDA (typename Kokkos::TeamPolicy<ExecutionSpace>::member_type team_member) {
-
-                unsigned int ptInd = team_member.league_rank () * team_member.team_size () + team_member.team_rank ();
-
-                if(ptInd<numPts){
-
-                    // Create a subview containing only the current point
-                    auto pt = Kokkos::subview(pts, Kokkos::ALL(), ptInd);
-                    
-                    // Get a pointer to the shared memory that Kokkos set up for this team
-                    Kokkos::View<double*,MemorySpace> cache(team_member.thread_scratch(1), cacheSize);
-                    Kokkos::View<double*,MemorySpace> grad(team_member.thread_scratch(1), maxParams);
-
-                    unsigned int coeffStartInd = 0;
-                    
-                    for(unsigned int d=0; d<this->outputDim; ++d){
-
-                        // Extract the coefficients for this output dimension
-                        auto coeffs = Kokkos::subview(this->savedCoeffs, std::make_pair(coeffStartInd, coeffStartInd+workers[d].NumCoeffs()));
-                         
-                        // Fill in entries in the cache that are independent of x_d.  By passing DerivativeFlags::None, we are telling the expansion that no derivatives with wrt x_1,...x_{d-1} will be needed.
-                        workers[d].FillCache1(cache.data(), pt, DerivativeFlags::Parameters);
-                        workers[d].FillCache2(cache.data(), pt, pt(pt.size()-1), DerivativeFlags::Parameters);
-
-                        // Evaluate the expansion
-                        workers[d].CoeffDerivative(cache.data(), coeffs, grad);
-
-                        for(unsigned int i=0; i<workers[d].NumCoeffs(); ++i)
-                            output(coeffStartInd + i, ptInd) = sens(d,ptInd) * grad(i);
-
-                        coeffStartInd += workers[d].NumCoeffs();
-                    }
-                }
-            };
 
             auto cacheBytes = Kokkos::View<double*,MemorySpace>::shmem_size(cacheSize + maxParams);
             Kokkos::TeamPolicy<ExecutionSpace> policy;
             policy.set_scratch_size(1,Kokkos::PerTeam(0), Kokkos::PerThread(cacheBytes));
 
-            if(workers.size()==1){
-                const unsigned int threadsPerTeam = std::min<unsigned int>(numPts, policy.team_size_recommended(functor1, Kokkos::ParallelForTag()));
-                const unsigned int numTeams = std::ceil( double(numPts) / threadsPerTeam );
-                
-                policy = Kokkos::TeamPolicy<ExecutionSpace>(numTeams, threadsPerTeam).set_scratch_size(1,Kokkos::PerTeam(0), Kokkos::PerThread(cacheBytes));
+            const unsigned int threadsPerTeam = std::min<unsigned int>(numPts, policy.team_size_recommended(functor, Kokkos::ParallelForTag()));
+            const unsigned int numTeams = std::ceil( double(numPts) / threadsPerTeam );
+            
+            policy = Kokkos::TeamPolicy<ExecutionSpace>(numTeams, threadsPerTeam).set_scratch_size(1,Kokkos::PerTeam(0), Kokkos::PerThread(cacheBytes));
 
-                // Paralel loop over each point computing T(x_1,...,x_D) for that point
-                Kokkos::parallel_for(policy, functor1);
-
-            }else{
-                const unsigned int threadsPerTeam = std::min<unsigned int>(numPts, policy.team_size_recommended(functor2, Kokkos::ParallelForTag()));
-                const unsigned int numTeams = std::ceil( double(numPts) / threadsPerTeam );
-                
-                policy = Kokkos::TeamPolicy<ExecutionSpace>(numTeams, threadsPerTeam).set_scratch_size(1,Kokkos::PerTeam(0), Kokkos::PerThread(cacheBytes));
-
-                // Paralel loop over each point computing T(x_1,...,x_D) for that point
-                Kokkos::parallel_for(policy, functor2);
-            }
+            // Paralel loop over each point computing T(x_1,...,x_D) for that point
+            Kokkos::parallel_for(policy, functor);
 
             Kokkos::fence();
         }
 
     private:
 
-        Kokkos::vector< MultivariateExpansionWorker<BasisEvaluatorType, MemorySpace> > workers;
+        MultivariateExpansionWorker<BasisEvaluatorType, MemorySpace> worker;
 
     }; // class MultivariateExpansion
 }

--- a/MParT/MultivariateExpansion.h
+++ b/MParT/MultivariateExpansion.h
@@ -37,9 +37,7 @@ namespace mpart{
         {
         };
 
-        virtual ~MultivariateExpansion(){
-            std::cout << "End of destructor..." << std::endl;
-        };
+        virtual ~MultivariateExpansion() = default;
 
 
         virtual void EvaluateImpl(Kokkos::View<const double**, MemorySpace> const& pts,

--- a/MParT/MultivariateExpansion.h
+++ b/MParT/MultivariateExpansion.h
@@ -28,8 +28,9 @@ namespace mpart{
         MultivariateExpansion(unsigned int              outDim, 
                               SetType            const& mset, 
                               BasisEvaluatorType const& basis1d) : ParameterizedFunctionBase<MemorySpace>(mset.Length(), outDim, mset.Size()*outDim)
-        {
+        {   std::cout << "Here 0..." << std::endl;
             workers.push_back( MultivariateExpansionWorker<BasisEvaluatorType, MemorySpace>(mset, basis1d) );
+            std::cout << "Here 1..." << std::endl;
         };
 
         template<typename ExpansionType>
@@ -150,6 +151,8 @@ namespace mpart{
                 // Paralel loop over each point computing T(x_1,...,x_D) for that point
                 Kokkos::parallel_for(policy, functor2);
             }
+
+            Kokkos::fence();
         }
 
         void CoeffGradImpl(Kokkos::View<const double**, MemorySpace> const& pts,  
@@ -262,6 +265,8 @@ namespace mpart{
                 // Paralel loop over each point computing T(x_1,...,x_D) for that point
                 Kokkos::parallel_for(policy, functor2);
             }
+
+            Kokkos::fence();
         }
 
     private:

--- a/src/Initialization.cpp
+++ b/src/Initialization.cpp
@@ -5,7 +5,9 @@ using namespace mpart;
 
 void mpart::Finalize()
 {
+    std::cout << "Before kokkos::finalize..." << std::endl;
     Kokkos::finalize();
+    std::cout << "After kokkos::finalize..." << std::endl;
 }
 
 InitializeStatus& mpart::GetInitializeStatusObject()

--- a/src/Initialization.cpp
+++ b/src/Initialization.cpp
@@ -5,9 +5,7 @@ using namespace mpart;
 
 void mpart::Finalize()
 {
-    std::cout << "Before kokkos::finalize..." << std::endl;
     Kokkos::finalize();
-    std::cout << "After kokkos::finalize..." << std::endl;
 }
 
 InitializeStatus& mpart::GetInitializeStatusObject()

--- a/tests/RunTests.cpp
+++ b/tests/RunTests.cpp
@@ -18,12 +18,12 @@ int main( int argc, char* argv[] ) {
 
   // Now pass the new composite back to Catch2 so it uses that
   session.cli( cli );
-
+  
   // Let Catch2 (using Clara) parse the command line
   int returnCode = session.applyCommandLine( argc, argv );
   if( returnCode != 0 ) // Indicates a command line error
       return returnCode;
 
   session.run();
-
+  std::cout << "Done running session..." << std::endl;
 }

--- a/tests/RunTests.cpp
+++ b/tests/RunTests.cpp
@@ -5,8 +5,6 @@
 int main( int argc, char* argv[] ) {
   mpart::Initialize(argc,argv);
 
-  std::cout << "Kokkos Concurrency = " << Kokkos::DefaultExecutionSpace::concurrency() << std::endl;
-
   Catch::Session session; // There must be exactly one instance
 
   int cores = 0; // Some user variable you want to be able to set
@@ -25,5 +23,4 @@ int main( int argc, char* argv[] ) {
       return returnCode;
 
   session.run();
-  std::cout << "Done running session..." << std::endl;
 }

--- a/tests/Test_MultivariateExpansion.cpp
+++ b/tests/Test_MultivariateExpansion.cpp
@@ -21,43 +21,43 @@ TEST_CASE( "Testing multivariate expansion", "[MultivariateExpansion]") {
 
     ProbabilistHermite basis;
     MultivariateExpansion<ProbabilistHermite,Kokkos::HostSpace> func(outDim, mset, basis);
-    CHECK(func.numCoeffs == mset.Size()*outDim);
+    CHECK(func.numCoeffs == (mset.Size()*outDim));
 
-    Kokkos::View<double*,Kokkos::HostSpace> coeffs("coefficients", func.numCoeffs);
-    for(unsigned int i=0; i<func.numCoeffs; ++i)
-        coeffs(i) = 0.01;
+    // Kokkos::View<double*,Kokkos::HostSpace> coeffs("coefficients", func.numCoeffs);
+    // for(unsigned int i=0; i<func.numCoeffs; ++i)
+    //     coeffs(i) = 0.01;
         
-    func.SetCoeffs(coeffs);
+    // func.SetCoeffs(coeffs);
 
     
-    Kokkos::View<double**,Kokkos::HostSpace> pts("Points",inDim,numPts);
-    for(unsigned int ptInd=0; ptInd<numPts; ++ptInd){
-        for(unsigned int d=0; d<inDim; ++d){
-            pts(d,ptInd) = d+1 + double(ptInd+1)/numPts;
-        }
-    }
+    // Kokkos::View<double**,Kokkos::HostSpace> pts("Points",inDim,numPts);
+    // for(unsigned int ptInd=0; ptInd<numPts; ++ptInd){
+    //     for(unsigned int d=0; d<inDim; ++d){
+    //         pts(d,ptInd) = d+1 + double(ptInd+1)/numPts;
+    //     }
+    // }
 
-    SECTION("Evaluate"){
-        Kokkos::View<double**,Kokkos::HostSpace> evals = func.Evaluate(pts);
+    // SECTION("Evaluate"){
+    //     Kokkos::View<double**,Kokkos::HostSpace> evals = func.Evaluate(pts);
         
-        for(unsigned int ptInd=0; ptInd<numPts; ++ptInd){
-            for(unsigned int d=0; d<outDim; ++d){
+    //     for(unsigned int ptInd=0; ptInd<numPts; ++ptInd){
+    //         for(unsigned int d=0; d<outDim; ++d){
 
-                double val = 0; 
-                for(unsigned int term=0; term<mset.Size(); ++term){
-                    auto multi = mset.IndexToMulti(term);
-                    double termVal = 1.0;
+    //             double val = 0; 
+    //             for(unsigned int term=0; term<mset.Size(); ++term){
+    //                 auto multi = mset.IndexToMulti(term);
+    //                 double termVal = 1.0;
 
-                    for(unsigned int i=0; i<inDim; ++i)
-                        termVal *= basis.Evaluate(multi.at(i), pts(i,ptInd));
+    //                 for(unsigned int i=0; i<inDim; ++i)
+    //                     termVal *= basis.Evaluate(multi.at(i), pts(i,ptInd));
 
-                    val += coeffs(term + d*mset.Size()) * termVal;
-                }
+    //                 val += coeffs(term + d*mset.Size()) * termVal;
+    //             }
                 
-                CHECK(evals(d,ptInd) == Approx(val).epsilon(1e-12));
-            }
-        }
-    }
+    //             CHECK(evals(d,ptInd) == Approx(val).epsilon(1e-12));
+    //         }
+    //     }
+    // }
 
     // SECTION("Coefficent Gradient"){
     //     Kokkos::View<double**,Kokkos::HostSpace> sens("Sensitivity", outDim, numPts);

--- a/tests/Test_MultivariateExpansion.cpp
+++ b/tests/Test_MultivariateExpansion.cpp
@@ -20,8 +20,11 @@ TEST_CASE( "Testing multivariate expansion", "[MultivariateExpansion]") {
     FixedMultiIndexSet<Kokkos::HostSpace> mset(inDim, maxDegree);
 
     ProbabilistHermite basis;
+    {
     MultivariateExpansion<ProbabilistHermite,Kokkos::HostSpace> func(outDim, mset, basis);
     std::cout << "Done constructing..." << std::endl;
+    }
+    std::cout << "done destructing..." << std::endl;
     //CHECK(func.numCoeffs == (mset.Size()*outDim));
 
     // Kokkos::View<double*,Kokkos::HostSpace> coeffs("coefficients", func.numCoeffs);

--- a/tests/Test_MultivariateExpansion.cpp
+++ b/tests/Test_MultivariateExpansion.cpp
@@ -21,6 +21,7 @@ TEST_CASE( "Testing multivariate expansion", "[MultivariateExpansion]") {
 
     ProbabilistHermite basis;
     MultivariateExpansion<ProbabilistHermite,Kokkos::HostSpace> func(outDim, mset, basis);
+    std::cout << "Done constructing..." << std::endl;
     //CHECK(func.numCoeffs == (mset.Size()*outDim));
 
     // Kokkos::View<double*,Kokkos::HostSpace> coeffs("coefficients", func.numCoeffs);

--- a/tests/Test_MultivariateExpansion.cpp
+++ b/tests/Test_MultivariateExpansion.cpp
@@ -20,7 +20,7 @@ TEST_CASE( "Testing multivariate expansion", "[MultivariateExpansion]") {
     FixedMultiIndexSet<Kokkos::HostSpace> mset(inDim, maxDegree);
 
     ProbabilistHermite basis;
-    //MultivariateExpansion<ProbabilistHermite,Kokkos::HostSpace> func(outDim, mset, basis);
+    MultivariateExpansion<ProbabilistHermite,Kokkos::HostSpace> func(outDim, mset, basis);
     //CHECK(func.numCoeffs == (mset.Size()*outDim));
 
     // Kokkos::View<double*,Kokkos::HostSpace> coeffs("coefficients", func.numCoeffs);

--- a/tests/Test_MultivariateExpansion.cpp
+++ b/tests/Test_MultivariateExpansion.cpp
@@ -20,8 +20,8 @@ TEST_CASE( "Testing multivariate expansion", "[MultivariateExpansion]") {
     FixedMultiIndexSet<Kokkos::HostSpace> mset(inDim, maxDegree);
 
     ProbabilistHermite basis;
-    MultivariateExpansion<ProbabilistHermite,Kokkos::HostSpace> func(outDim, mset, basis);
-    CHECK(func.numCoeffs == (mset.Size()*outDim));
+    //MultivariateExpansion<ProbabilistHermite,Kokkos::HostSpace> func(outDim, mset, basis);
+    //CHECK(func.numCoeffs == (mset.Size()*outDim));
 
     // Kokkos::View<double*,Kokkos::HostSpace> coeffs("coefficients", func.numCoeffs);
     // for(unsigned int i=0; i<func.numCoeffs; ++i)

--- a/tests/Test_MultivariateExpansion.cpp
+++ b/tests/Test_MultivariateExpansion.cpp
@@ -59,41 +59,41 @@ TEST_CASE( "Testing multivariate expansion", "[MultivariateExpansion]") {
         }
     }
 
-    SECTION("Coefficent Gradient"){
-        Kokkos::View<double**,Kokkos::HostSpace> sens("Sensitivity", outDim, numPts);
-        Kokkos::View<double**,Kokkos::HostSpace> grads;
+    // SECTION("Coefficent Gradient"){
+    //     Kokkos::View<double**,Kokkos::HostSpace> sens("Sensitivity", outDim, numPts);
+    //     Kokkos::View<double**,Kokkos::HostSpace> grads;
 
-        for(unsigned int d=0; d<outDim; ++d){
+    //     for(unsigned int d=0; d<outDim; ++d){
             
-            // Set the sensitivity wrt this output to 1
-            for(unsigned int ptInd=0; ptInd<numPts; ++ptInd)
-                sens(d,ptInd) = 1.0;
+    //         // Set the sensitivity wrt this output to 1
+    //         for(unsigned int ptInd=0; ptInd<numPts; ++ptInd)
+    //             sens(d,ptInd) = 1.0;
 
-            // Evaluate the gradient
-            grads = func.CoeffGrad(pts,sens);
+    //         // Evaluate the gradient
+    //         grads = func.CoeffGrad(pts,sens);
 
-            REQUIRE(grads.extent(0)==func.numCoeffs);
-            REQUIRE(grads.extent(1)==numPts);
+    //         REQUIRE(grads.extent(0)==func.numCoeffs);
+    //         REQUIRE(grads.extent(1)==numPts);
 
-            // Check the solution
-            for(unsigned int ptInd=0; ptInd<numPts; ++ptInd){
+    //         // Check the solution
+    //         for(unsigned int ptInd=0; ptInd<numPts; ++ptInd){
 
-                for(unsigned int term=0; term<mset.Size(); ++term){
-                    auto multi = mset.IndexToMulti(term);
-                    double termVal = 1.0;
+    //             for(unsigned int term=0; term<mset.Size(); ++term){
+    //                 auto multi = mset.IndexToMulti(term);
+    //                 double termVal = 1.0;
 
-                    for(unsigned int i=0; i<inDim; ++i)
-                        termVal *= basis.Evaluate(multi.at(i), pts(i,ptInd));
+    //                 for(unsigned int i=0; i<inDim; ++i)
+    //                     termVal *= basis.Evaluate(multi.at(i), pts(i,ptInd));
         
-                    CHECK(grads(term+d*mset.Size(),ptInd) == Approx(termVal).epsilon(1e-12));
-                }
-            }
+    //                 CHECK(grads(term+d*mset.Size(),ptInd) == Approx(termVal).epsilon(1e-12));
+    //             }
+    //         }
             
-            // Reset this row to 0
-            for(unsigned int ptInd=0; ptInd<numPts; ++ptInd)
-                sens(d,ptInd) = 0.0;
+    //         // Reset this row to 0
+    //         for(unsigned int ptInd=0; ptInd<numPts; ++ptInd)
+    //             sens(d,ptInd) = 0.0;
 
-        }
+    //     }
         
-    }
+    // }
 }

--- a/tests/Test_MultivariateExpansion.cpp
+++ b/tests/Test_MultivariateExpansion.cpp
@@ -20,84 +20,80 @@ TEST_CASE( "Testing multivariate expansion", "[MultivariateExpansion]") {
     FixedMultiIndexSet<Kokkos::HostSpace> mset(inDim, maxDegree);
 
     ProbabilistHermite basis;
-    {
     MultivariateExpansion<ProbabilistHermite,Kokkos::HostSpace> func(outDim, mset, basis);
-    std::cout << "Done constructing..." << std::endl;
-    }
-    std::cout << "done destructing..." << std::endl;
-    //CHECK(func.numCoeffs == (mset.Size()*outDim));
+    CHECK(func.numCoeffs == (mset.Size()*outDim));
 
-    // Kokkos::View<double*,Kokkos::HostSpace> coeffs("coefficients", func.numCoeffs);
-    // for(unsigned int i=0; i<func.numCoeffs; ++i)
-    //     coeffs(i) = 0.01;
+    Kokkos::View<double*,Kokkos::HostSpace> coeffs("coefficients", func.numCoeffs);
+    for(unsigned int i=0; i<func.numCoeffs; ++i)
+        coeffs(i) = 0.01;
         
-    // func.SetCoeffs(coeffs);
+    func.SetCoeffs(coeffs);
 
     
-    // Kokkos::View<double**,Kokkos::HostSpace> pts("Points",inDim,numPts);
-    // for(unsigned int ptInd=0; ptInd<numPts; ++ptInd){
-    //     for(unsigned int d=0; d<inDim; ++d){
-    //         pts(d,ptInd) = d+1 + double(ptInd+1)/numPts;
-    //     }
-    // }
+    Kokkos::View<double**,Kokkos::HostSpace> pts("Points",inDim,numPts);
+    for(unsigned int ptInd=0; ptInd<numPts; ++ptInd){
+        for(unsigned int d=0; d<inDim; ++d){
+            pts(d,ptInd) = d+1 + double(ptInd+1)/numPts;
+        }
+    }
 
-    // SECTION("Evaluate"){
-    //     Kokkos::View<double**,Kokkos::HostSpace> evals = func.Evaluate(pts);
+    SECTION("Evaluate"){
+        Kokkos::View<double**,Kokkos::HostSpace> evals = func.Evaluate(pts);
         
-    //     for(unsigned int ptInd=0; ptInd<numPts; ++ptInd){
-    //         for(unsigned int d=0; d<outDim; ++d){
+        for(unsigned int ptInd=0; ptInd<numPts; ++ptInd){
+            for(unsigned int d=0; d<outDim; ++d){
 
-    //             double val = 0; 
-    //             for(unsigned int term=0; term<mset.Size(); ++term){
-    //                 auto multi = mset.IndexToMulti(term);
-    //                 double termVal = 1.0;
+                double val = 0; 
+                for(unsigned int term=0; term<mset.Size(); ++term){
+                    auto multi = mset.IndexToMulti(term);
+                    double termVal = 1.0;
 
-    //                 for(unsigned int i=0; i<inDim; ++i)
-    //                     termVal *= basis.Evaluate(multi.at(i), pts(i,ptInd));
+                    for(unsigned int i=0; i<inDim; ++i)
+                        termVal *= basis.Evaluate(multi.at(i), pts(i,ptInd));
 
-    //                 val += coeffs(term + d*mset.Size()) * termVal;
-    //             }
+                    val += coeffs(term + d*mset.Size()) * termVal;
+                }
                 
-    //             CHECK(evals(d,ptInd) == Approx(val).epsilon(1e-12));
-    //         }
-    //     }
-    // }
+                CHECK(evals(d,ptInd) == Approx(val).epsilon(1e-12));
+            }
+        }
+    }
 
-    // SECTION("Coefficent Gradient"){
-    //     Kokkos::View<double**,Kokkos::HostSpace> sens("Sensitivity", outDim, numPts);
-    //     Kokkos::View<double**,Kokkos::HostSpace> grads;
+    SECTION("Coefficent Gradient"){
+        Kokkos::View<double**,Kokkos::HostSpace> sens("Sensitivity", outDim, numPts);
+        Kokkos::View<double**,Kokkos::HostSpace> grads;
 
-    //     for(unsigned int d=0; d<outDim; ++d){
+        for(unsigned int d=0; d<outDim; ++d){
             
-    //         // Set the sensitivity wrt this output to 1
-    //         for(unsigned int ptInd=0; ptInd<numPts; ++ptInd)
-    //             sens(d,ptInd) = 1.0;
+            // Set the sensitivity wrt this output to 1
+            for(unsigned int ptInd=0; ptInd<numPts; ++ptInd)
+                sens(d,ptInd) = 1.0;
 
-    //         // Evaluate the gradient
-    //         grads = func.CoeffGrad(pts,sens);
+            // Evaluate the gradient
+            grads = func.CoeffGrad(pts,sens);
 
-    //         REQUIRE(grads.extent(0)==func.numCoeffs);
-    //         REQUIRE(grads.extent(1)==numPts);
+            REQUIRE(grads.extent(0)==func.numCoeffs);
+            REQUIRE(grads.extent(1)==numPts);
 
-    //         // Check the solution
-    //         for(unsigned int ptInd=0; ptInd<numPts; ++ptInd){
+            // Check the solution
+            for(unsigned int ptInd=0; ptInd<numPts; ++ptInd){
 
-    //             for(unsigned int term=0; term<mset.Size(); ++term){
-    //                 auto multi = mset.IndexToMulti(term);
-    //                 double termVal = 1.0;
+                for(unsigned int term=0; term<mset.Size(); ++term){
+                    auto multi = mset.IndexToMulti(term);
+                    double termVal = 1.0;
 
-    //                 for(unsigned int i=0; i<inDim; ++i)
-    //                     termVal *= basis.Evaluate(multi.at(i), pts(i,ptInd));
+                    for(unsigned int i=0; i<inDim; ++i)
+                        termVal *= basis.Evaluate(multi.at(i), pts(i,ptInd));
         
-    //                 CHECK(grads(term+d*mset.Size(),ptInd) == Approx(termVal).epsilon(1e-12));
-    //             }
-    //         }
+                    CHECK(grads(term+d*mset.Size(),ptInd) == Approx(termVal).epsilon(1e-12));
+                }
+            }
             
-    //         // Reset this row to 0
-    //         for(unsigned int ptInd=0; ptInd<numPts; ++ptInd)
-    //             sens(d,ptInd) = 0.0;
+            // Reset this row to 0
+            for(unsigned int ptInd=0; ptInd<numPts; ++ptInd)
+                sens(d,ptInd) = 0.0;
 
-    //     }
+        }
         
-    // }
+    }
 }


### PR DESCRIPTION
Closes #130 

First argument to `MParT::Initialize` is now accepted by reference, which allows Kokkos to remove arguments from the command line inputs and allows Catch2 to function properly.