### PR TITLE
Converted entire map stack to use Strided layouts.

### DIFF
--- a/MParT/ConditionalMapBase.h
+++ b/MParT/ConditionalMapBase.h
@@ -62,7 +62,7 @@ namespace mpart {
         virtual Eigen::VectorXd LogDeterminant(Eigen::Ref<const Eigen::RowMatrixXd> const& pts);
 
         virtual void LogDeterminantImpl(StridedMatrix<const double, MemorySpace> const& pts,
-                                        Kokkos::View<double*, MemorySpace>              output) = 0;
+                                        StridedVector<double, MemorySpace>              output) = 0;
 
 
         /** Returns the value of \f$x_2\f$ given \f$x_1\f$ and \f$r\f$.   Note that the \f$x1\f$ view may contain more

--- a/MParT/ConditionalMapBase.h
+++ b/MParT/ConditionalMapBase.h
@@ -57,26 +57,26 @@ namespace mpart {
 
         @param pts The points where we want to evaluate the log determinant.
         */
-        virtual Kokkos::View<double*, MemorySpace> LogDeterminant(Kokkos::View<const double**, MemorySpace> const& pts);
+        virtual Kokkos::View<double*, MemorySpace> LogDeterminant(StridedMatrix<const double, MemorySpace> const& pts);
 
         virtual Eigen::VectorXd LogDeterminant(Eigen::Ref<const Eigen::RowMatrixXd> const& pts);
 
-        virtual void LogDeterminantImpl(Kokkos::View<const double**, MemorySpace> const& pts,
-                                        Kokkos::View<double*, MemorySpace>             &output) = 0;
+        virtual void LogDeterminantImpl(StridedMatrix<const double, MemorySpace> const& pts,
+                                        Kokkos::View<double*, MemorySpace>              output) = 0;
 
 
         /** Returns the value of \f$x_2\f$ given \f$x_1\f$ and \f$r\f$.   Note that the \f$x1\f$ view may contain more
             than \f$N\f$ rows, but only the first \f$N\f$ will be used in this function.
         */
-        virtual Kokkos::View<double**, MemorySpace> Inverse(Kokkos::View<const double**, MemorySpace> const& x1,
-                                                            Kokkos::View<const double**, MemorySpace> const& r);
+        virtual StridedMatrix<double, MemorySpace> Inverse(StridedMatrix<const double, MemorySpace> const& x1,
+                                                           StridedMatrix<const double, MemorySpace> const& r);
 
         virtual Eigen::RowMatrixXd Inverse(Eigen::Ref<const Eigen::RowMatrixXd> const& x1, 
                                            Eigen::Ref<const Eigen::RowMatrixXd> const& r);
 
-        virtual void InverseImpl(Kokkos::View<const double**, MemorySpace> const& x1,
-                                 Kokkos::View<const double**, MemorySpace> const& r,
-                                 Kokkos::View<double**, MemorySpace>            & output) = 0;
+        virtual void InverseImpl(StridedMatrix<const double, MemorySpace> const& x1,
+                                 StridedMatrix<const double, MemorySpace> const& r,
+                                 StridedMatrix<double, MemorySpace>              output) = 0;
         /**
            @brief Computes the gradient of the log determinant with respect to the map coefficients.
            @details For a map \f$T(x; w) : \mathbb{R}^N \rightarrow \mathbb{R}^M\f$ parameterized by coefficients \f$w\in\mathbb{R}^K\f$,
@@ -88,12 +88,12 @@ namespace mpart {
            @param pts A collection of points where we want to evaluate the gradient.  Each column corresponds to a point.
            @return A matrix containing the coefficient gradient at each input point.  The \f$i^{th}\f$ column  contains \f$\nabla_w \det{\nabla_x T(x_i; w)}\f$.
          */
-        virtual Kokkos::View<double**, MemorySpace> LogDeterminantCoeffGrad(Kokkos::View<const double**, MemorySpace> const& pts);
+        virtual StridedMatrix<double, MemorySpace> LogDeterminantCoeffGrad(StridedMatrix<const double, MemorySpace> const& pts);
 
         virtual Eigen::RowMatrixXd LogDeterminantCoeffGrad(Eigen::Ref<const Eigen::RowMatrixXd> const& pts);
 
-        virtual void LogDeterminantCoeffGradImpl(Kokkos::View<const double**, MemorySpace> const& pts, 
-                                                 Kokkos::View<double**, MemorySpace> &output) = 0;
+        virtual void LogDeterminantCoeffGradImpl(StridedMatrix<const double, MemorySpace> const& pts, 
+                                                 StridedMatrix<double, MemorySpace>              output) = 0;
 
 
     }; // class ConditionalMapBase<MemorySpace>

--- a/MParT/MonotoneComponent.h
+++ b/MParT/MonotoneComponent.h
@@ -62,24 +62,24 @@ public:
     virtual std::shared_ptr<ParameterizedFunctionBase<MemorySpace>> GetBaseFunction() override{return std::make_shared<MultivariateExpansion<typename ExpansionType::BasisType, typename ExpansionType::KokkosSpace>>(1,_expansion);};
 
     /** Override the ConditionalMapBase Evaluate function. */
-    virtual void EvaluateImpl(Kokkos::View<const double**, MemorySpace> const& pts,
-                              Kokkos::View<double**, MemorySpace>      & output) override
+    virtual void EvaluateImpl(StridedMatrix<const double, MemorySpace> const& pts,
+                              StridedMatrix<double, MemorySpace>              output) override
     {
         Kokkos::View<double*,MemorySpace> outputSlice = Kokkos::subview(output, 0, Kokkos::ALL());
         EvaluateImpl(pts, ConditionalMapBase<MemorySpace>::savedCoeffs, outputSlice);
     }
 
-    virtual void InverseImpl(Kokkos::View<const double**, MemorySpace> const& x1,
-                             Kokkos::View<const double**, MemorySpace> const& r,
-                             Kokkos::View<double**, MemorySpace>      & output) override
+    virtual void InverseImpl(StridedMatrix<const double, MemorySpace> const& x1,
+                             StridedMatrix<const double, MemorySpace> const& r,
+                             StridedMatrix<double, MemorySpace>              output) override
     {
         Kokkos::View<const double*,MemorySpace> rSlice = Kokkos::subview(r,0,Kokkos::ALL());
         Kokkos::View<double*,MemorySpace> outputSlice = Kokkos::subview(output, 0, Kokkos::ALL());
         InverseImpl(x1, rSlice, ConditionalMapBase<MemorySpace>::savedCoeffs, outputSlice);
     }
 
-    virtual void LogDeterminantImpl(Kokkos::View<const double**, MemorySpace> const& pts,
-                                    Kokkos::View<double*, MemorySpace>             &output) override
+    virtual void LogDeterminantImpl(StridedMatrix<const double, MemorySpace> const& pts,
+                                    Kokkos::View<double*, MemorySpace>              output) override
     {
         // First, get the diagonal derivative
         if(_useContDeriv){
@@ -100,9 +100,9 @@ public:
         });
     }
 
-    virtual void CoeffGradImpl(Kokkos::View<const double**, MemorySpace> const& pts,  
-                               Kokkos::View<const double**, MemorySpace> const& sens,
-                               Kokkos::View<double**, MemorySpace>            & output) override
+    virtual void CoeffGradImpl(StridedMatrix<const double, MemorySpace> const& pts,  
+                               StridedMatrix<const double, MemorySpace> const& sens,
+                               StridedMatrix<double, MemorySpace>              output) override
     {
         assert(sens.extent(0)==this->outputDim);
         assert(sens.extent(1)==pts.extent(1));
@@ -123,8 +123,8 @@ public:
     }
 
 
-    virtual void LogDeterminantCoeffGradImpl(Kokkos::View<const double**, MemorySpace> const& pts, 
-                                             Kokkos::View<double**, MemorySpace> &output) override
+    virtual void LogDeterminantCoeffGradImpl(StridedMatrix<const double, MemorySpace> const& pts, 
+                                             StridedMatrix<double, MemorySpace>              output) override
     {   
         Kokkos::View<double*,MemorySpace> derivs("Diagonal Derivative", pts.extent(1));
 
@@ -548,10 +548,10 @@ public:
         @see CoeffGradient
     */
     template<typename ExecutionSpace=typename MemoryToExecution<MemorySpace>::Space>
-    void CoeffJacobian(Kokkos::View<const double**,MemorySpace> const& pts,
-                       Kokkos::View<const double*,MemorySpace>  const& coeffs,
-                       Kokkos::View<double*,MemorySpace>       & evaluations,
-                       Kokkos::View<double**,MemorySpace>      & jacobian)
+    void CoeffJacobian(StridedMatrix<const double, MemorySpace>  const& pts,
+                       Kokkos::View<const double*,MemorySpace>   const& coeffs,
+                       Kokkos::View<double*,MemorySpace>                evaluations,
+                       StridedMatrix<double, MemorySpace>               jacobian)
     {
         const unsigned int numPts = pts.extent(1);
         const unsigned int numTerms = coeffs.extent(0);
@@ -606,9 +606,9 @@ public:
     }
 
     template<typename ExecutionSpace=typename MemoryToExecution<MemorySpace>::Space>
-    void ContinuousMixedJacobian(Kokkos::View<const double**,MemorySpace> const& pts,
-                                 Kokkos::View<const double*,MemorySpace>  const& coeffs,
-                                 Kokkos::View<double**,MemorySpace>      & jacobian)
+    void ContinuousMixedJacobian(StridedMatrix<const double, MemorySpace> const& pts,
+                                 Kokkos::View<const double*, MemorySpace> const& coeffs,
+                                 StridedMatrix<double, MemorySpace>              jacobian)
     {
         const unsigned int numPts = pts.extent(1);
         const unsigned int numTerms = coeffs.extent(0);
@@ -655,9 +655,9 @@ public:
     }
 
     template<typename ExecutionSpace=typename MemoryToExecution<MemorySpace>::Space>
-    void DiscreteMixedJacobian(Kokkos::View<const double**,MemorySpace> const& pts,
-                               Kokkos::View<const double*,MemorySpace>  const& coeffs,
-                               Kokkos::View<double**,MemorySpace>      & jacobian)
+    void DiscreteMixedJacobian(StridedMatrix<const double, MemorySpace> const& pts,
+                               Kokkos::View<const double*, MemorySpace> const& coeffs,
+                               StridedMatrix<double, MemorySpace>              jacobian)
     {
         const unsigned int numPts = pts.extent(1);
         const unsigned int numTerms = coeffs.extent(0);

--- a/MParT/MonotoneComponent.h
+++ b/MParT/MonotoneComponent.h
@@ -65,28 +65,28 @@ public:
     virtual void EvaluateImpl(StridedMatrix<const double, MemorySpace> const& pts,
                               StridedMatrix<double, MemorySpace>              output) override
     {
-        Kokkos::View<double*,MemorySpace> outputSlice = Kokkos::subview(output, 0, Kokkos::ALL());
-        EvaluateImpl(pts, ConditionalMapBase<MemorySpace>::savedCoeffs, outputSlice);
+        StridedVector<double,MemorySpace> outputSlice = Kokkos::subview(output, 0, Kokkos::ALL());
+        EvaluateImpl(pts, this->savedCoeffs, outputSlice);
     }
 
     virtual void InverseImpl(StridedMatrix<const double, MemorySpace> const& x1,
                              StridedMatrix<const double, MemorySpace> const& r,
                              StridedMatrix<double, MemorySpace>              output) override
     {
-        Kokkos::View<const double*,MemorySpace> rSlice = Kokkos::subview(r,0,Kokkos::ALL());
-        Kokkos::View<double*,MemorySpace> outputSlice = Kokkos::subview(output, 0, Kokkos::ALL());
-        InverseImpl(x1, rSlice, ConditionalMapBase<MemorySpace>::savedCoeffs, outputSlice);
+        auto rSlice = Kokkos::subview(r,0,Kokkos::ALL());
+        auto outputSlice = Kokkos::subview(output, 0, Kokkos::ALL());
+        InverseImpl(x1, rSlice, this->savedCoeffs, outputSlice);
     }
 
     virtual void LogDeterminantImpl(StridedMatrix<const double, MemorySpace> const& pts,
-                                    Kokkos::View<double*, MemorySpace>              output) override
+                                    StridedVector<double,MemorySpace>               output) override
     {
         // First, get the diagonal derivative
         if(_useContDeriv){
-            ContinuousDerivative(pts, ConditionalMapBase<MemorySpace>::savedCoeffs, output);
+            ContinuousDerivative(pts, this->savedCoeffs, output);
         }else{
             Kokkos::View<double*,MemorySpace> evals("Evaluations", pts.extent(1));
-            DiscreteDerivative(pts, ConditionalMapBase<MemorySpace>::savedCoeffs, evals, output);
+            DiscreteDerivative(pts, this->savedCoeffs, evals, output);
         }
 
         // Now take the log
@@ -150,12 +150,12 @@ public:
      * @brief Support calling EvaluateImpl with non-const views.
      */
     template<typename ExecutionSpace=typename MemoryToExecution<MemorySpace>::Space, class... OtherTraits>
-    void EvaluateImpl(Kokkos::View<double**, OtherTraits...> const& pts,
-                      Kokkos::View<double*,MemorySpace>  const& coeffs,
-                      Kokkos::View<double*,MemorySpace>       & output)
+    void EvaluateImpl(Kokkos::View<double**, OtherTraits...>  const& pts,
+                      StridedVector<double,MemorySpace> const& coeffs,
+                      StridedVector<double,MemorySpace>              output)
     {
         Kokkos::View<const double**, OtherTraits...> constPts = pts;
-        Kokkos::View<const double*,MemorySpace> constCoeffs = coeffs;
+        StridedVector<const double, MemorySpace> constCoeffs = coeffs;
 
         EvaluateImpl<ExecutionSpace,OtherTraits...>(constPts,constCoeffs,output);
     }
@@ -168,9 +168,9 @@ public:
      * @param[out] output Kokkos::View<double*> An array containing the evaluattions \f$T(x^{(i)}_1,\ldots,x^{(i)}_D)\f$ for each \f$i\in\{0,\ldots,N\}\f$.
      */
     template<typename ExecutionSpace=typename MemoryToExecution<MemorySpace>::Space, class... OtherTraits>
-    void EvaluateImpl(Kokkos::View<const double**, OtherTraits...> const& pts,
-                      Kokkos::View<const double*,MemorySpace>  const& coeffs,
-                      Kokkos::View<double*,MemorySpace>       & output)
+    void EvaluateImpl(Kokkos::View<const double**, OtherTraits...>   const& pts,
+                      StridedVector<const double,MemorySpace>        const& coeffs,
+                      StridedVector<double,MemorySpace>                     output)
     {
         const unsigned int numPts = pts.extent(1);
 
@@ -205,19 +205,19 @@ public:
     }
 
 
-    template< typename ExecutionSpace=typename MemoryToExecution<MemorySpace>::Space>
-    void InverseImpl(Kokkos::View<double**,MemorySpace>       const& xs,
-                     Kokkos::View<double*,MemorySpace>        const& ys,
-                     Kokkos::View<double*,MemorySpace>        const& coeffs,
-                     Kokkos::View<double*,MemorySpace>             & output,
-                     std::map<std::string, std::string>              options=std::map<std::string,std::string>())
-    {
-        Kokkos::View<const double**,MemorySpace> constXs = xs;
-        Kokkos::View<const double*,MemorySpace> constYs = ys;
-        Kokkos::View<const double*,MemorySpace> constCoeffs = coeffs;
+    // template< typename ExecutionSpace=typename MemoryToExecution<MemorySpace>::Space>
+    // void InverseImpl(StridedMatrix<double, MemorySpace> const& xs,
+    //                  StridedVector<double, MemorySpace> const& ys,
+    //                  StridedVector<double, MemorySpace> const& coeffs,
+    //                  StridedVector<double, MemorySpace>        output,
+    //                  std::map<std::string, std::string>        options=std::map<std::string,std::string>())
+    // {
+    //     StridedMatrix<const double, MemorySpace> constXs = xs;
+    //     StridedVector<const double, MemorySpace> constYs = ys;
+    //     StridedVector<const double, MemorySpace> constCoeffs = coeffs;
 
-        InverseImpl<ExecutionSpace>(constXs,constYs,constCoeffs,output,options);
-    }
+    //     InverseImpl<ExecutionSpace>(constXs,constYs,constCoeffs,output,options);
+    // }
 
     /**
      @brief Evaluates the inverse of the diagonal of the monotone component.
@@ -234,11 +234,11 @@ public:
      @param options A map containing options for the method (e.g., converge criteria, step sizes).   Available options are "Method" (must be "Bracket"), "xtol" (any nonnegative float), and "ytol" (any nonnegative float).
      */
     template<typename ExecutionSpace=typename MemoryToExecution<MemorySpace>::Space>
-    void InverseImpl(Kokkos::View<const double**,MemorySpace>       const& xs,
-                 Kokkos::View<const double*,MemorySpace>        const& ys,
-                 Kokkos::View<const double*,MemorySpace>        const& coeffs,
-                 Kokkos::View<double*,MemorySpace>             & output,
-                 std::map<std::string, std::string>              options=std::map<std::string,std::string>())
+    void InverseImpl(StridedMatrix<const double, MemorySpace> const& xs,
+                     StridedVector<const double, MemorySpace> const& ys,
+                     StridedVector<const double, MemorySpace> const& coeffs,
+                     StridedVector<double, MemorySpace>              output,
+                 std::map<std::string, std::string>                  options=std::map<std::string,std::string>())
     {
         // Extract the method from the options map
         std::string method;
@@ -343,8 +343,8 @@ public:
         @see DiscreteDerivative
      */
     template<typename ExecutionSpace=typename MemoryToExecution<MemorySpace>::Space>
-    Kokkos::View<double*,MemorySpace>  ContinuousDerivative(Kokkos::View<const double**,MemorySpace> const& pts,
-                                                            Kokkos::View<const double*,MemorySpace>  const& coeffs)
+    Kokkos::View<double*,MemorySpace>  ContinuousDerivative(StridedMatrix<const double, MemorySpace> const& pts,
+                                                            StridedVector<const double, MemorySpace> const& coeffs)
     {
         const unsigned int numPts = pts.extent(1);
         Kokkos::View<double*,MemorySpace> derivs("Monotone Component Derivatives", numPts);
@@ -353,14 +353,14 @@ public:
 
         return derivs;
     }
-    template<typename ExecutionSpace=typename MemoryToExecution<MemorySpace>::Space>
-    Kokkos::View<double*,MemorySpace>  ContinuousDerivative(Kokkos::View<double**,MemorySpace> const& pts,
-                                                            Kokkos::View<double*,MemorySpace>  const& coeffs)
-    {
-        Kokkos::View<const double**, MemorySpace> pts2 = pts;
-        Kokkos::View<const double*, MemorySpace> coeffs2 = coeffs;
-        return ContinuousDerivative<ExecutionSpace>(pts2,coeffs2);
-    }
+    // template<typename ExecutionSpace=typename MemoryToExecution<MemorySpace>::Space>
+    // Kokkos::View<double*,MemorySpace>  ContinuousDerivative(StridedMatrix<double, MemorySpace> const& pts,
+    //                                                         StridedVector<double, MemorySpace> const& coeffs)
+    // {
+    //     StridedMatrix<const double, MemorySpace> pts2 = pts;
+    //     StridedVector<const double, MemorySpace> coeffs2 = coeffs;
+    //     return ContinuousDerivative<ExecutionSpace>(pts2,coeffs2);
+    // }
     
 
 
@@ -375,9 +375,9 @@ public:
         @see DiscreteDerivative
      */
     template<typename ExecutionSpace=typename MemoryToExecution<MemorySpace>::Space>
-    void ContinuousDerivative(Kokkos::View<const double**,MemorySpace> const& pts,
-                              Kokkos::View<const double*,MemorySpace>  const& coeffs,
-                              Kokkos::View<double*,MemorySpace>       & derivs)
+    void ContinuousDerivative(StridedMatrix<const double, MemorySpace> const& pts,
+                              StridedVector<const double, MemorySpace> const& coeffs,
+                              StridedVector<double, MemorySpace>              derivs)
     {
         const unsigned int numPts = pts.extent(1);
         const unsigned int dim = pts.extent(0);
@@ -415,15 +415,15 @@ public:
         });
     }
 
-    template<typename ExecutionSpace=typename MemoryToExecution<MemorySpace>::Space>
-    void ContinuousDerivative(Kokkos::View<double**,MemorySpace> const& pts,
-                              Kokkos::View<double*,MemorySpace>  const& coeffs,
-                              Kokkos::View<double*,MemorySpace>       & derivs)
-    {
-        Kokkos::View<const double**, MemorySpace> pts2 = pts;
-        Kokkos::View<const double*, MemorySpace> coeffs2 = coeffs;
-        ContinuousDerivative<ExecutionSpace>(pts2,coeffs2, derivs);
-    }
+    // template<typename ExecutionSpace=typename MemoryToExecution<MemorySpace>::Space>
+    // void ContinuousDerivative(StridedMatrix<double, MemorySpace> const& pts,
+    //                           StridedVector<double, MemorySpace> const& coeffs,
+    //                           StridedVector<double, MemorySpace>        derivs)
+    // {
+    //     StridedMatrix<const double, MemorySpace> pts2 = pts;
+    //     StridedVector<const double, MemorySpace> coeffs2 = coeffs;
+    //     ContinuousDerivative<ExecutionSpace>(pts2,coeffs2, derivs);
+    // }
 
     /**
     @brief Approximates the "discrete derivative" of the quadrature-based approximation \f$\tilde{T}\f$.
@@ -435,8 +435,8 @@ public:
         @see ContinuousDerivative
     */
     template<typename ExecutionSpace=typename MemoryToExecution<MemorySpace>::Space>
-    Kokkos::View<double*, MemorySpace>  DiscreteDerivative(Kokkos::View<const double**,MemorySpace> const& pts,
-                                                           Kokkos::View<const double*,MemorySpace>  const& coeffs)
+    Kokkos::View<double*, MemorySpace>  DiscreteDerivative(StridedMatrix<const double, MemorySpace> const& pts,
+                                                           StridedVector<const double, MemorySpace> const& coeffs)
     {
         const unsigned int numPts = pts.extent(1);
         Kokkos::View<double*,MemorySpace> evals("Component Evaluations", numPts);
@@ -447,14 +447,14 @@ public:
         return derivs;
     }
 
-    template<typename ExecutionSpace=typename MemoryToExecution<MemorySpace>::Space>
-    Kokkos::View<double*, MemorySpace>  DiscreteDerivative(Kokkos::View<double**,MemorySpace> const& pts,
-                                                           Kokkos::View<double*,MemorySpace>  const& coeffs)
-    {
-        Kokkos::View<const double**, MemorySpace> pts2 = pts;
-        Kokkos::View<const double*, MemorySpace> coeffs2 = coeffs;
-        return DiscreteDerivative<ExecutionSpace>(pts2,coeffs2);
-    }
+    // template<typename ExecutionSpace=typename MemoryToExecution<MemorySpace>::Space>
+    // Kokkos::View<double*, MemorySpace>  DiscreteDerivative(StridedMatrix<double, MemorySpace> const& pts,
+    //                                                        StridedVector<double, MemorySpace>  const& coeffs)
+    // {
+    //     StridedMatrix<const double, MemorySpace> pts2 = pts;
+    //     StridedVector<const double, MemorySpace> coeffs2 = coeffs;
+    //     return DiscreteDerivative<ExecutionSpace>(pts2,coeffs2);
+    // }
 
 
     /**
@@ -468,10 +468,10 @@ public:
         @see ContinuousDerivative
      */
     template<typename ExecutionSpace=typename MemoryToExecution<MemorySpace>::Space>
-    void  DiscreteDerivative(Kokkos::View<const double**,MemorySpace> const& pts,
-                             Kokkos::View<const double*,MemorySpace>  const& coeffs,
-                             Kokkos::View<double*,MemorySpace>       & evals,
-                             Kokkos::View<double*,MemorySpace>       & derivs)
+    void  DiscreteDerivative(StridedMatrix<const double, MemorySpace> const& pts,
+                             StridedVector<const double, MemorySpace> const& coeffs,
+                             StridedVector<double, MemorySpace>              evals,
+                             StridedVector<double, MemorySpace>              derivs)
     {
         const unsigned int numPts = pts.extent(1);
         const unsigned int numTerms = coeffs.extent(0);
@@ -522,16 +522,16 @@ public:
         });
     }
 
-    template<typename ExecutionSpace=typename MemoryToExecution<MemorySpace>::Space>
-    void  DiscreteDerivative(Kokkos::View<double**,MemorySpace> const& pts,
-                             Kokkos::View<double*,MemorySpace>  const& coeffs,
-                             Kokkos::View<double*,MemorySpace>       & evals,
-                             Kokkos::View<double*,MemorySpace>       & derivs)
-    {
-        Kokkos::View<const double**, MemorySpace> pts2 = pts;
-        Kokkos::View<const double*, MemorySpace> coeffs2 = coeffs;
-        DiscreteDerivative(pts2, coeffs2, evals, derivs);
-    }
+    // template<typename ExecutionSpace=typename MemoryToExecution<MemorySpace>::Space>
+    // void  DiscreteDerivative(StridedMatrix<double, MemorySpace> const& pts,
+    //                          StridedVector<double, MemorySpace> const& coeffs,
+    //                          StridedVector<double, MemorySpace>        evals,
+    //                          StridedVector<double, MemorySpace>        derivs)
+    // {
+    //     StridedMatrix<const double, MemorySpace> pts2 = pts;
+    //     StridedVector<const double, MemorySpace> coeffs2 = coeffs;
+    //     DiscreteDerivative(pts2, coeffs2, evals, derivs);
+    // }
 
     /** @brief Returns the gradient of the map with respect to the parameters \f$\mathbf{w}\f$ at multiple points.
 
@@ -549,8 +549,8 @@ public:
     */
     template<typename ExecutionSpace=typename MemoryToExecution<MemorySpace>::Space>
     void CoeffJacobian(StridedMatrix<const double, MemorySpace>  const& pts,
-                       Kokkos::View<const double*,MemorySpace>   const& coeffs,
-                       Kokkos::View<double*,MemorySpace>                evaluations,
+                       StridedVector<const double, MemorySpace>  const& coeffs,
+                       StridedVector<double, MemorySpace>               evaluations,
                        StridedMatrix<double, MemorySpace>               jacobian)
     {
         const unsigned int numPts = pts.extent(1);
@@ -607,7 +607,7 @@ public:
 
     template<typename ExecutionSpace=typename MemoryToExecution<MemorySpace>::Space>
     void ContinuousMixedJacobian(StridedMatrix<const double, MemorySpace> const& pts,
-                                 Kokkos::View<const double*, MemorySpace> const& coeffs,
+                                 StridedVector<const double, MemorySpace> const& coeffs,
                                  StridedMatrix<double, MemorySpace>              jacobian)
     {
         const unsigned int numPts = pts.extent(1);
@@ -656,7 +656,7 @@ public:
 
     template<typename ExecutionSpace=typename MemoryToExecution<MemorySpace>::Space>
     void DiscreteMixedJacobian(StridedMatrix<const double, MemorySpace> const& pts,
-                               Kokkos::View<const double*, MemorySpace> const& coeffs,
+                               StridedVector<const double, MemorySpace> const& coeffs,
                                StridedMatrix<double, MemorySpace>              jacobian)
     {
         const unsigned int numPts = pts.extent(1);

--- a/MParT/MultivariateExpansion.h
+++ b/MParT/MultivariateExpansion.h
@@ -40,8 +40,8 @@ namespace mpart{
         virtual ~MultivariateExpansion() = default;
 
 
-        virtual void EvaluateImpl(Kokkos::View<const double**, MemorySpace> const& pts,
-                                  Kokkos::View<double**, MemorySpace>            & output) override
+        virtual void EvaluateImpl(StridedMatrix<const double, MemorySpace> const& pts,
+                                  StridedMatrix<double, MemorySpace>              output) override
         {
             using ExecutionSpace = typename MemoryToExecution<MemorySpace>::Space;
             
@@ -97,9 +97,9 @@ namespace mpart{
             Kokkos::fence();
         }
 
-        void CoeffGradImpl(Kokkos::View<const double**, MemorySpace> const& pts,  
-                           Kokkos::View<const double**, MemorySpace> const& sens,
-                           Kokkos::View<double**, MemorySpace>            & output) override
+        void CoeffGradImpl(StridedMatrix<const double, MemorySpace> const& pts,  
+                           StridedMatrix<const double, MemorySpace> const& sens,
+                           StridedMatrix<double, MemorySpace>              output) override
         {
             using ExecutionSpace = typename MemoryToExecution<MemorySpace>::Space;
             

--- a/MParT/ParameterizedFunctionBase.h
+++ b/MParT/ParameterizedFunctionBase.h
@@ -53,12 +53,12 @@ namespace mpart {
 
         
 
-        virtual Kokkos::View<double**, MemorySpace> Evaluate(Kokkos::View<const double**, MemorySpace> const& pts);
+        virtual StridedMatrix<double, MemorySpace> Evaluate(StridedMatrix<const double, MemorySpace> const& pts);
 
         virtual Eigen::RowMatrixXd Evaluate(Eigen::Ref<const Eigen::RowMatrixXd> const& pts);
 
-        virtual void EvaluateImpl(Kokkos::View<const double**, MemorySpace> const& pts,
-                                  Kokkos::View<double**, MemorySpace>            & output) = 0;
+        virtual void EvaluateImpl(StridedMatrix<const double, MemorySpace> const& pts,
+                                  StridedMatrix<double, MemorySpace>              output) = 0;
 
 
         /** @brief Computes the gradient of the map output with respect to the map coefficients.
@@ -79,15 +79,15 @@ namespace mpart {
                     this view should therefore have the same number of columns as `pts`.  It should also have \f$M\f$ rows.   
         @return A collection of vectors \f$g_i\f$.  Will have the same number of columns as pts with \f$K\f$ rows.
         */
-        virtual Kokkos::View<double**, MemorySpace> CoeffGrad(Kokkos::View<const double**, MemorySpace> const& pts, 
-                                                              Kokkos::View<const double**, MemorySpace> const& sens);
+        virtual StridedMatrix<double, MemorySpace> CoeffGrad(StridedMatrix<const double, MemorySpace> const& pts, 
+                                                             StridedMatrix<const double, MemorySpace> const& sens);
 
         virtual Eigen::RowMatrixXd CoeffGrad(Eigen::Ref<const Eigen::RowMatrixXd> const& pts,
                                              Eigen::Ref<const Eigen::RowMatrixXd> const& sens);
 
-        virtual void CoeffGradImpl(Kokkos::View<const double**, MemorySpace> const& pts,  
-                                   Kokkos::View<const double**, MemorySpace> const& sens,
-                                   Kokkos::View<double**, MemorySpace> &output) = 0;
+        virtual void CoeffGradImpl(StridedMatrix<const double, MemorySpace> const& pts,  
+                                   StridedMatrix<const double, MemorySpace> const& sens,
+                                   StridedMatrix<double, MemorySpace>              output) = 0;
 
         
         const unsigned int inputDim; /// The total dimension of the input N+M

--- a/MParT/TriangularMap.h
+++ b/MParT/TriangularMap.h
@@ -62,7 +62,7 @@ public:
                   vector should be correctly allocated and sized before calling this function.
     */
     virtual void LogDeterminantImpl(StridedMatrix<const double, MemorySpace> const& pts,
-                                    Kokkos::View<double*, MemorySpace>              output) override;
+                                    StridedVector<double, MemorySpace>              output) override;
 
 
     /** @brief Evaluates the map.

--- a/MParT/TriangularMap.h
+++ b/MParT/TriangularMap.h
@@ -61,8 +61,8 @@ public:
     @param output A vector with length equal to the number of columns in pts containing the log determinant of the Jacobian.  This
                   vector should be correctly allocated and sized before calling this function.
     */
-    virtual void LogDeterminantImpl(Kokkos::View<const double**, MemorySpace> const& pts,
-                                    Kokkos::View<double*, MemorySpace>             &output) override;
+    virtual void LogDeterminantImpl(StridedMatrix<const double, MemorySpace> const& pts,
+                                    Kokkos::View<double*, MemorySpace>              output) override;
 
 
     /** @brief Evaluates the map.
@@ -72,8 +72,8 @@ public:
     @param output A matrix with \f$M\f$ rows to store the map output.  Should have the same number of columns as pts and be
                   allocated before calling this function.
     */
-    void EvaluateImpl(Kokkos::View<const double**, MemorySpace> const& pts,
-                      Kokkos::View<double**, MemorySpace>            & output) override;
+    void EvaluateImpl(StridedMatrix<const double, MemorySpace> const& pts,
+                      StridedMatrix<double, MemorySpace>              output) override;
 
 
     /** @brief Evaluates the map inverse.
@@ -88,22 +88,22 @@ public:
     @param r The map output \f$r_{1:M}\f$ to invert.
     @param output A matrix with \f$M\f$ rows to store the computed map inverse \f$x_{N-M+1:M}\f$.
     */
-    virtual void InverseImpl(Kokkos::View<const double**, MemorySpace> const& x1,
-                             Kokkos::View<const double**, MemorySpace> const& r,
-                             Kokkos::View<double**, MemorySpace>            & output) override;
+    virtual void InverseImpl(StridedMatrix<const double, MemorySpace> const& x1,
+                             StridedMatrix<const double, MemorySpace> const& r,
+                             StridedMatrix<double, MemorySpace>              output) override;
 
 
-    virtual void InverseInplace(Kokkos::View<double**, MemorySpace> const& x1,
-                                Kokkos::View<const double**, MemorySpace> const& r);
+    virtual void InverseInplace(StridedMatrix<double, MemorySpace>              x1,
+                                StridedMatrix<const double, MemorySpace> const& r);
 
 
-    virtual void CoeffGradImpl(Kokkos::View<const double**, MemorySpace> const& pts,  
-                               Kokkos::View<const double**, MemorySpace> const& sens,
-                               Kokkos::View<double**, MemorySpace>            & output) override;
+    virtual void CoeffGradImpl(StridedMatrix<const double, MemorySpace> const& pts,  
+                               StridedMatrix<const double, MemorySpace> const& sens,
+                               StridedMatrix<double, MemorySpace>              output) override;
 
 
-    virtual void LogDeterminantCoeffGradImpl(Kokkos::View<const double**, MemorySpace> const& pts, 
-                                             Kokkos::View<double**, MemorySpace> &output) override;
+    virtual void LogDeterminantCoeffGradImpl(StridedMatrix<const double, MemorySpace> const& pts, 
+                                             StridedMatrix<double, MemorySpace>              output) override;
 private:
 
     std::vector<std::shared_ptr<ConditionalMapBase<MemorySpace>>> comps_;

--- a/MParT/Utilities/ArrayConversions.h
+++ b/MParT/Utilities/ArrayConversions.h
@@ -13,7 +13,10 @@ namespace mpart{
     
     /** Alias declaration for strided Kokkos matrix type. */
     template<typename ScalarType, typename MemorySpace>
-    using StridedMatrix = Kokkos::View<ScalarType**, Kokkos::LayoutStride, Kokkos::HostSpace>;
+    using StridedMatrix = Kokkos::View<ScalarType**, Kokkos::LayoutStride, MemorySpace>;
+
+    template<typename ScalarType, typename MemorySpace>
+    using StridedVector = Kokkos::View<ScalarType*, Kokkos::LayoutStride, MemorySpace>;
 
     /** @brief Converts a pointer to a 1d unmanaged Kokkos view.  
         @ingroup ArrayUtilities

--- a/MParT/Utilities/ArrayConversions.h
+++ b/MParT/Utilities/ArrayConversions.h
@@ -11,6 +11,10 @@ namespace mpart{
         @brief Code for converting between different array types.  Often used in bindings to other languages.
     */
     
+    /** Alias declaration for strided Kokkos matrix type. */
+    template<typename ScalarType, typename MemorySpace>
+    using StridedMatrix = Kokkos::View<ScalarType**, Kokkos::LayoutStride, Kokkos::HostSpace>;
+
     /** @brief Converts a pointer to a 1d unmanaged Kokkos view.  
         @ingroup ArrayUtilities
         @details Creates a Kokkos unmanaged view around a preallocated block of memory.  
@@ -221,7 +225,7 @@ namespace mpart{
         @tparam ScalarType The scalar type, typically double, int, or unsigned int.
     */
     template<typename ScalarType>
-    inline Kokkos::View<ScalarType**, Kokkos::LayoutStride, Kokkos::HostSpace> MatToKokkos(Eigen::Ref<Eigen::Matrix<ScalarType,Eigen::Dynamic,Eigen::Dynamic,Eigen::ColMajor>, 0, Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>> ref)
+    inline StridedMatrix<ScalarType, Kokkos::HostSpace> MatToKokkos(Eigen::Ref<Eigen::Matrix<ScalarType,Eigen::Dynamic,Eigen::Dynamic,Eigen::ColMajor>, 0, Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>> ref)
     {   
         Kokkos::LayoutStride strides(ref.rows(), ref.innerStride(), ref.cols(), ref.outerStride());
 
@@ -263,7 +267,7 @@ namespace mpart{
         @tparam ScalarType The scalar type, typically double, int, or unsigned int.
     */
     template<typename ScalarType>
-    inline Kokkos::View<ScalarType**, Kokkos::LayoutStride, Kokkos::HostSpace> MatToKokkos(Eigen::Ref<Eigen::Matrix<ScalarType,Eigen::Dynamic,Eigen::Dynamic,Eigen::RowMajor>, 0, Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>> ref)
+    inline StridedMatrix<ScalarType, Kokkos::HostSpace> MatToKokkos(Eigen::Ref<Eigen::Matrix<ScalarType,Eigen::Dynamic,Eigen::Dynamic,Eigen::RowMajor>, 0, Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>> ref)
     {   
         Kokkos::LayoutStride strides(ref.rows(), ref.outerStride(), ref.cols(), ref.innerStride());
 

--- a/bindings/matlab/mat/ConditionalMap.m
+++ b/bindings/matlab/mat/ConditionalMap.m
@@ -79,28 +79,41 @@ methods
   end
 
   function result = Evaluate(this,pts)
-    result = MParT_('ConditionalMap_Evaluate',this.id_,pts);
+    result = zeros(this.outputDim, size(pts,2));
+    MParT_('ConditionalMap_Evaluate',this.id_,pts,result);
   end
 
   function result = LogDeterminant(this,pts)
-    result = MParT_('ConditionalMap_LogDeterminant',this.id_,pts);
+    result = zeros(size(pts,2),1);
+    MParT_('ConditionalMap_LogDeterminant',this.id_,pts,result);
   end
 
   function result = Inverse(this,x1,r)
-    result = MParT_('ConditionalMap_Inverse',this.id_,x1,r);
+    result = zeros(this.outputDim, size(r,2));
+    MParT_('ConditionalMap_Inverse',this.id_,x1,r,result);
   end
 
   function result = CoeffGrad(this,pts,sens)
-    result = MParT_('ConditionalMap_CoeffGrad',this.id_,pts,sens);
+    result = zeros(this.numCoeffs, size(pts,2));
+    MParT_('ConditionalMap_CoeffGrad',this.id_,pts,sens,result);
   end
 
   function result = LogDeterminantCoeffGrad(this,pts)
-    result = MParT_('ConditionalMap_LogDeterminantCoeffGrad',this.id_,pts);
+    result = zeros(this.numCoeffs, size(pts,2));
+    MParT_('ConditionalMap_LogDeterminantCoeffGrad',this.id_,pts,result);
   end
 
   function result = get_id(this)
     result = this.id_;
   end
+
+  function result = outputDim(this)
+    result = MParT_('ConditionalMap_outputDim',this.id_);
+  end 
+
+  function result = inputDim(this)
+    result = MParT_('ConditionalMap_inputDim',this.id_);
+  end 
 
 end
 

--- a/bindings/matlab/src/MexArrayConversions.cpp
+++ b/bindings/matlab/src/MexArrayConversions.cpp
@@ -36,8 +36,8 @@ Kokkos::View<double*, Kokkos::HostSpace>  mpart::MexToKokkos1d(const mxArray *mx
 
 Kokkos::View<double**, Kokkos::LayoutLeft, Kokkos::HostSpace>  mpart::MexToKokkos2d(const mxArray *mx)
 {   
-    size_t rows = mxGetN(mx);
-    size_t cols = mxGetM(mx);
+    size_t cols = mxGetN(mx);
+    size_t rows = mxGetM(mx);
 
     if(mxIsComplex(mx)){
         std::stringstream msg;

--- a/src/ConditionalMapBase.cpp
+++ b/src/ConditionalMapBase.cpp
@@ -5,7 +5,7 @@
 using namespace mpart;
 
 template<typename MemorySpace>
-Kokkos::View<double*, MemorySpace> ConditionalMapBase<MemorySpace>::LogDeterminant(Kokkos::View<const double**, MemorySpace> const& pts)
+Kokkos::View<double*, MemorySpace> ConditionalMapBase<MemorySpace>::LogDeterminant(StridedMatrix<const double, MemorySpace> const& pts)
 {   
     this->CheckCoefficients("LogDeterminant");
     Kokkos::View<double*, MemorySpace> output("Log Determinants", pts.extent(1));
@@ -19,7 +19,7 @@ Eigen::VectorXd ConditionalMapBase<Kokkos::HostSpace>::LogDeterminant(Eigen::Ref
     this->CheckCoefficients("LogDeterminant");
    
     Eigen::VectorXd output(pts.cols());
-    Kokkos::View<const double**, Kokkos::HostSpace> ptsView = ConstRowMatToKokkos<double>(pts);
+    StridedMatrix<const double, Kokkos::HostSpace> ptsView = ConstRowMatToKokkos<double>(pts);
     Kokkos::View<double*, Kokkos::HostSpace> outView = VecToKokkos<double>(output);
     LogDeterminantImpl(ptsView, outView);
     return output;
@@ -35,8 +35,8 @@ Eigen::VectorXd ConditionalMapBase<MemorySpace>::LogDeterminant(Eigen::Ref<const
 }
 
 template<typename MemorySpace>
-Kokkos::View<double**, MemorySpace> ConditionalMapBase<MemorySpace>::Inverse(Kokkos::View<const double**, MemorySpace> const& x1,
-                                                                      Kokkos::View<const double**, MemorySpace> const& r)
+StridedMatrix<double, MemorySpace> ConditionalMapBase<MemorySpace>::Inverse(StridedMatrix<const double, MemorySpace> const& x1,
+                                                                            StridedMatrix<const double, MemorySpace> const& r)
 {
     this->CheckCoefficients("Inverse");
     // Throw an error if the inputs don't have the same number of columns
@@ -58,9 +58,9 @@ Eigen::RowMatrixXd ConditionalMapBase<Kokkos::HostSpace>::Inverse(Eigen::Ref<con
     
     Eigen::RowMatrixXd output(outputDim, r.cols());
 
-    Kokkos::View<const double**, Kokkos::HostSpace> x1View = ConstRowMatToKokkos<double>(x1);
-    Kokkos::View<const double**, Kokkos::HostSpace> rView = ConstRowMatToKokkos<double>(r);
-    Kokkos::View<double**, Kokkos::HostSpace> outView = MatToKokkos<double>(output);
+    StridedMatrix<const double, Kokkos::HostSpace> x1View = ConstRowMatToKokkos<double>(x1);
+    StridedMatrix<const double, Kokkos::HostSpace> rView = ConstRowMatToKokkos<double>(r);
+    StridedMatrix<double, Kokkos::HostSpace> outView = MatToKokkos<double>(output);
 
     InverseImpl(x1View, rView, outView);
     return output;
@@ -78,7 +78,7 @@ Eigen::RowMatrixXd ConditionalMapBase<MemorySpace>::Inverse(Eigen::Ref<const Eig
 
 
 template<typename MemorySpace>
-Kokkos::View<double**, MemorySpace> ConditionalMapBase<MemorySpace>::LogDeterminantCoeffGrad(Kokkos::View<const double**, MemorySpace> const& pts)
+StridedMatrix<double, MemorySpace> ConditionalMapBase<MemorySpace>::LogDeterminantCoeffGrad(StridedMatrix<const double, MemorySpace> const& pts)
 {
     this->CheckCoefficients("LogDeterminantCoeffGrad");
     Kokkos::View<double**, MemorySpace> output("LogDeterminantCoeffGrad", this->numCoeffs, pts.extent(1));
@@ -92,7 +92,7 @@ Eigen::RowMatrixXd ConditionalMapBase<Kokkos::HostSpace>::LogDeterminantCoeffGra
     this->CheckCoefficients("LogDeterminantCoeffGrad");
     Eigen::RowMatrixXd output(numCoeffs, pts.cols());
 
-    Kokkos::View<const double**, Kokkos::HostSpace> ptsView = ConstRowMatToKokkos<double>(pts);
+    StridedMatrix<const double, Kokkos::HostSpace> ptsView = ConstRowMatToKokkos<double>(pts);
     Kokkos::View<double**, Kokkos::HostSpace> outView = MatToKokkos<double>(output);
     
     LogDeterminantCoeffGradImpl(ptsView, outView);

--- a/src/ParameterizedFunctionBase.cpp
+++ b/src/ParameterizedFunctionBase.cpp
@@ -22,7 +22,7 @@ void ParameterizedFunctionBase<MemorySpace>::CheckDeviceMismatch(std::string fun
 
 
 template<typename MemorySpace>
-Kokkos::View<double**, MemorySpace> ParameterizedFunctionBase<MemorySpace>::Evaluate(Kokkos::View<const double**, MemorySpace> const& pts)
+StridedMatrix<double, MemorySpace> ParameterizedFunctionBase<MemorySpace>::Evaluate(StridedMatrix<const double, MemorySpace> const& pts)
 {   
     CheckCoefficients("Evaluate");
 
@@ -37,8 +37,8 @@ Eigen::RowMatrixXd ParameterizedFunctionBase<Kokkos::HostSpace>::Evaluate(Eigen:
     CheckCoefficients("Evaluate");
 
     Eigen::RowMatrixXd output(outputDim, pts.cols());
-    Kokkos::View<const double**, Kokkos::HostSpace> ptsView = ConstRowMatToKokkos<double>(pts);
-    Kokkos::View<double**, Kokkos::HostSpace> outView = MatToKokkos<double>(output);
+    StridedMatrix<const double, Kokkos::HostSpace> ptsView = ConstRowMatToKokkos<double>(pts);
+    StridedMatrix<double, Kokkos::HostSpace> outView = MatToKokkos<double>(output);
     EvaluateImpl(ptsView, outView);
     return output;
 }
@@ -102,8 +102,8 @@ Eigen::Map<Eigen::VectorXd> ParameterizedFunctionBase<MemorySpace>::CoeffMap()
 
 
 template<typename MemorySpace>
-Kokkos::View<double**, MemorySpace> ParameterizedFunctionBase<MemorySpace>::CoeffGrad(Kokkos::View<const double**, MemorySpace> const& pts, 
-                                                                               Kokkos::View<const double**, MemorySpace> const& sens)
+StridedMatrix<double, MemorySpace> ParameterizedFunctionBase<MemorySpace>::CoeffGrad(StridedMatrix<const double, MemorySpace> const& pts, 
+                                                                                     StridedMatrix<const double, MemorySpace> const& sens)
 {
     CheckCoefficients("CoeffGrad");
     Kokkos::View<double**, MemorySpace> output("Coeff Grad", numCoeffs, pts.extent(1));
@@ -113,14 +113,14 @@ Kokkos::View<double**, MemorySpace> ParameterizedFunctionBase<MemorySpace>::Coef
 
 template<>
 Eigen::RowMatrixXd ParameterizedFunctionBase<Kokkos::HostSpace>::CoeffGrad(Eigen::Ref<const Eigen::RowMatrixXd> const& pts, 
-                                                                    Eigen::Ref<const Eigen::RowMatrixXd> const& sens)
+                                                                           Eigen::Ref<const Eigen::RowMatrixXd> const& sens)
 {
     CheckCoefficients("CoeffGrad");
     Eigen::RowMatrixXd output(numCoeffs, pts.cols());
 
-    Kokkos::View<const double**, Kokkos::HostSpace> ptsView = ConstRowMatToKokkos<double>(pts);
-    Kokkos::View<const double**, Kokkos::HostSpace> sensView = ConstRowMatToKokkos<double>(sens);
-    Kokkos::View<double**, Kokkos::HostSpace> outView = MatToKokkos<double>(output);
+    StridedMatrix<const double, Kokkos::HostSpace> ptsView = ConstRowMatToKokkos<double>(pts);
+    StridedMatrix<const double, Kokkos::HostSpace> sensView = ConstRowMatToKokkos<double>(sens);
+    StridedMatrix<double, Kokkos::HostSpace> outView = MatToKokkos<double>(output);
     
     CoeffGradImpl(ptsView, sensView, outView);
 

--- a/src/TriangularMap.cpp
+++ b/src/TriangularMap.cpp
@@ -49,8 +49,8 @@ void TriangularMap<MemorySpace>::SetCoeffs(Kokkos::View<double*, MemorySpace> co
 }
 
 template<typename MemorySpace>
-void TriangularMap<MemorySpace>::LogDeterminantImpl(Kokkos::View<const double**, MemorySpace> const& pts,
-                                       Kokkos::View<double*, MemorySpace>             &output)
+void TriangularMap<MemorySpace>::LogDeterminantImpl(StridedMatrix<const double, MemorySpace> const& pts,
+                                                    Kokkos::View<double*, MemorySpace>              output)
 {
     // Evaluate the log determinant for the first component
     Kokkos::View<const double**, MemorySpace> subPts = Kokkos::subview(pts, std::make_pair(0,int(comps_.at(0)->inputDim)), Kokkos::ALL());
@@ -73,8 +73,8 @@ void TriangularMap<MemorySpace>::LogDeterminantImpl(Kokkos::View<const double**,
 }
 
 template<typename MemorySpace>
-void TriangularMap<MemorySpace>::EvaluateImpl(Kokkos::View<const double**, MemorySpace> const& pts,
-                                 Kokkos::View<double**, MemorySpace>            & output)
+void TriangularMap<MemorySpace>::EvaluateImpl(StridedMatrix<const double, MemorySpace> const& pts,
+                                              StridedMatrix<double, MemorySpace>              output)
 {
     // Evaluate the output for each component
     Kokkos::View<const double**, MemorySpace> subPts;
@@ -91,9 +91,9 @@ void TriangularMap<MemorySpace>::EvaluateImpl(Kokkos::View<const double**, Memor
 }
 
 template<typename MemorySpace>
-void TriangularMap<MemorySpace>::InverseImpl(Kokkos::View<const double**, MemorySpace> const& x1,
-                                Kokkos::View<const double**, MemorySpace> const& r,
-                                Kokkos::View<double**, MemorySpace>            & output)
+void TriangularMap<MemorySpace>::InverseImpl(StridedMatrix<const double, MemorySpace> const& x1,
+                                             StridedMatrix<const double, MemorySpace> const& r,
+                                             StridedMatrix<double, MemorySpace>              output)
 {
     unsigned int ipdim = ConditionalMapBase<MemorySpace>::inputDim;
     unsigned int opdim = ConditionalMapBase<MemorySpace>::outputDim;
@@ -106,8 +106,8 @@ void TriangularMap<MemorySpace>::InverseImpl(Kokkos::View<const double**, Memory
 }
 
 template<typename MemorySpace>
-void TriangularMap<MemorySpace>::InverseInplace(Kokkos::View<double**, MemorySpace> const& x,
-                                   Kokkos::View<const double**, MemorySpace> const& r)
+void TriangularMap<MemorySpace>::InverseInplace(StridedMatrix<double, MemorySpace> x,
+                                                StridedMatrix<const double, MemorySpace> const& r)
 {
     // Evaluate the output for each component
     Kokkos::View<const double**, MemorySpace> subR;
@@ -132,9 +132,9 @@ void TriangularMap<MemorySpace>::InverseInplace(Kokkos::View<double**, MemorySpa
 
 
 template<typename MemorySpace>
-void TriangularMap<MemorySpace>::CoeffGradImpl(Kokkos::View<const double**, MemorySpace> const& pts,  
-                                               Kokkos::View<const double**, MemorySpace> const& sens,
-                                               Kokkos::View<double**, MemorySpace>            & output)
+void TriangularMap<MemorySpace>::CoeffGradImpl(StridedMatrix<const double, MemorySpace> const& pts,  
+                                               StridedMatrix<const double, MemorySpace> const& sens,
+                                               StridedMatrix<double, MemorySpace>              output)
 {
     // Evaluate the output for each component
     Kokkos::View<const double**, MemorySpace> subPts;
@@ -157,8 +157,8 @@ void TriangularMap<MemorySpace>::CoeffGradImpl(Kokkos::View<const double**, Memo
 }
 
 template<typename MemorySpace>
-void TriangularMap<MemorySpace>::LogDeterminantCoeffGradImpl(Kokkos::View<const double**, MemorySpace> const& pts, 
-                                                             Kokkos::View<double**, MemorySpace> &output)
+void TriangularMap<MemorySpace>::LogDeterminantCoeffGradImpl(StridedMatrix<const double, MemorySpace> const& pts, 
+                                                             StridedMatrix<double, MemorySpace>              output)
 {
     // Evaluate the output for each component
     Kokkos::View<const double**, MemorySpace> subPts;

--- a/src/TriangularMap.cpp
+++ b/src/TriangularMap.cpp
@@ -50,10 +50,10 @@ void TriangularMap<MemorySpace>::SetCoeffs(Kokkos::View<double*, MemorySpace> co
 
 template<typename MemorySpace>
 void TriangularMap<MemorySpace>::LogDeterminantImpl(StridedMatrix<const double, MemorySpace> const& pts,
-                                                    Kokkos::View<double*, MemorySpace>              output)
+                                                    StridedVector<double, MemorySpace>              output)
 {
     // Evaluate the log determinant for the first component
-    Kokkos::View<const double**, MemorySpace> subPts = Kokkos::subview(pts, std::make_pair(0,int(comps_.at(0)->inputDim)), Kokkos::ALL());
+    StridedMatrix<const double, MemorySpace> subPts = Kokkos::subview(pts, std::make_pair(0,int(comps_.at(0)->inputDim)), Kokkos::ALL());
     comps_.at(0)->LogDeterminantImpl(subPts, output);
 
     if(comps_.size()==1)
@@ -77,13 +77,14 @@ void TriangularMap<MemorySpace>::EvaluateImpl(StridedMatrix<const double, Memory
                                               StridedMatrix<double, MemorySpace>              output)
 {
     // Evaluate the output for each component
-    Kokkos::View<const double**, MemorySpace> subPts;
-    Kokkos::View<double**, MemorySpace> subOut;
+    StridedMatrix<const double, MemorySpace> subPts;
+    StridedMatrix<double, MemorySpace> subOut;
 
     int startOutDim = 0;
     for(unsigned int i=0; i<comps_.size(); ++i){
         subPts = Kokkos::subview(pts, std::make_pair(0,int(comps_.at(i)->inputDim)), Kokkos::ALL());
         subOut = Kokkos::subview(output, std::make_pair(startOutDim,int(startOutDim+comps_.at(i)->outputDim)), Kokkos::ALL());
+        
         comps_.at(i)->EvaluateImpl(subPts, subOut);
 
         startOutDim += comps_.at(i)->outputDim;
@@ -110,9 +111,9 @@ void TriangularMap<MemorySpace>::InverseInplace(StridedMatrix<double, MemorySpac
                                                 StridedMatrix<const double, MemorySpace> const& r)
 {
     // Evaluate the output for each component
-    Kokkos::View<const double**, MemorySpace> subR;
-    Kokkos::View<const double**, MemorySpace> subX;
-    Kokkos::View<double**, MemorySpace> subOut;
+    StridedMatrix<const double, MemorySpace> subR;
+    StridedMatrix<const double, MemorySpace> subX;
+    StridedMatrix<double, MemorySpace> subOut;
 
     unsigned int ipdim = ConditionalMapBase<MemorySpace>::inputDim;
     unsigned int opdim = ConditionalMapBase<MemorySpace>::outputDim;
@@ -137,9 +138,9 @@ void TriangularMap<MemorySpace>::CoeffGradImpl(StridedMatrix<const double, Memor
                                                StridedMatrix<double, MemorySpace>              output)
 {
     // Evaluate the output for each component
-    Kokkos::View<const double**, MemorySpace> subPts;
-    Kokkos::View<const double**, MemorySpace> subSens; 
-    Kokkos::View<double**, MemorySpace> subOut;
+    StridedMatrix<const double, MemorySpace> subPts;
+    StridedMatrix<const double, MemorySpace> subSens; 
+    StridedMatrix<double, MemorySpace> subOut;
 
     int startOutDim = 0;
     int startParamDim = 0;
@@ -161,8 +162,8 @@ void TriangularMap<MemorySpace>::LogDeterminantCoeffGradImpl(StridedMatrix<const
                                                              StridedMatrix<double, MemorySpace>              output)
 {
     // Evaluate the output for each component
-    Kokkos::View<const double**, MemorySpace> subPts;
-    Kokkos::View<double**, MemorySpace> subOut;
+    StridedMatrix<const double, MemorySpace> subPts;
+    StridedMatrix<double, MemorySpace> subOut;
 
     int startParamDim = 0;
     for(unsigned int i=0; i<comps_.size(); ++i){

--- a/tests/Test_ArrayConversions.cpp
+++ b/tests/Test_ArrayConversions.cpp
@@ -216,7 +216,7 @@ TEST_CASE( "Testing constant Eigen to Kokkos Conversions in 2D", "[ConstEigenArr
     unsigned int rows = 64;
     unsigned int cols = 32;
 
-    SECTION("Row Major"){
+    SECTION("Column Major"){
         Eigen::MatrixXd x(rows,cols);
         for(unsigned int j=0; j<cols; ++j){
             for(unsigned int i=0; i<rows; ++i){
@@ -233,7 +233,7 @@ TEST_CASE( "Testing constant Eigen to Kokkos Conversions in 2D", "[ConstEigenArr
         }
     }
 
-    SECTION("Column Major"){
+    SECTION("Row Major"){
         Eigen::RowMatrixXd x(rows,cols);
         for(unsigned int j=0; j<cols; ++j){
             for(unsigned int i=0; i<rows; ++i){
@@ -304,11 +304,20 @@ TEST_CASE( "Testing Eigen to Kokkos Conversions in 2D", "[EigenArrayConversions2
             }
         }
         
-        auto x_view = MatToKokkos<double>(x2);
+        Kokkos::View<double**,Kokkos::LayoutStride,Kokkos::HostSpace> x_view = MatToKokkos<double>(x2);
         for(unsigned int i=0; i<10; ++i){
             for(unsigned int j=0; j<10; ++j){
                 CHECK(x_view(i,j)==x2(i,j));   
                 CHECK(&x_view(i,j) == &x2(i,j));
+            }
+        }
+
+        // Test conversion from strided type to layoutright
+        Kokkos::View<double**,Kokkos::LayoutRight,Kokkos::HostSpace> x_right = x_view;
+        for(unsigned int i=0; i<10; ++i){
+            for(unsigned int j=0; j<10; ++j){
+                CHECK(x_right(i,j)==x2(i,j));   
+                CHECK(&x_right(i,j) == &x2(i,j));
             }
         }
     }

--- a/tests/Test_ConditionalMapBase.cpp
+++ b/tests/Test_ConditionalMapBase.cpp
@@ -16,7 +16,7 @@ public:
                               StridedMatrix<double, MemorySpace>              output) override{Kokkos::deep_copy(output,pts);};
 
     virtual void LogDeterminantImpl(StridedMatrix<const double, MemorySpace> const&,
-                                    Kokkos::View<double*, Kokkos::HostSpace>        output) override{
+                                    StridedVector<double, MemorySpace>        output) override{
         for(unsigned int i=0; i<output.size(); ++i)
             output(i)=0.0;
     }

--- a/tests/Test_ConditionalMapBase.cpp
+++ b/tests/Test_ConditionalMapBase.cpp
@@ -12,29 +12,29 @@ public:
 
     virtual ~MyIdentityMap() = default;
 
-    virtual void EvaluateImpl(Kokkos::View<const double**, Kokkos::HostSpace> const& pts,
-                              Kokkos::View<double**, Kokkos::HostSpace>      &output) override{Kokkos::deep_copy(output,pts);};
+    virtual void EvaluateImpl(StridedMatrix<const double, MemorySpace> const& pts,
+                              StridedMatrix<double, MemorySpace>              output) override{Kokkos::deep_copy(output,pts);};
 
-    virtual void LogDeterminantImpl(Kokkos::View<const double**, Kokkos::HostSpace> const&,
-                                    Kokkos::View<double*, Kokkos::HostSpace>             &output) override{
+    virtual void LogDeterminantImpl(StridedMatrix<const double, MemorySpace> const&,
+                                    Kokkos::View<double*, Kokkos::HostSpace>        output) override{
         for(unsigned int i=0; i<output.size(); ++i)
             output(i)=0.0;
     }
 
-    virtual void InverseImpl(Kokkos::View<const double**, Kokkos::HostSpace> const&,
-                            Kokkos::View<const double**, Kokkos::HostSpace> const& r,
-                            Kokkos::View<double**, Kokkos::HostSpace>      & output) override{Kokkos::deep_copy(output,r);};
+    virtual void InverseImpl(StridedMatrix<const double, MemorySpace> const&,
+                             StridedMatrix<const double, MemorySpace> const& r,
+                             StridedMatrix<double, MemorySpace>              output) override{Kokkos::deep_copy(output,r);};
 
-    virtual void CoeffGradImpl(Kokkos::View<const double**, MemorySpace> const& pts,  
-                               Kokkos::View<const double**, MemorySpace> const& sens,
-                               Kokkos::View<double**, MemorySpace>            & output) override
+    virtual void CoeffGradImpl(StridedMatrix<const double, MemorySpace> const& pts,  
+                               StridedMatrix<const double, MemorySpace> const& sens,
+                               StridedMatrix<double, MemorySpace>              output) override
     {
         assert(false);  
     }
 
 
-    virtual void LogDeterminantCoeffGradImpl(Kokkos::View<const double**, MemorySpace> const& pts, 
-                                             Kokkos::View<double**, MemorySpace> &output) override
+    virtual void LogDeterminantCoeffGradImpl(StridedMatrix<const double, MemorySpace> const& pts, 
+                                             StridedMatrix<double, MemorySpace>              output) override
     {   
         assert(false);
     }


### PR DESCRIPTION
Closes #71 

Previously, we were using Kokkos views that were restricted to the default Kokkos memory layout (row-major on host code or column-major in device code).   When constructing arrays, I still use these defaults, but I updated the function definitions in `ConditionalMapBase` and `ParameterizedFunctionBase` to accepted general strided layouts.   This enables either row major OR column major formats to be used.  Strided layouts can also be used to grab "slices" or matrices without making copies.

One immediate benefit of this update is that we can now natively support the memory layouts of any other language, such as Matlab.   So we no longer need to copy memory when interfacing between matlab and MParT.

@rubiop I updated the Matlab bindings, but could you rerun your speed tests to verify that Matlab performance is now more in line with the other languages?   Thanks!


I used this code for testing in matlab:
```matlab
clear 
close all

addpath('~/Installations/MParT/matlab/')
addpath('~/Installations/MParT/matlab/MapOptions')

KokkosInitialize(8)
opts = MapOptions();

%% Create Map
dim = 2;
totalOrder = 2;
triMap = CreateTriangular(dim,dim,totalOrder,opts);

%% Generate Test Samples
nsamp = 10000;
X = randn(dim,nsamp);

%% Test functions
tic
log_det = triMap.LogDeterminant(X);
toc

tic 
evals = triMap.Evaluate(X);
toc 

tic 
X2 = triMap.Inverse(X,evals);
toc 

tic 
detGrad = triMap.LogDeterminantCoeffGrad(X);
toc 

tic 
sens = ones(dim,nsamp);
coeffGrad = triMap.CoeffGrad(X,sens);
toc 
```