### PR TITLE
Added handling of other quadrature options.

### DIFF
--- a/src/MapFactory.cpp
+++ b/src/MapFactory.cpp
@@ -63,6 +63,108 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> mpart::MapFactory::CreateCompon
             output->Coeffs() = Kokkos::View<double*,MemorySpace>("Component Coefficients", mset.Size());
             return output;
         }
+
+    }else if(opts.quadType==QuadTypes::ClenshawCurtis){
+
+        ClenshawCurtisQuadrature<MemorySpace> quad(opts.quadPts, 1);
+            
+        if(opts.basisType==BasisTypes::ProbabilistHermite){
+
+            MultivariateExpansionWorker<ProbabilistHermite,MemorySpace> expansion(mset);
+            std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
+
+            switch(opts.posFuncType) {
+                case PosFuncTypes::SoftPlus:
+                    output = std::make_shared<MonotoneComponent<decltype(expansion), SoftPlus, decltype(quad), MemorySpace>>(mset, quad, opts.contDeriv); break;
+                case PosFuncTypes::Exp:
+                    output = std::make_shared<MonotoneComponent<decltype(expansion), Exp, decltype(quad), MemorySpace>>(mset, quad, opts.contDeriv); break;
+            }
+
+            output->SetCoeffs(Kokkos::View<double*,MemorySpace>("Component Coefficients", mset.Size()));
+            return output;
+
+        }else if(opts.basisType==BasisTypes::PhysicistHermite){
+
+            MultivariateExpansionWorker<PhysicistHermite, MemorySpace> expansion(mset);
+            std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
+
+            switch(opts.posFuncType) {
+                case PosFuncTypes::SoftPlus:
+                    output = std::make_shared<MonotoneComponent<decltype(expansion), SoftPlus, decltype(quad), MemorySpace>>(mset, quad, opts.contDeriv); break;
+                case PosFuncTypes::Exp:
+                    output = std::make_shared<MonotoneComponent<decltype(expansion), Exp, decltype(quad), MemorySpace>>(mset, quad, opts.contDeriv); break;
+            }
+
+            output->SetCoeffs(Kokkos::View<double*,MemorySpace>("Component Coefficients", mset.Size()));
+            return output;
+
+        }else if(opts.basisType==BasisTypes::HermiteFunctions){
+
+            MultivariateExpansionWorker<HermiteFunction, MemorySpace> expansion(mset);
+            std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
+
+            switch(opts.posFuncType) {
+                case PosFuncTypes::SoftPlus:
+                    output = std::make_shared<MonotoneComponent<decltype(expansion), SoftPlus, decltype(quad), MemorySpace>>(mset, quad, opts.contDeriv);
+                case PosFuncTypes::Exp:
+                    output = std::make_shared<MonotoneComponent<decltype(expansion), Exp, decltype(quad), MemorySpace>>(mset, quad, opts.contDeriv);
+            }
+
+            output->Coeffs() = Kokkos::View<double*,MemorySpace>("Component Coefficients", mset.Size());
+            return output;
+        }
+
+    }else if(opts.quadType==QuadTypes::AdaptiveClenshawCurtis){
+
+        unsigned int level = std::log2(opts.quadPts-2);
+        AdaptiveClenshawCurtis<MemorySpace> quad(level, opts.quadMaxSub, 1, nullptr, opts.quadAbsTol, opts.quadRelTol, QuadError::First, opts.quadMinSub);
+
+        if(opts.basisType==BasisTypes::ProbabilistHermite){
+
+            MultivariateExpansionWorker<ProbabilistHermite,MemorySpace> expansion(mset);
+            std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
+
+            switch(opts.posFuncType) {
+                case PosFuncTypes::SoftPlus:
+                    output = std::make_shared<MonotoneComponent<decltype(expansion), SoftPlus, decltype(quad), MemorySpace>>(mset, quad, opts.contDeriv); break;
+                case PosFuncTypes::Exp:
+                    output = std::make_shared<MonotoneComponent<decltype(expansion), Exp, decltype(quad), MemorySpace>>(mset, quad, opts.contDeriv); break;
+            }
+
+            output->SetCoeffs(Kokkos::View<double*,MemorySpace>("Component Coefficients", mset.Size()));
+            return output;
+
+        }else if(opts.basisType==BasisTypes::PhysicistHermite){
+
+            MultivariateExpansionWorker<PhysicistHermite, MemorySpace> expansion(mset);
+            std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
+
+            switch(opts.posFuncType) {
+                case PosFuncTypes::SoftPlus:
+                    output = std::make_shared<MonotoneComponent<decltype(expansion), SoftPlus, decltype(quad), MemorySpace>>(mset, quad, opts.contDeriv); break;
+                case PosFuncTypes::Exp:
+                    output = std::make_shared<MonotoneComponent<decltype(expansion), Exp, decltype(quad), MemorySpace>>(mset, quad, opts.contDeriv); break;
+            }
+
+            output->SetCoeffs(Kokkos::View<double*,MemorySpace>("Component Coefficients", mset.Size()));
+            return output;
+
+        }else if(opts.basisType==BasisTypes::HermiteFunctions){
+
+            MultivariateExpansionWorker<HermiteFunction, MemorySpace> expansion(mset);
+            std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
+
+            switch(opts.posFuncType) {
+                case PosFuncTypes::SoftPlus:
+                    output = std::make_shared<MonotoneComponent<decltype(expansion), SoftPlus, decltype(quad), MemorySpace>>(mset, quad, opts.contDeriv);
+                case PosFuncTypes::Exp:
+                    output = std::make_shared<MonotoneComponent<decltype(expansion), Exp, decltype(quad), MemorySpace>>(mset, quad, opts.contDeriv);
+            }
+
+            output->Coeffs() = Kokkos::View<double*,MemorySpace>("Component Coefficients", mset.Size());
+            return output;
+        }
+
     }
 
 

--- a/tests/Test_MapFactory.cpp
+++ b/tests/Test_MapFactory.cpp
@@ -13,6 +13,7 @@ using MemorySpace = Kokkos::HostSpace;
 
 TEST_CASE( "Testing map component factory", "[MapFactoryComponent]" ) {
 
+    
     MapOptions options;
     options.basisType = BasisTypes::ProbabilistHermite;
 
@@ -20,15 +21,47 @@ TEST_CASE( "Testing map component factory", "[MapFactoryComponent]" ) {
     unsigned int maxDegree = 5;
     FixedMultiIndexSet<MemorySpace> mset(dim,maxDegree);
 
-    std::shared_ptr<ConditionalMapBase<MemorySpace>> map = MapFactory::CreateComponent<MemorySpace>(mset, options);
-    REQUIRE(map!=nullptr);
+    SECTION("AdaptiveSimpson"){
+        options.quadType = QuadTypes::AdaptiveSimpson;
 
-    unsigned int numPts = 100;
-    Kokkos::View<double**,MemorySpace> pts("Points", dim, numPts);
-    for(unsigned int i=0; i<numPts; ++i)
-        pts(dim-1,i) = double(i)/double(numPts-1);
+        std::shared_ptr<ConditionalMapBase<MemorySpace>> map = MapFactory::CreateComponent<MemorySpace>(mset, options);
+        REQUIRE(map!=nullptr);
 
-    Kokkos::View<double**, MemorySpace> eval = map->Evaluate(pts);
+        unsigned int numPts = 100;
+        Kokkos::View<double**,MemorySpace> pts("Points", dim, numPts);
+        for(unsigned int i=0; i<numPts; ++i)
+            pts(dim-1,i) = double(i)/double(numPts-1);
+
+        Kokkos::View<double**, MemorySpace> eval = map->Evaluate(pts);
+    }
+
+    SECTION("ClenshawCurtis"){
+        options.quadType = QuadTypes::ClenshawCurtis;
+        
+        std::shared_ptr<ConditionalMapBase<MemorySpace>> map = MapFactory::CreateComponent<MemorySpace>(mset, options);
+        REQUIRE(map!=nullptr);
+
+        unsigned int numPts = 100;
+        Kokkos::View<double**,MemorySpace> pts("Points", dim, numPts);
+        for(unsigned int i=0; i<numPts; ++i)
+            pts(dim-1,i) = double(i)/double(numPts-1);
+
+        Kokkos::View<double**, MemorySpace> eval = map->Evaluate(pts);
+    }
+
+    SECTION("AdaptiveClenshawCurtis"){
+        options.quadType = QuadTypes::AdaptiveClenshawCurtis;
+        
+        std::shared_ptr<ConditionalMapBase<MemorySpace>> map = MapFactory::CreateComponent<MemorySpace>(mset, options);
+        REQUIRE(map!=nullptr);
+
+        unsigned int numPts = 100;
+        Kokkos::View<double**,MemorySpace> pts("Points", dim, numPts);
+        for(unsigned int i=0; i<numPts; ++i)
+            pts(dim-1,i) = double(i)/double(numPts-1);
+
+        Kokkos::View<double**, MemorySpace> eval = map->Evaluate(pts);
+    }
 }
 
 


### PR DESCRIPTION
Closes #97 

- Added additional branches to MapFactory::CreateComponent if statement to process `ClenshawCurtis` and `AdaptiveClenshawCurtis` quadrature rules.
- Added test to make sure we can build/evaluation components with these rules.

This crazy nested if statement is a clunky way of handling these options, but I'm not sure if there is a better way with the templating we're doing.