### PR TITLE
Revert "explicitly search (and find) for python during cmake"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,6 @@ endif()
 
 # Add pybind11 if necessary
 if(MPART_PYTHON)
-  find_package(Python COMPONENTS Interpreter Development)
   find_package(pybind11 CONFIG QUIET)
   if(NOT pybind11_FOUND)
     message(STATUS "Could not find pybind11. Using internal build.")


### PR DESCRIPTION
Reverts MeasureTransport/MParT#166

See discussion in #167 .