### PR TITLE
Fix issues with Julia

### DIFF
--- a/bindings/julia/include/CommonJuliaUtilities.h
+++ b/bindings/julia/include/CommonJuliaUtilities.h
@@ -11,9 +11,6 @@
 namespace mpart{
 namespace binding{
 
-/** Define a wrapper around Kokkos::Initialize that accepts a sequence of Cstrings. */
-void Initialize(jlcxx::ArrayRef<char*>);
-
 /**
    @brief Adds Kokkos bindings to the existing module m.
    @param mod CxxWrap.jl module

--- a/bindings/julia/package/MParT.jl
+++ b/bindings/julia/package/MParT.jl
@@ -5,11 +5,14 @@ module MParT
 
     function __init__()
         @initcxx
-        Initialize()
+        threads = get(ENV, "KOKKOS_NUM_THREADS", nothing)
+        opts = isnothing(threads) ? [] : ["kokkos_num_threads", threads]
+        length(opts) > 0 && @info "Using MParT options: "*string(string.(opts))
+        Initialize(StdVector(StdString.(opts)))
     end
 
     module BasisTypes
-        using CxxWrap    
+        using CxxWrap
         @wrapmodule("libmpartjl", :BasisType_julia_module)
         function __init__()
             @initcxx

--- a/bindings/julia/src/CommonJuliaUtilities.cpp
+++ b/bindings/julia/src/CommonJuliaUtilities.cpp
@@ -6,12 +6,12 @@ using namespace mpart::binding;
 
 namespace mpart{
     namespace binding{
-        std::vector<std::string> makeInitArguments(jlcxx::ArrayRef<char*> opts) {
+        std::vector<std::string> makeInitArguments(std::vector<std::string> opts) {
             std::vector<std::string> args;
 
             for(int i = 0; i < opts.size(); i+=2){
-                auto key = std::string(opts[i]);
-                auto val = std::string(opts[i+1]);
+                auto key = opts[i];
+                auto val = opts[i+1];
                 std::string opt = "--" + key + "=" + val;
                 args.push_back(opt);
             }
@@ -20,14 +20,10 @@ namespace mpart{
     }
 }
 
-
-void mpart::binding::Initialize(jlcxx::ArrayRef<char*> opts) {
-    mpart::binding::Initialize(makeInitArguments(opts));
-}
-
 void mpart::binding::CommonUtilitiesWrapper(jlcxx::Module &mod)
 {
     mod.method("Initialize", [](){mpart::binding::Initialize(std::vector<std::string> {});});
+    mod.method("Initialize", [](std::vector<std::string> v){mpart::binding::Initialize(makeInitArguments(v));});
     mod.add_type<Kokkos::HostSpace>("HostSpace");
     mod.add_type<Kokkos::LayoutStride>("LayoutStride");
 }

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -94,7 +94,7 @@ You should now be able to run python and import the MParT package!
 
 Julia
 ^^^^^^^^^^
-See the section :ref:`compiling-julia` for information on how to set up the Julia environment manually. After this setup, you should now be able to use MParT from Julia by including MParT as a local package.  For example:
+See the section :ref:`compiling_julia` for information on how to set up the Julia environment manually. After this setup, you should now be able to use MParT from Julia by including MParT as a local package.  For example:
 
 .. code-block:: julia
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -94,27 +94,13 @@ You should now be able to run python and import the MParT package!
 
 Julia
 ^^^^^^^^^^
-First, make sure your library path includes the installation of MParT:
-
-.. tabbed:: OSX
-
-    .. code-block:: bash
-
-        export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:<your/install/path>/lib:<your/install/path>/python
-
-.. tabbed:: Linux
-
-    .. code-block:: bash
-
-         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:<your/install/path>/lib:<your/install/path>/python
-
-You should now be able to use MParT from Julia by including MParT as a local package.  For example:
+See the section :ref:`compiling-julia` for information on how to set up the Julia environment manually. After this setup, you should now be able to use MParT from Julia by including MParT as a local package.  For example:
 
 .. code-block:: julia
 
-    include("<your/install/path>/julia/mpart/MParT.jl")
+    using MParT
 
     dim = 3
     value = 1
-    idx = MParT.MultiIndex(dim,value)
+    idx = MultiIndex(dim,value)
     print(idx)

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -77,20 +77,22 @@ Or, with the additional specification of the number of Kokkos threads to use:
 
    This often results when due to conda environment mismatches, but can typically be circumvented by explicitly setting the path to your python executable.  When calling cmake, add :code:`-DPYTHON_EXECUTABLE=`which python``.
 
-.. tip:: 
+.. tip::
   On OSX, using MParT with the system version of python might result in an error with something like:
-  
+
   .. code-block::
 
     ImportError: dlopen(pympart.so, 2): no suitable image found.  Did find:
         MParT/python/mpart/pympart.so: mach-o, but wrong architecture
         MParT/python/mpart/pympart.so: mach-o, but wrong architecture
 
-  You can sometimes force OSX to use the x86_64 version of python using the :code:`arch` executable.   For example, to run a script :code:`test.py`, you can use 
+  You can sometimes force OSX to use the x86_64 version of python using the :code:`arch` executable.   For example, to run a script :code:`test.py`, you can use
 
   .. code-block::
 
     arch -x86_64 /usr/bin/python test.py
+
+.. _compiling_julia:
 
 Compiling with Julia Bindings
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -109,6 +111,7 @@ Once MParT is installed with Julia bindings (i.e. :code:`MPART_JULIA=ON`) into :
 .. tabbed:: MacOS
 
     .. code-block:: bash
+
         $ export DYLD_LIBRARY_PATH=<your MParT install path>/julia/mpart/:$DYLD_LIBRARY_PATH
         $ export JULIA_LOAD_PATH="<your MParT install path>/julia/mpart/:$JULIA_LOAD_PATH"
 


### PR DESCRIPTION
@rubiop pointed out some issues with the Julia bindings in the Julia docs and lack of support for kokkos threads. Now you should be able to do, e.g., 
```
$ export KOKKOS_NUM_THREADS=8
$ julia
...
julia> using MParT
```
and it will automatically start up with 8 threads (it should say so).