### PR TITLE
Rearrange how Julia bindings are compiled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,18 +132,27 @@ endif()
 if(MPART_JULIA)
   find_package(Julia REQUIRED)
 
+  # Get a hint for the location of JlCxx 
+  get_filename_component(PARENT_DIR ${Julia_LIBRARY_DIR} DIRECTORY)
+
   # Use JlCxx_DIR to tell where CxxWrap is located
+  if(NOT DEFINED JlCxx_DIR)
+    execute_process(COMMAND ${Julia_EXECUTABLE} -e "import CxxWrap; print(CxxWrap.prefix_path())" OUTPUT_VARIABLE cxxwrap_location)
+    set(JlCxx_DIR "${cxxwrap_location}/lib/cmake/JlCxx/")
+  endif()
+
   find_package(JlCxx)
 
   if(NOT JlCxx_FOUND)
     set(MPART_JULIA OFF)
     message(WARNING "Requested Julia bindings but CMake could not find JlCxx package.  Setting MPART_JULIA=OFF.")
-
   else()
+    get_target_property(JlCxx_location JlCxx::cxxwrap_julia LOCATION)
+    message(STATUS "Found JlCxx: ${JlCxx_location}")
+
     add_definitions(-DJULIA_ENABLE_THREADING)
     set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib;${Julia_LIBRARY_DIR}")
     set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-
   endif()
 
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,22 +131,18 @@ endif()
 # Add Julia if necessary
 if(MPART_JULIA)
   find_package(Julia REQUIRED)
-  # Set the julie executable and look for the location of cxxwrap
-  execute_process(COMMAND ${Julia_EXECUTABLE} -e "using CxxWrap; print(CxxWrap.prefix_path())" OUTPUT_VARIABLE cxxwrap_location)
-  list(APPEND CMAKE_PREFIX_PATH "${cxxwrap_location}/lib/cmake/JlCxx/" )
+
+  # Use JlCxx_DIR to tell where CxxWrap is located
   find_package(JlCxx)
 
   if(NOT JlCxx_FOUND)
     set(MPART_JULIA OFF)
     message(WARNING "Requested Julia bindings but CMake could not find JlCxx package.  Setting MPART_JULIA=OFF.")
+
   else()
     add_definitions(-DJULIA_ENABLE_THREADING)
-    get_target_property(JlCxx_location JlCxx::cxxwrap_julia LOCATION)
-    get_filename_component(JlCxx_location ${JlCxx_location} DIRECTORY)
-    get_filename_component(JlCxx_src ${JlCxx_location} DIRECTORY)
-    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib;${JlCxx_location};${Julia_LIBRARY_DIR}")
+    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib;${Julia_LIBRARY_DIR}")
     set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-    include_directories(${JlCxx_src}/include)
 
   endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ find_package(Kokkos QUIET)
 if(NOT Kokkos_FOUND)
     IF(MPART_FETCH_DEPS)
         message(STATUS "Could not find Kokkos.  Fetching source.")
-        
+
         FetchContent_Declare(
             kokkos
             GIT_REPOSITORY https://github.com/kokkos/kokkos
@@ -93,7 +93,7 @@ if(NOT Eigen3_FOUND)
         message(STATUS "Could not find Eigen. Fetching source.")
 
         FetchContent_Declare(
-            eigen3 
+            eigen3
             GIT_REPOSITORY https://gitlab.com/libeigen/eigen
             GIT_TAG 3.4.0
         )
@@ -111,7 +111,7 @@ if(MPART_PYTHON)
   if(NOT pybind11_FOUND)
     if(${MPART_FETCH_DEPS})
         message(STATUS "Could not find pybind11. Fetching source.")
-        
+
         FetchContent_Declare(
             pybind11
             GIT_REPOSITORY https://github.com/pybind/pybind11
@@ -130,12 +130,9 @@ endif()
 
 # Add Julia if necessary
 if(MPART_JULIA)
-
+  find_package(Julia REQUIRED)
   # Set the julie executable and look for the location of cxxwrap
-  if(NOT DEFINED JULIA_EXE)
-      set(JULIA_EXE "julia")
-  endif()
-  execute_process(COMMAND ${JULIA_EXE} -e "using CxxWrap; print(CxxWrap.prefix_path())" OUTPUT_VARIABLE cxxwrap_location)
+  execute_process(COMMAND ${Julia_EXECUTABLE} -e "using CxxWrap; print(CxxWrap.prefix_path())" OUTPUT_VARIABLE cxxwrap_location)
   list(APPEND CMAKE_PREFIX_PATH "${cxxwrap_location}/lib/cmake/JlCxx/" )
   find_package(JlCxx)
 
@@ -143,11 +140,14 @@ if(MPART_JULIA)
     set(MPART_JULIA OFF)
     message(WARNING "Requested Julia bindings but CMake could not find JlCxx package.  Setting MPART_JULIA=OFF.")
   else()
+    add_definitions(-DJULIA_ENABLE_THREADING)
     get_target_property(JlCxx_location JlCxx::cxxwrap_julia LOCATION)
     get_filename_component(JlCxx_location ${JlCxx_location} DIRECTORY)
     get_filename_component(JlCxx_src ${JlCxx_location} DIRECTORY)
-    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib;${JlCxx_location}")
+    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib;${JlCxx_location};${Julia_LIBRARY_DIR}")
+    set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
     include_directories(${JlCxx_src}/include)
+
   endif()
 
 endif()
@@ -197,11 +197,11 @@ if(MPART_BUILD_TESTS)
     if(NOT Catch2_FOUND)
         IF(MPART_FETCH_DEPS)
             message(STATUS "Could not find Catch2.  Fetching Catch2 source.")
-            
+
             FetchContent_Declare(
                 Catch2
                 GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-                GIT_TAG        v3.0.0-preview3 
+                GIT_TAG        v3.0.0-preview3
             )
 
             FetchContent_MakeAvailable(Catch2)

--- a/cmake/FindJulia.cmake
+++ b/cmake/FindJulia.cmake
@@ -1,0 +1,181 @@
+# Original FindJulia.cmake from https://github.com/QuantStack/xtensor-julia-cookiecutter/blob/master/%7B%7Bcookiecutter.github_project_name%7D%7D/cmake/FindJulia.cmake
+
+if(Julia_FOUND)
+    return()
+endif()
+
+####################
+# Julia Executable #
+####################
+
+if(Julia_PREFIX)
+    message(STATUS "Adding path ${Julia_PREFIX} to search path")
+    list(APPEND CMAKE_PREFIX_PATH ${Julia_PREFIX})
+    message(STATUS "THIS BRANCH")
+else()
+    find_program(Julia_EXECUTABLE julia DOC "Julia executable")
+    message(STATUS "Found Julia executable: " ${Julia_EXECUTABLE})
+endif()
+
+#################
+# Julia Version #
+#################
+
+if(Julia_EXECUTABLE)
+    execute_process(
+        COMMAND "${Julia_EXECUTABLE}" --startup-file=no --version
+        OUTPUT_VARIABLE Julia_VERSION_STRING
+    )
+else()
+    find_file(Julia_VERSION_INCLUDE julia_version.h PATH_SUFFIXES include/julia)
+    file(READ ${Julia_VERSION_INCLUDE} Julia_VERSION_STRING)
+    string(REGEX MATCH "JULIA_VERSION_STRING.*" Julia_VERSION_STRING ${Julia_VERSION_STRING})
+endif()
+
+string(
+    REGEX REPLACE ".*([0-9]+\\.[0-9]+\\.[0-9]+).*" "\\1"
+      Julia_VERSION_STRING "${Julia_VERSION_STRING}"
+)
+
+MESSAGE(STATUS "Julia_VERSION_STRING: ${Julia_VERSION_STRING}")
+
+##################
+# Julia Includes #
+##################
+
+set(JULIA_HOME_NAME "Sys.BINDIR")
+if(${Julia_VERSION_STRING} VERSION_LESS "0.7.0")
+    set(JULIA_HOME_NAME "JULIA_HOME")
+else()
+    set(USING_LIBDL "using Libdl")
+endif()
+
+if(DEFINED ENV{JULIA_INCLUDE_DIRS})
+    set(Julia_INCLUDE_DIRS $ENV{JULIA_INCLUDE_DIRS}
+        CACHE STRING "Location of Julia include files")
+elseif(Julia_EXECUTABLE)
+    execute_process(
+        COMMAND ${Julia_EXECUTABLE} --startup-file=no -E "julia_include_dir = joinpath(match(r\"(.*)(bin)\",${JULIA_HOME_NAME}).captures[1],\"include\",\"julia\")\n
+            if !isdir(julia_include_dir)  # then we're running directly from build\n
+            julia_base_dir_aux = splitdir(splitdir(${JULIA_HOME_NAME})[1])[1]  # useful for running-from-build\n
+            julia_include_dir = joinpath(julia_base_dir_aux, \"usr\", \"include\" )\n
+            julia_include_dir *= \";\" * joinpath(julia_base_dir_aux, \"src\", \"support\" )\n
+            julia_include_dir *= \";\" * joinpath(julia_base_dir_aux, \"src\" )\n
+            end\n
+            julia_include_dir"
+        OUTPUT_VARIABLE Julia_INCLUDE_DIRS
+    )
+
+    string(REGEX REPLACE "\"" "" Julia_INCLUDE_DIRS "${Julia_INCLUDE_DIRS}")
+    string(REGEX REPLACE "\n" "" Julia_INCLUDE_DIRS "${Julia_INCLUDE_DIRS}")
+    set(Julia_INCLUDE_DIRS ${Julia_INCLUDE_DIRS}
+        CACHE PATH "Location of Julia include files")
+elseif(Julia_PREFIX)
+    set(Julia_INCLUDE_DIRS ${Julia_PREFIX}/include/julia)
+endif()
+set(Julia_INCLUDE_DIRS ${Julia_INCLUDE_DIRS};$ENV{includedir})
+MESSAGE(STATUS "Julia_INCLUDE_DIRS:   ${Julia_INCLUDE_DIRS}")
+
+###################
+# Julia Libraries #
+###################
+
+if(WIN32)
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES} .a;.dll)
+endif()
+
+if(Julia_EXECUTABLE)
+    execute_process(
+        COMMAND ${Julia_EXECUTABLE} --startup-file=no -E "${USING_LIBDL}\nabspath(Libdl.dlpath((ccall(:jl_is_debugbuild, Cint, ()) != 0) ? \"libjulia-debug\" : \"libjulia\"))"
+        OUTPUT_VARIABLE Julia_LIBRARY
+    )
+
+    string(REGEX REPLACE "\"" "" Julia_LIBRARY "${Julia_LIBRARY}")
+    string(REGEX REPLACE "\n" "" Julia_LIBRARY "${Julia_LIBRARY}")
+    string(STRIP "${Julia_LIBRARY}" Julia_LIBRARY)
+
+    if(WIN32)
+        get_filename_component(Julia_LIBRARY_DIR ${Julia_LIBRARY} DIRECTORY)
+        get_filename_component(Julia_LIBRARY_DIR ${Julia_LIBRARY_DIR} DIRECTORY)
+        find_library(win_Julia_LIBRARY
+            NAMES libjulia.dll.a
+            PATHS "${Julia_LIBRARY_DIR}/lib"
+            NO_DEFAULT_PATH
+        )
+        set(Julia_LIBRARY "${win_Julia_LIBRARY}")
+    endif()
+
+    set(Julia_LIBRARY "${Julia_LIBRARY}"
+        CACHE PATH "Julia library")
+else()
+    find_library(Julia_LIBRARY NAMES libjulia.${Julia_VERSION_STRING}.dylib julia libjulia.dll.a libjulia CMAKE_FIND_ROOT_PATH_BOTH)
+endif()
+
+get_filename_component(Julia_LIBRARY_DIR ${Julia_LIBRARY} DIRECTORY)
+
+MESSAGE(STATUS "Julia_LIBRARY_DIR:    ${Julia_LIBRARY_DIR}")
+MESSAGE(STATUS "Julia_LIBRARY:        ${Julia_LIBRARY}")
+
+##############
+# JULIA_HOME #
+##############
+
+if(Julia_EXECUTABLE)
+    execute_process(
+        COMMAND ${Julia_EXECUTABLE} --startup-file=no -E "${JULIA_HOME_NAME}"
+        OUTPUT_VARIABLE JULIA_HOME
+    )
+
+    string(REGEX REPLACE "\"" "" JULIA_HOME "${JULIA_HOME}")
+    string(REGEX REPLACE "\n" "" JULIA_HOME "${JULIA_HOME}")
+
+    MESSAGE(STATUS "JULIA_HOME:           ${JULIA_HOME}")
+
+###################
+# libLLVM version #
+###################
+
+    execute_process(
+        COMMAND ${Julia_EXECUTABLE} --startup-file=no -E "Base.libllvm_version"
+        OUTPUT_VARIABLE Julia_LLVM_VERSION
+    )
+
+    string(REGEX REPLACE "\"" "" Julia_LLVM_VERSION "${Julia_LLVM_VERSION}")
+    string(REGEX REPLACE "\n" "" Julia_LLVM_VERSION "${Julia_LLVM_VERSION}")
+
+    MESSAGE(STATUS "Julia_LLVM_VERSION:   ${Julia_LLVM_VERSION}")
+endif()
+
+##################################
+# Check for Existence of Headers #
+##################################
+
+find_path(Julia_MAIN_HEADER julia.h HINTS ${Julia_INCLUDE_DIRS})
+
+#######################################
+# Determine if we are on 32 or 64 bit #
+#######################################
+
+if(Julia_EXECUTABLE)
+    execute_process(
+        COMMAND ${Julia_EXECUTABLE} --startup-file=no -E "Sys.WORD_SIZE"
+        OUTPUT_VARIABLE Julia_WORD_SIZE
+    )
+    string(REGEX REPLACE "\n" "" Julia_WORD_SIZE "${Julia_WORD_SIZE}")
+    MESSAGE(STATUS "Julia_WORD_SIZE:      ${Julia_WORD_SIZE}")
+endif()
+
+if($ENV{target} MATCHES "^i686.*")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse -msse2")
+endif()
+
+###########################
+# FindPackage Boilerplate #
+###########################
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Julia
+    REQUIRED_VARS   Julia_LIBRARY Julia_LIBRARY_DIR Julia_INCLUDE_DIRS Julia_MAIN_HEADER
+    VERSION_VAR     Julia_VERSION_STRING
+    FAIL_MESSAGE    "Julia not found"
+)


### PR DESCRIPTION
I know I keep doing this, but it needs to be changed again because the Julia bindings still don't work the way they should when pulling MParT.jl. I know it's not the most convenient way to compile them locally (and I'm open to adding some way for auto-detecting JlCxx), but I think a large problem is using the runtime-detected Julia.