### PR TITLE
Separated python installation location.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,10 @@ option(MPART_JULIA "Build julia bindings with CxxWrap.jl" ON)
 option(MPART_FETCH_DEPS "If CMake should be allowed to fetch and build external dependencies that weren't found." ON)
 
 ##############################################################
+# Installation path configuration 
+Include(SetInstallPaths)
+
+##############################################################
 # Compiler configuration
 
 # Set the C++ version

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -17,5 +17,5 @@ pybind11_add_module(pympart SHARED NO_EXTRAS ${PYTHON_BINDING_SOURCES})
 target_link_libraries(pympart PRIVATE mpart Kokkos::kokkos Eigen3::Eigen)
 
 # Add an installation target for the python bindings
-install(TARGETS pympart DESTINATION python/mpart)
-install(DIRECTORY package/ DESTINATION python/mpart)
+install(TARGETS pympart DESTINATION "${PYTHON_INSTALL_PREFIX}/mpart")
+install(DIRECTORY package/ DESTINATION "${PYTHON_INSTALL_PREFIX}/mpart")

--- a/cmake/SetInstallPaths.cmake
+++ b/cmake/SetInstallPaths.cmake
@@ -1,0 +1,10 @@
+
+
+if(PYTHON_INSTALL_PREFIX)
+  message(STATUS "PYTHON_INSTALL_PREFIX was set by user to be ${PYTHON_INSTALL_PREFIX}.")
+else()
+  message(STATUS "PYTHON_INSTALL_PREFIX was not set by user, defaulting to CMAKE_INSTALL_PREFIX/python.")
+  set(PYTHON_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX}/python)
+endif()
+
+message(STATUS "Python packages will be installed to ${PYTHON_INSTALL_PREFIX}.")


### PR DESCRIPTION
I added an additional CMake option, `PYTHON_INSTALL_PREFIX` that allows the conda-recipe to install the python package into a different location than the default `CMAKE_INSTALL_PREFIX/python`.   If `PYTHON_INSTALL_PREFIX` is not set, than everything behaves as it did before.