### PR TITLE
Add option for Julia install path

### DIFF
--- a/bindings/julia/CMakeLists.txt
+++ b/bindings/julia/CMakeLists.txt
@@ -16,4 +16,4 @@ add_library(mpartjl SHARED ${JULIA_BINDING_SOURCES})
 target_link_libraries(mpartjl PRIVATE mpart JlCxx::cxxwrap_julia JlCxx::cxxwrap_julia_stl Kokkos::kokkos Eigen3::Eigen)
 
 # Add an installation target for the julia bindings
-install(TARGETS mpartjl DESTINATION julia/mpart)
+install(TARGETS mpartjl DESTINATION "${JULIA_INSTALL_PREFIX}")

--- a/cmake/SetInstallPaths.cmake
+++ b/cmake/SetInstallPaths.cmake
@@ -8,3 +8,10 @@ else()
 endif()
 
 message(STATUS "Python packages will be installed to ${PYTHON_INSTALL_PREFIX}.")
+
+if(JULIA_INSTALL_PREFIX)
+  message(STATUS "JULIA_INSTALL_PREFIX was set by user to be ${JULIA_INSTALL_PREFIX}.")
+else()
+  message(STATUS "JULIA_INSTALL_PREFIX was not set by user, defaulting to CMAKE_INSTALL_PREFIX/julia.")
+  set(JULIA_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX}/julia)
+endif()


### PR DESCRIPTION
Similar to #201 , add the ability to install the julia binding target anywhere. Slightly different-- this does not automatically put the target under an `mpart` directory! I believe the issue being faced for MacOS in building could be attributed to just not having all the libraries in `lib`, and so I would like to make that an option.