### PR TITLE
Create component from a FixedMultiIndexSet

### DIFF
--- a/bindings/matlab/mat/ConditionalMap.m
+++ b/bindings/matlab/mat/ConditionalMap.m
@@ -32,13 +32,25 @@ methods
           mset = varargin{1};
           mapOptions = varargin{2};
           mexOptions = mapOptions.getMexOptions;
-          input_str=['MParT_(',char(39),'ConditionalMap_newMap',char(39),',mset.get_id()'];
-          for o=1:length(mexOptions)
-              input_o=[',mexOptions{',num2str(o),'}'];
-              input_str=[input_str,input_o];
+          if isa(mset,"MultiIndexSet")
+              input_str=['MParT_(',char(39),'ConditionalMap_newMap',char(39),',mset.get_id()'];
+              for o=1:length(mexOptions)
+                  input_o=[',mexOptions{',num2str(o),'}'];
+                  input_str=[input_str,input_o];
+              end
+              input_str=[input_str,')'];
+              this.id_ = eval(input_str);
+          elseif isa(mset,"FixedMultiIndexSet")
+              input_str=['MParT_(',char(39),'ConditionalMap_newMapFixed',char(39),',mset.get_id()'];
+              for o=1:length(mexOptions)
+                  input_o=[',mexOptions{',num2str(o),'}'];
+                  input_str=[input_str,input_o];
+              end
+              input_str=[input_str,')'];
+              this.id_ = eval(input_str);
+          else
+              error("Wrong input argument");
           end
-          input_str=[input_str,')'];
-          this.id_ = eval(input_str);
         end
     elseif(nargin==4)
       inputDim = varargin{1};

--- a/bindings/matlab/mat/TriangularMap.m
+++ b/bindings/matlab/mat/TriangularMap.m
@@ -1,7 +1,7 @@
 function map = TriangularMap(listCondMaps)
     listCondMap_ids =[];
     for i=1:length(listCondMaps)
-        listCondMap_ids=[listCondMap_ids,listCondMaps(i).get_id()]
+        listCondMap_ids=[listCondMap_ids,listCondMaps(i).get_id()];
     end
     map = ConditionalMap(listCondMap_ids);
 end

--- a/bindings/matlab/mat/TriangularMap.m
+++ b/bindings/matlab/mat/TriangularMap.m
@@ -1,3 +1,7 @@
 function map = TriangularMap(listCondMaps)
-    map = ConditionalMap(listCondMaps);
+    listCondMap_ids =[];
+    for i=1:length(listCondMaps)
+        listCondMap_ids=[listCondMap_ids,listCondMaps(i).get_id()]
+    end
+    map = ConditionalMap(listCondMap_ids);
 end

--- a/bindings/matlab/src/ConditionalMap_mex.cpp
+++ b/bindings/matlab/src/ConditionalMap_mex.cpp
@@ -110,6 +110,21 @@ MEX_DEFINE(ConditionalMap_newMap) (int nlhs, mxArray* plhs[],
   output.set(0, Session<ConditionalMapMex>::create(new ConditionalMapMex(mset.Fix(),opts)));
 }
 
+MEX_DEFINE(ConditionalMap_newMapFixed) (int nlhs, mxArray* plhs[],
+                    int nrhs, const mxArray* prhs[]) {
+
+  InputArguments input(nrhs, prhs, 10);
+  OutputArguments output(nlhs, plhs, 1);
+  const FixedMultiIndexSet<MemorySpace>& mset = Session<FixedMultiIndexSet<MemorySpace>>::getConst(input.get(0));
+  MapOptions opts = MapOptionsFromMatlab(input.get<std::string>(1),input.get<std::string>(2),
+                                         input.get<std::string>(3),input.get<double>(4),
+                                         input.get<double>(5),input.get<unsigned int>(6),
+                                         input.get<unsigned int>(7),input.get<unsigned int>(8),
+                                         input.get<bool>(9));
+
+  output.set(0, Session<ConditionalMapMex>::create(new ConditionalMapMex(mset,opts)));
+}
+
 // Defines MEX API for delete.
 MEX_DEFINE(ConditionalMap_deleteMap) (int nlhs, mxArray* plhs[],
                     int nrhs, const mxArray* prhs[]) {

--- a/bindings/matlab/src/FixedMultiIndexSet_mex.cpp
+++ b/bindings/matlab/src/FixedMultiIndexSet_mex.cpp
@@ -21,7 +21,7 @@ namespace {
 MEX_DEFINE(FixedMultiIndexSet_newTotalOrder) (int nlhs, mxArray* plhs[],
                                               int nrhs, const mxArray* prhs[]) {
   
-  InputArguments input(nrhs, prhs, 1);
+  InputArguments input(nrhs, prhs, 2);
   OutputArguments output(nlhs, plhs, 1);
   const unsigned int dim = input.get<unsigned int>(0);
   const unsigned int order = input.get<unsigned int>(1);

--- a/bindings/matlab/tests/Test_TriangularMap.m
+++ b/bindings/matlab/tests/Test_TriangularMap.m
@@ -13,7 +13,7 @@ mset2 = MultiIndexSet(multis2);
 map1 = ConditionalMap(mset1,opts); %create ConditionalMap with Matlab MultiIndexSet and MapOptions
 map2 = ConditionalMap(mset2,opts);
 
-triMap = TriangularMap([map1.get_id(),map2.get_id()]);
+triMap = TriangularMap([map1,map2]);
 
 disp(map1.Coeffs)
 coeffs = 0.1*[1 2 3 4 5 6];


### PR DESCRIPTION
Before this update the map component could be created from a `MultiIndexSet` (which is automatically fixed when calling the map component constructor in C++).

Now you can directly use a `FixedMultiIndexSet`. 

Maybe we should remove the ability of doing it directly from a `MultiIndexSet`.
