### PR TITLE
Poly normalization

### DIFF
--- a/MParT/HermiteFunction.h
+++ b/MParT/HermiteFunction.h
@@ -4,6 +4,7 @@
 #include <Kokkos_Core.hpp>
 
 #include "MParT/OrthogonalPolynomial.h"
+#include "MParT/Utilities/MathFunctions.h"
 
 namespace mpart{
 
@@ -135,13 +136,6 @@ public:
 
 private:
     PhysicistHermite polyBase;
-
-    KOKKOS_INLINE_FUNCTION unsigned int Factorial(unsigned int d) const{
-        unsigned int out = 1;
-        for(unsigned int i=2; i<=d; ++i)
-            out *= i;
-        return out;
-    }
     
 }; // class HermiteFunction
 

--- a/MParT/MapOptions.h
+++ b/MParT/MapOptions.h
@@ -92,7 +92,7 @@ namespace mpart{
         bool contDeriv = true;
 
         /** If orthogonal polynomial basis functions should be normalized. */
-        bool normalizePolys = true;
+        bool basisNorm = true;
     }; 
 };
 

--- a/MParT/MapOptions.h
+++ b/MParT/MapOptions.h
@@ -90,6 +90,9 @@ namespace mpart{
             is differentiated. 
         */
         bool contDeriv = true;
+
+        /** If orthogonal polynomial basis functions should be normalized. */
+        bool normalizePolys = true;
     }; 
 };
 

--- a/MParT/Utilities/MathFunctions.h
+++ b/MParT/Utilities/MathFunctions.h
@@ -1,0 +1,18 @@
+#ifndef MPART_MATHFUNCTIONS_H
+#define MPART_MATHFUNCTIONS_H
+
+#include <Kokkos_Core.hpp>
+
+namespace mpart{
+
+    /** Computes the factorial d! */
+    KOKKOS_INLINE_FUNCTION unsigned int Factorial(unsigned int d)
+    {
+        unsigned int out = 1;
+        for(unsigned int i=2; i<=d; ++i)
+            out *= i;
+        return out;
+    }
+}
+
+#endif 

--- a/bindings/julia/src/MapOptions.cpp
+++ b/bindings/julia/src/MapOptions.cpp
@@ -34,6 +34,7 @@ void mpart::binding::MapOptionsWrapper(jlcxx::Module &mod) {
         .method("__basisType!", [](MapOptions &opts, unsigned int basis){ opts.basisType = static_cast<BasisTypes>(basis); })
         .method("__basisLB!", [](MapOptions &opts, double lb){ opts.basisLB = lb; })
         .method("__basisUB!", [](MapOptions &opts, double ub){ opts.basisUB = ub; })
+        .method("__basisNorm!", [](MapOptions &opts, bool shouldNorm){ opts.basisNorm = shouldNorm; })
         .method("__posFuncType!", [](MapOptions &opts, unsigned int f){ opts.posFuncType = static_cast<PosFuncTypes>(f); })
         .method("__quadType!", [](MapOptions &opts, unsigned int quad){ opts.quadType = static_cast<QuadTypes>(quad); })
         .method("__quadAbsTol!", [](MapOptions &opts, double tol){ opts.quadAbsTol = tol; })

--- a/bindings/matlab/include/MexMapOptionsConversions.h
+++ b/bindings/matlab/include/MexMapOptionsConversions.h
@@ -13,7 +13,7 @@ namespace mpart{
                                         std::string quadType, double quadAbsTol,
                                         double quadRelTol, unsigned int quadMaxSub, 
                                         unsigned int quadMinSub,unsigned int quadPts, 
-                                        bool contDeriv, double basisLB, double basisUB);
+                                        bool contDeriv, double basisLB, double basisUB, bool basisNorm);
 }
 
 

--- a/bindings/matlab/mat/MapOptions/MapOptions.m
+++ b/bindings/matlab/mat/MapOptions/MapOptions.m
@@ -3,6 +3,7 @@ classdef MapOptions
         basisType = BasisTypes.ProbabilistHermite;
         basisLB = log(0);
         basisUB = 1.0/0.0;
+        basisNorm = true;
         posFuncType = PosFuncTypes.SoftPlus;
         quadType = QuadTypes.AdaptiveSimpson;
         quadAbsTol = 1e-6;
@@ -22,6 +23,9 @@ classdef MapOptions
         end
         function obj = set.basisUB(obj,value)
             obj.basisUB = value;
+        end
+        function obj = set.basisNorm(obj,value)
+            obj.basisNorm = value;
         end
         function obj = set.posFuncType(obj,type)
             obj.posFuncType = type;
@@ -59,6 +63,7 @@ classdef MapOptions
             optionsArray{9} = obj.contDeriv;
             optionsArray{10} = obj.basisLB;
             optionsArray{11} = obj.basisUB;
+            optionsArray{12} = obj.basisNorm;
         end
     end
 

--- a/bindings/matlab/src/ConditionalMap_mex.cpp
+++ b/bindings/matlab/src/ConditionalMap_mex.cpp
@@ -80,7 +80,7 @@ MEX_DEFINE(ConditionalMap_newTriMap) (int nlhs, mxArray* plhs[],
 MEX_DEFINE(ConditionalMap_newTotalTriMap) (int nlhs, mxArray* plhs[],
                                            int nrhs, const mxArray* prhs[]) {
 
-  InputArguments input(nrhs, prhs, 14);
+  InputArguments input(nrhs, prhs, 15);
   OutputArguments output(nlhs, plhs, 1);
   unsigned int inputDim = input.get<unsigned int>(0);
   unsigned int outputDim = input.get<unsigned int>(1);
@@ -90,7 +90,7 @@ MEX_DEFINE(ConditionalMap_newTotalTriMap) (int nlhs, mxArray* plhs[],
                                          input.get<std::string>(5),input.get<double>(6),
                                          input.get<double>(7),input.get<unsigned int>(8),
                                          input.get<unsigned int>(9),input.get<unsigned int>(10),
-                                         input.get<bool>(11),input.get<double>(12),input.get<double>(13));
+                                         input.get<bool>(11),input.get<double>(12),input.get<double>(13),input.get<bool>(14));
 
   output.set(0, Session<ConditionalMapMex>::create(new ConditionalMapMex(inputDim,outputDim,totalOrder,opts)));
 }
@@ -98,14 +98,14 @@ MEX_DEFINE(ConditionalMap_newTotalTriMap) (int nlhs, mxArray* plhs[],
 MEX_DEFINE(ConditionalMap_newMap) (int nlhs, mxArray* plhs[],
                     int nrhs, const mxArray* prhs[]) {
 
-  InputArguments input(nrhs, prhs, 12);
+  InputArguments input(nrhs, prhs, 13);
   OutputArguments output(nlhs, plhs, 1);
   const MultiIndexSet& mset = Session<MultiIndexSet>::getConst(input.get(0));
   MapOptions opts = MapOptionsFromMatlab(input.get<std::string>(1),input.get<std::string>(2),
                                          input.get<std::string>(3),input.get<double>(4),
                                          input.get<double>(5),input.get<unsigned int>(6),
                                          input.get<unsigned int>(7),input.get<unsigned int>(8),
-                                         input.get<bool>(9),input.get<double>(10),input.get<double>(11));
+                                         input.get<bool>(9),input.get<double>(10),input.get<double>(11),input.get<bool>(12));
 
   output.set(0, Session<ConditionalMapMex>::create(new ConditionalMapMex(mset.Fix(),opts)));
 }
@@ -113,14 +113,14 @@ MEX_DEFINE(ConditionalMap_newMap) (int nlhs, mxArray* plhs[],
 MEX_DEFINE(ConditionalMap_newMapFixed) (int nlhs, mxArray* plhs[],
                     int nrhs, const mxArray* prhs[]) {
 
-  InputArguments input(nrhs, prhs, 12);
+  InputArguments input(nrhs, prhs, 13);
   OutputArguments output(nlhs, plhs, 1);
   const FixedMultiIndexSet<MemorySpace>& mset = Session<FixedMultiIndexSet<MemorySpace>>::getConst(input.get(0));
   MapOptions opts = MapOptionsFromMatlab(input.get<std::string>(1),input.get<std::string>(2),
                                          input.get<std::string>(3),input.get<double>(4),
                                          input.get<double>(5),input.get<unsigned int>(6),
                                          input.get<unsigned int>(7),input.get<unsigned int>(8),
-                                         input.get<bool>(9),input.get<double>(10),input.get<double>(11));
+                                         input.get<bool>(9),input.get<double>(10),input.get<double>(11),input.get<bool>(12));
 
   output.set(0, Session<ConditionalMapMex>::create(new ConditionalMapMex(mset,opts)));
 }

--- a/bindings/matlab/src/MexMapOptionsConversions.cpp
+++ b/bindings/matlab/src/MexMapOptionsConversions.cpp
@@ -7,7 +7,7 @@ MapOptions  mpart::MapOptionsFromMatlab(std::string basisType, std::string posFu
                                         std::string quadType, double quadAbsTol,
                                         double quadRelTol, unsigned int quadMaxSub, 
                                         unsigned int quadMinSub,unsigned int quadPts, 
-                                        bool contDeriv, double basisLB, double basisUB)
+                                        bool contDeriv, double basisLB, double basisUB, bool basisNorm)
 {   
     MapOptions opts;
 
@@ -47,6 +47,7 @@ MapOptions  mpart::MapOptionsFromMatlab(std::string basisType, std::string posFu
     opts.contDeriv = contDeriv;
     opts.basisLB = basisLB;
     opts.basisUB = basisUB;
+    opts.basisNorm = basisNorm;
     return opts;
 }
 

--- a/bindings/matlab/src/ParameterizedFunctionBase_mex.cpp
+++ b/bindings/matlab/src/ParameterizedFunctionBase_mex.cpp
@@ -37,7 +37,7 @@ namespace {
 MEX_DEFINE(ParameterizedFunction_newMap) (int nlhs, mxArray* plhs[],
                     int nrhs, const mxArray* prhs[]) {
 
-  InputArguments input(nrhs, prhs, 13);
+  InputArguments input(nrhs, prhs, 14);
   OutputArguments output(nlhs, plhs, 1);
   unsigned int outputDim = input.get<unsigned int>(0);
   const MultiIndexSet& mset = Session<MultiIndexSet>::getConst(input.get(1));
@@ -45,7 +45,7 @@ MEX_DEFINE(ParameterizedFunction_newMap) (int nlhs, mxArray* plhs[],
                                          input.get<std::string>(4),input.get<double>(5),
                                          input.get<double>(6),input.get<unsigned int>(7),
                                          input.get<unsigned int>(8),input.get<unsigned int>(9),
-                                         input.get<bool>(10),input.get<double>(11),input.get<double>(12));
+                                         input.get<bool>(10),input.get<double>(11),input.get<double>(12),input.get<bool>(13));
 
   output.set(0, Session<ParameterizedFunctionMex>::create(new ParameterizedFunctionMex(outputDim,mset.Fix(),opts)));
 }

--- a/bindings/python/src/MapOptions.cpp
+++ b/bindings/python/src/MapOptions.cpp
@@ -35,6 +35,7 @@ void mpart::binding::MapOptionsWrapper(py::module &m)
     .def_readwrite("basisType", &MapOptions::basisType)
     .def_readwrite("basisLB", &MapOptions::basisLB)
     .def_readwrite("basisUB", &MapOptions::basisUB)
+    .def_readwrite("basisNorm", &MapOptions::basisNorm)
     .def_readwrite("posFuncType", &MapOptions::posFuncType)
     .def_readwrite("quadType", &MapOptions::quadType)
     .def_readwrite("quadAbsTol", &MapOptions::quadAbsTol)
@@ -44,7 +45,4 @@ void mpart::binding::MapOptionsWrapper(py::module &m)
     .def_readwrite("quadPts", &MapOptions::quadPts)
     .def_readwrite("contDeriv", &MapOptions::contDeriv);
     
-        
-
-
 }

--- a/src/MapFactory.cpp
+++ b/src/MapFactory.cpp
@@ -23,7 +23,8 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> mpart::MapFactory::CreateCompon
             
             if(isinf(opts.basisLB) && isinf(opts.basisUB)){
                
-                MultivariateExpansionWorker<ProbabilistHermite,MemorySpace> expansion(mset);
+                ProbabilistHermite basis1d(opts.normalizePolys);
+                MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
                 std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
                 switch(opts.posFuncType) {
@@ -38,8 +39,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> mpart::MapFactory::CreateCompon
 
             }else{
 
-                LinearizedBasis<ProbabilistHermite> basis1d(opts.basisLB, opts.basisUB);
-
+                LinearizedBasis<ProbabilistHermite> basis1d(ProbabilistHermite(opts.normalizePolys), opts.basisLB, opts.basisUB);
                 MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
                 std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
@@ -59,7 +59,8 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> mpart::MapFactory::CreateCompon
 
             if(isinf(opts.basisLB) && isinf(opts.basisUB)){
                 
-                MultivariateExpansionWorker<PhysicistHermite, MemorySpace> expansion(mset);
+                PhysicistHermite basis1d(opts.normalizePolys);
+                MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
                 std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
                 switch(opts.posFuncType) {
@@ -74,7 +75,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> mpart::MapFactory::CreateCompon
 
             }else{
 
-                LinearizedBasis<PhysicistHermite> basis1d(opts.basisLB, opts.basisUB);
+                LinearizedBasis<PhysicistHermite> basis1d(PhysicistHermite(opts.normalizePolys), opts.basisLB, opts.basisUB);
                 MultivariateExpansionWorker<decltype(basis1d), MemorySpace> expansion(mset, basis1d);
                 std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
@@ -91,7 +92,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> mpart::MapFactory::CreateCompon
 
         }else if(opts.basisType==BasisTypes::HermiteFunctions){
             if(isinf(opts.basisLB) && isinf(opts.basisUB)){
-                    
+                
                 MultivariateExpansionWorker<HermiteFunction, MemorySpace> expansion(mset);
                 std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
@@ -130,8 +131,9 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> mpart::MapFactory::CreateCompon
         if(opts.basisType==BasisTypes::ProbabilistHermite){
             
             if(isinf(opts.basisLB) && isinf(opts.basisUB)){
-
-                MultivariateExpansionWorker<ProbabilistHermite,MemorySpace> expansion(mset);
+                
+                ProbabilistHermite basis1d(opts.normalizePolys);
+                MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
                 std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
                 switch(opts.posFuncType) {
@@ -146,7 +148,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> mpart::MapFactory::CreateCompon
 
             }else{
                 
-                LinearizedBasis<ProbabilistHermite> basis1d(opts.basisLB, opts.basisUB);
+                LinearizedBasis<ProbabilistHermite> basis1d(ProbabilistHermite(opts.normalizePolys), opts.basisLB, opts.basisUB);
 
                 MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
                 std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
@@ -167,7 +169,8 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> mpart::MapFactory::CreateCompon
 
             if(isinf(opts.basisLB) && isinf(opts.basisUB)){
                     
-                MultivariateExpansionWorker<PhysicistHermite, MemorySpace> expansion(mset);
+                PhysicistHermite basis1d(opts.normalizePolys);
+                MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
                 std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
                 switch(opts.posFuncType) {
@@ -181,7 +184,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> mpart::MapFactory::CreateCompon
                 return output;
             }else{
 
-                LinearizedBasis<PhysicistHermite> basis1d(opts.basisLB, opts.basisUB);
+                LinearizedBasis<PhysicistHermite> basis1d(PhysicistHermite(opts.normalizePolys), opts.basisLB, opts.basisUB);
                 MultivariateExpansionWorker<decltype(basis1d), MemorySpace> expansion(mset, basis1d);
                 std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
@@ -237,7 +240,8 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> mpart::MapFactory::CreateCompon
             
             if(isinf(opts.basisLB) && isinf(opts.basisUB)){
 
-                MultivariateExpansionWorker<ProbabilistHermite,MemorySpace> expansion(mset);
+                ProbabilistHermite basis1d(opts.normalizePolys);
+                MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
                 std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
                 switch(opts.posFuncType) {
@@ -252,7 +256,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> mpart::MapFactory::CreateCompon
 
             }else{
                 
-                LinearizedBasis<ProbabilistHermite> basis1d(opts.basisLB, opts.basisUB);
+                LinearizedBasis<ProbabilistHermite> basis1d(ProbabilistHermite(opts.normalizePolys), opts.basisLB, opts.basisUB);
 
                 MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
                 std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
@@ -273,7 +277,8 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> mpart::MapFactory::CreateCompon
 
             if(isinf(opts.basisLB) && isinf(opts.basisUB)){
                     
-                MultivariateExpansionWorker<PhysicistHermite, MemorySpace> expansion(mset);
+                PhysicistHermite basis1d(opts.normalizePolys);
+                MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
                 std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
                 switch(opts.posFuncType) {
@@ -287,7 +292,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> mpart::MapFactory::CreateCompon
                 return output;
             }else{
 
-                LinearizedBasis<PhysicistHermite> basis1d(opts.basisLB, opts.basisUB);
+                LinearizedBasis<PhysicistHermite> basis1d(PhysicistHermite(opts.normalizePolys), opts.basisLB, opts.basisUB);
                 MultivariateExpansionWorker<decltype(basis1d), MemorySpace> expansion(mset, basis1d);
                 std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
@@ -374,19 +379,19 @@ std::shared_ptr<ParameterizedFunctionBase<MemorySpace>> mpart::MapFactory::Creat
     if(opts.basisType==BasisTypes::ProbabilistHermite){
         
         if(isinf(opts.basisLB) && isinf(opts.basisUB)){
-            ProbabilistHermite basis1d;
+            ProbabilistHermite basis1d(opts.normalizePolys);
             output = std::make_shared<MultivariateExpansion<ProbabilistHermite, MemorySpace>>(outputDim, mset, basis1d);
         }else{
-            LinearizedBasis<ProbabilistHermite> basis1d(opts.basisLB, opts.basisUB);
+            LinearizedBasis<ProbabilistHermite> basis1d(ProbabilistHermite(opts.normalizePolys), opts.basisLB, opts.basisUB);
             output = std::make_shared<MultivariateExpansion<decltype(basis1d), MemorySpace>>(outputDim, mset, basis1d);
         }
     }else if(opts.basisType==BasisTypes::PhysicistHermite){
 
         if(isinf(opts.basisLB) && isinf(opts.basisUB)){
-            PhysicistHermite basis1d;
+            PhysicistHermite basis1d(opts.normalizePolys);
             output = std::make_shared<MultivariateExpansion<PhysicistHermite, MemorySpace>>(outputDim, mset, basis1d);
         }else{
-            LinearizedBasis<PhysicistHermite> basis1d(opts.basisLB, opts.basisUB);
+            LinearizedBasis<PhysicistHermite> basis1d(PhysicistHermite(opts.normalizePolys), opts.basisLB, opts.basisUB);
             output = std::make_shared<MultivariateExpansion<decltype(basis1d), MemorySpace>>(outputDim, mset, basis1d);
         }
     }else if(opts.basisType==BasisTypes::HermiteFunctions){

--- a/src/MapFactory.cpp
+++ b/src/MapFactory.cpp
@@ -23,7 +23,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> mpart::MapFactory::CreateCompon
             
             if(isinf(opts.basisLB) && isinf(opts.basisUB)){
                
-                ProbabilistHermite basis1d(opts.normalizePolys);
+                ProbabilistHermite basis1d(opts.basisNorm);
                 MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
                 std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
@@ -39,7 +39,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> mpart::MapFactory::CreateCompon
 
             }else{
 
-                LinearizedBasis<ProbabilistHermite> basis1d(ProbabilistHermite(opts.normalizePolys), opts.basisLB, opts.basisUB);
+                LinearizedBasis<ProbabilistHermite> basis1d(ProbabilistHermite(opts.basisNorm), opts.basisLB, opts.basisUB);
                 MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
                 std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
@@ -59,7 +59,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> mpart::MapFactory::CreateCompon
 
             if(isinf(opts.basisLB) && isinf(opts.basisUB)){
                 
-                PhysicistHermite basis1d(opts.normalizePolys);
+                PhysicistHermite basis1d(opts.basisNorm);
                 MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
                 std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
@@ -75,7 +75,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> mpart::MapFactory::CreateCompon
 
             }else{
 
-                LinearizedBasis<PhysicistHermite> basis1d(PhysicistHermite(opts.normalizePolys), opts.basisLB, opts.basisUB);
+                LinearizedBasis<PhysicistHermite> basis1d(PhysicistHermite(opts.basisNorm), opts.basisLB, opts.basisUB);
                 MultivariateExpansionWorker<decltype(basis1d), MemorySpace> expansion(mset, basis1d);
                 std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
@@ -132,7 +132,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> mpart::MapFactory::CreateCompon
             
             if(isinf(opts.basisLB) && isinf(opts.basisUB)){
                 
-                ProbabilistHermite basis1d(opts.normalizePolys);
+                ProbabilistHermite basis1d(opts.basisNorm);
                 MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
                 std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
@@ -148,7 +148,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> mpart::MapFactory::CreateCompon
 
             }else{
                 
-                LinearizedBasis<ProbabilistHermite> basis1d(ProbabilistHermite(opts.normalizePolys), opts.basisLB, opts.basisUB);
+                LinearizedBasis<ProbabilistHermite> basis1d(ProbabilistHermite(opts.basisNorm), opts.basisLB, opts.basisUB);
 
                 MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
                 std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
@@ -169,7 +169,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> mpart::MapFactory::CreateCompon
 
             if(isinf(opts.basisLB) && isinf(opts.basisUB)){
                     
-                PhysicistHermite basis1d(opts.normalizePolys);
+                PhysicistHermite basis1d(opts.basisNorm);
                 MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
                 std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
@@ -184,7 +184,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> mpart::MapFactory::CreateCompon
                 return output;
             }else{
 
-                LinearizedBasis<PhysicistHermite> basis1d(PhysicistHermite(opts.normalizePolys), opts.basisLB, opts.basisUB);
+                LinearizedBasis<PhysicistHermite> basis1d(PhysicistHermite(opts.basisNorm), opts.basisLB, opts.basisUB);
                 MultivariateExpansionWorker<decltype(basis1d), MemorySpace> expansion(mset, basis1d);
                 std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
@@ -240,7 +240,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> mpart::MapFactory::CreateCompon
             
             if(isinf(opts.basisLB) && isinf(opts.basisUB)){
 
-                ProbabilistHermite basis1d(opts.normalizePolys);
+                ProbabilistHermite basis1d(opts.basisNorm);
                 MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
                 std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
@@ -256,7 +256,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> mpart::MapFactory::CreateCompon
 
             }else{
                 
-                LinearizedBasis<ProbabilistHermite> basis1d(ProbabilistHermite(opts.normalizePolys), opts.basisLB, opts.basisUB);
+                LinearizedBasis<ProbabilistHermite> basis1d(ProbabilistHermite(opts.basisNorm), opts.basisLB, opts.basisUB);
 
                 MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
                 std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
@@ -277,7 +277,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> mpart::MapFactory::CreateCompon
 
             if(isinf(opts.basisLB) && isinf(opts.basisUB)){
                     
-                PhysicistHermite basis1d(opts.normalizePolys);
+                PhysicistHermite basis1d(opts.basisNorm);
                 MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
                 std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
@@ -292,7 +292,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> mpart::MapFactory::CreateCompon
                 return output;
             }else{
 
-                LinearizedBasis<PhysicistHermite> basis1d(PhysicistHermite(opts.normalizePolys), opts.basisLB, opts.basisUB);
+                LinearizedBasis<PhysicistHermite> basis1d(PhysicistHermite(opts.basisNorm), opts.basisLB, opts.basisUB);
                 MultivariateExpansionWorker<decltype(basis1d), MemorySpace> expansion(mset, basis1d);
                 std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
@@ -379,19 +379,19 @@ std::shared_ptr<ParameterizedFunctionBase<MemorySpace>> mpart::MapFactory::Creat
     if(opts.basisType==BasisTypes::ProbabilistHermite){
         
         if(isinf(opts.basisLB) && isinf(opts.basisUB)){
-            ProbabilistHermite basis1d(opts.normalizePolys);
+            ProbabilistHermite basis1d(opts.basisNorm);
             output = std::make_shared<MultivariateExpansion<ProbabilistHermite, MemorySpace>>(outputDim, mset, basis1d);
         }else{
-            LinearizedBasis<ProbabilistHermite> basis1d(ProbabilistHermite(opts.normalizePolys), opts.basisLB, opts.basisUB);
+            LinearizedBasis<ProbabilistHermite> basis1d(ProbabilistHermite(opts.basisNorm), opts.basisLB, opts.basisUB);
             output = std::make_shared<MultivariateExpansion<decltype(basis1d), MemorySpace>>(outputDim, mset, basis1d);
         }
     }else if(opts.basisType==BasisTypes::PhysicistHermite){
 
         if(isinf(opts.basisLB) && isinf(opts.basisUB)){
-            PhysicistHermite basis1d(opts.normalizePolys);
+            PhysicistHermite basis1d(opts.basisNorm);
             output = std::make_shared<MultivariateExpansion<PhysicistHermite, MemorySpace>>(outputDim, mset, basis1d);
         }else{
-            LinearizedBasis<PhysicistHermite> basis1d(PhysicistHermite(opts.normalizePolys), opts.basisLB, opts.basisUB);
+            LinearizedBasis<PhysicistHermite> basis1d(PhysicistHermite(opts.basisNorm), opts.basisLB, opts.basisUB);
             output = std::make_shared<MultivariateExpansion<decltype(basis1d), MemorySpace>>(outputDim, mset, basis1d);
         }
     }else if(opts.basisType==BasisTypes::HermiteFunctions){

--- a/tests/Test_MapFactory.cpp
+++ b/tests/Test_MapFactory.cpp
@@ -16,6 +16,7 @@ TEST_CASE( "Testing map component factory", "[MapFactoryComponent]" ) {
     
     MapOptions options;
     options.basisType = BasisTypes::ProbabilistHermite;
+    options.normalizePolys = false;
 
     unsigned int dim = 3;
     unsigned int maxDegree = 5;
@@ -72,10 +73,13 @@ TEST_CASE( "Testing map component factory with linearized basis", "[MapFactoryLi
     options.basisType = BasisTypes::ProbabilistHermite;
     options.basisLB = -5;
     options.basisUB = 4;
+    options.normalizePolys = false;
+    
     
     MapOptions options2;
     options2.basisType = BasisTypes::ProbabilistHermite;
-
+    options2.normalizePolys = false;
+    
     unsigned int dim = 1;
     unsigned int maxDegree = 7;
     FixedMultiIndexSet<MemorySpace> mset(dim,maxDegree);
@@ -123,7 +127,7 @@ TEST_CASE( "Testing multivariate expansion factory", "[MapFactoryExpansion]" ) {
 
     MapOptions options;
     options.basisType = BasisTypes::ProbabilistHermite;
-
+    
     unsigned int outDim = 5;
     unsigned int inDim = 3;
     unsigned int maxDegree = 5;
@@ -147,7 +151,6 @@ TEST_CASE( "Testing factory method for triangular map", "[MapFactoryTriangular]"
 
     MapOptions options;
     options.basisType = BasisTypes::ProbabilistHermite;
-
 
     std::shared_ptr<ConditionalMapBase<MemorySpace>> map = MapFactory::CreateTriangular<MemorySpace>(4,3,5, options);
 

--- a/tests/Test_MapFactory.cpp
+++ b/tests/Test_MapFactory.cpp
@@ -16,7 +16,7 @@ TEST_CASE( "Testing map component factory", "[MapFactoryComponent]" ) {
     
     MapOptions options;
     options.basisType = BasisTypes::ProbabilistHermite;
-    options.normalizePolys = false;
+    options.basisNorm = false;
 
     unsigned int dim = 3;
     unsigned int maxDegree = 5;
@@ -73,12 +73,12 @@ TEST_CASE( "Testing map component factory with linearized basis", "[MapFactoryLi
     options.basisType = BasisTypes::ProbabilistHermite;
     options.basisLB = -5;
     options.basisUB = 4;
-    options.normalizePolys = false;
+    options.basisNorm = false;
     
     
     MapOptions options2;
     options2.basisType = BasisTypes::ProbabilistHermite;
-    options2.normalizePolys = false;
+    options2.basisNorm = false;
     
     unsigned int dim = 1;
     unsigned int maxDegree = 7;

--- a/tests/Test_OrthogonalPolynomials.cpp
+++ b/tests/Test_OrthogonalPolynomials.cpp
@@ -8,6 +8,61 @@ using namespace mpart;
 using namespace Catch;
 
 
+TEST_CASE( "Testing Probabilist Hermite normalization", "[ProbabilistHermiteNorm]" ) {
+
+    ProbabilistHermite poly(false);
+
+    // Gauss-Hermite quadrature points to integrate with exp(-0.5x^2) weight function
+    Eigen::VectorXd quadPts(15);
+    quadPts << -6.363947888829836,    
+            -5.190093591304779,    
+            -4.196207711269016,    
+            -3.289082424398763,    
+            -2.432436827009758,    
+            -1.606710069028730,    
+            -0.7991290683245480,    
+            0,
+            0.7991290683245480,    
+            1.606710069028730,    
+            2.432436827009756,    
+            3.289082424398766,    
+            4.196207711269015,    
+            5.190093591304779,    
+            6.363947888829833;  
+
+   // Pulled from https://people.math.sc.edu/Burkardt/datasets/quadrature_rules_hermite_probabilist/hermite_probabilist_015_w.txt
+   Eigen::VectorXd quadWts(15);
+   quadWts << 0.2153105930760208E-08,
+            0.1497815571693205E-05,
+            0.1414276370885442E-03,
+            0.3928782634853375E-02,
+            0.4352954135285805E-01,
+            0.2241371742044199,    
+            0.5826965579477278,    
+            0.7977583071397497,    
+            0.5826965579477275,    
+            0.2241371742044203,    
+            0.4352954135285790E-01,
+            0.3928782634853367E-02,
+            0.1414276370885451E-03,
+            0.1497815571693205E-05,
+            0.2153105930760234E-08;
+
+
+    Eigen::VectorXd evals(15);
+    for(unsigned int order=0; order<10; ++order){
+        for(unsigned int i=0; i<quadWts.size(); ++i)
+            evals(i) = std::pow(poly.Evaluate(order, quadPts(i)), 2.0);
+        
+        double quadNorm = std::sqrt( (evals.array() * quadWts.array()).sum());
+        double classNorm = poly.Normalization(order);
+
+        CHECK(classNorm == Approx(quadNorm).epsilon(1e-7));
+    }
+
+}
+
+
 TEST_CASE( "Testing Probabilist Hermite polynomials", "[ProbabilistHermite]" ) {
 
     const double floatTol = 1e-15;
@@ -87,6 +142,62 @@ TEST_CASE( "Testing Probabilist Hermite polynomials", "[ProbabilistHermite]" ) {
         CHECK( allderivs2[2] == Approx(2.0).epsilon(floatTol) );
         CHECK( allderivs2[3] == Approx(6.0*x).epsilon(floatTol) );
         CHECK( allderivs2[4] == Approx(12.0*x*x - 12.0).epsilon(floatTol) );
+    }
+
+}
+
+
+
+TEST_CASE( "Testing Physicist Hermite normalization", "[PhysicistHermiteNorm]" ) {
+
+    PhysicistHermite poly(false);
+
+    // Gauss-Hermite quadrature points to integrate with exp(-0.5x^2) weight function
+    Eigen::VectorXd quadPts(15);
+    quadPts <<   -4.499990707309390,    
+                -3.669950373404451,    
+                -2.967166927905604,    
+                -2.325732486173856,    
+                -1.719992575186489,    
+                -1.136115585210921,    
+                -0.5650695832555758,    
+                0,
+                0.5650695832555758,    
+                1.136115585210921,    
+                1.719992575186488,    
+                2.325732486173858,    
+                2.967166927905603,    
+                3.669950373404451,    
+                4.499990707309388; 
+
+   // Pulled from https://people.math.sc.edu/Burkardt/datasets/quadrature_rules_hermite_physicist/hermite_physicist_015_w.txt
+   Eigen::VectorXd quadWts(15);
+   quadWts <<   0.1522475804253516E-08,
+                0.1059115547711071E-05,
+                0.1000044412324996E-03,
+                0.2778068842912774E-02,
+                0.3078003387254618E-01,
+                0.1584889157959359,    
+                0.4120286874988984,    
+                0.5641003087264176,    
+                0.4120286874988981,    
+                0.1584889157959361,    
+                0.3078003387254607E-01,
+                0.2778068842912767E-02,
+                0.1000044412325003E-03,
+                0.1059115547711071E-05,
+                0.1522475804253535E-08;
+
+
+    Eigen::VectorXd evals(15);
+    for(unsigned int order=0; order<10; ++order){
+        for(unsigned int i=0; i<quadWts.size(); ++i)
+            evals(i) = std::pow(poly.Evaluate(order, quadPts(i)), 2.0);
+        
+        double quadNorm = std::sqrt( (evals.array() * quadWts.array()).sum());
+        double classNorm = poly.Normalization(order);
+
+        CHECK(classNorm == Approx(quadNorm).epsilon(1e-7));
     }
 
 }

--- a/tests/Test_TriangularMap.cpp
+++ b/tests/Test_TriangularMap.cpp
@@ -11,7 +11,8 @@ TEST_CASE( "Testing 3d triangular map from MonotoneComponents", "[TriangularMap_
 
     MapOptions options;
     options.basisType = BasisTypes::ProbabilistHermite;
-
+    options.normalizePolys = false;
+    
     unsigned int numBlocks = 3;
     unsigned int maxDegree = 2;
     unsigned int extraInputs = 1;

--- a/tests/Test_TriangularMap.cpp
+++ b/tests/Test_TriangularMap.cpp
@@ -11,7 +11,7 @@ TEST_CASE( "Testing 3d triangular map from MonotoneComponents", "[TriangularMap_
 
     MapOptions options;
     options.basisType = BasisTypes::ProbabilistHermite;
-    options.normalizePolys = false;
+    options.basisNorm = false;
     
     unsigned int numBlocks = 3;
     unsigned int maxDegree = 2;


### PR DESCRIPTION
- Added ability to normalize orthogonal polynomials so that the inner product of p_n(x) with p_n(x) is 1.0 (with the weighting corresponding to the polynomial family).
- Added `basisNorm` option to `MapOptions` to allow normalization to be controlled during map construction.
- Added `basisNorm` option to all language bindings.