### PR TITLE
Fix indexing for MultiIndexSets

### DIFF
--- a/bindings/julia/src/MultiIndex.cpp
+++ b/bindings/julia/src/MultiIndex.cpp
@@ -54,9 +54,9 @@ void mpart::binding::MultiIndexWrapper(jlcxx::Module &mod) {
 
     mod.set_override_module(jl_base_module);
     mod.method("sum", [](MultiIndex const& idx){ return idx.Sum(); });
-    mod.method("setindex!", [](MultiIndex& idx, unsigned int val, unsigned int ind) { return idx.Set(ind, val); });
-    mod.method("getindex", [](MultiIndex const& idx, unsigned int ind) { return idx.Get(ind); });
-    mod.method("getindex", [](MultiIndexSet const& idx, int ind) { return idx.at(ind); });
+    mod.method("setindex!", [](MultiIndex& idx, unsigned int val, unsigned int ind) { return idx.Set(ind-1, val); });
+    mod.method("getindex", [](MultiIndex const& idx, unsigned int ind) { return idx.Get(ind-1); });
+    mod.method("getindex", [](MultiIndexSet const& idx, int ind) { return idx.at(ind-1); });
     mod.method("maximum", [](MultiIndex const& idx){ return idx.Max(); });
     mod.method("string", [](MultiIndex const& idx){ return idx.String(); });
     mod.method("length", [](MultiIndex const& idx){ return idx.Length(); });


### PR DESCRIPTION
I realized that I messed up one-based vs. zero-based indexing in the bindings :/