### PR TITLE
Added Checkpointing to ComposedMap class.

### DIFF
--- a/MParT/ComposedMap.h
+++ b/MParT/ComposedMap.h
@@ -27,6 +27,10 @@ for \f$x_{N_i-M_i:N_i}\f$ given a vector \f$r\in\mathbb{R}^{M_i}\f$ and previous
 This block triangular form is analogous to a block triangular matrix where each \f$M_i\timesM_i\f$ diagonal block
 is positive definite.
 
+Checkpointing can be used for deep maps to reduce the amount of memory that is required for gradient computations.
+The checkpointing logic was adapted from the :code:`revolve` algorithm of `[Griewank and Walther, 2000] <https://dl.acm.org/doi/10.1145/347837.347846>`_,
+which is an optimal binomial checkpointing scheme.
+
  */
 template<typename MemorySpace>
 class ComposedMap : public ConditionalMapBase<MemorySpace>
@@ -37,8 +41,10 @@ public:
 
     @param components A vector of ConditionalMapBase objects defining each \f$T_k\f$ in the block triangular map.
                       To maintain the correct block structure, the dimensions of the components must satisfy \f$N_k = N_{k-1}+M_{k}\f$.
+    @param maxChecks The maximum number of checkpoints to use during gradient computations.  If maxChecks==1, then no checkpointing will be utilized and all forward states will be recomputed.  If maxChecks==components.size(), then all states will be stored and reused during the backward pass.  This is the most efficient option, but can require an intractable amount of memory for high-dimensional or deep parameterizations.   The default value is -1, which will set the maximum number of checkpoints to be equal to the number of layers (i.e., map.size()). 
     */
-    ComposedMap(std::vector<std::shared_ptr<ConditionalMapBase<MemorySpace>>> const& components);
+    ComposedMap(std::vector<std::shared_ptr<ConditionalMapBase<MemorySpace>>> const& components,
+                int maxChecks=-1);
 
     virtual ~ComposedMap() = default;
 
@@ -116,8 +122,10 @@ public:
 private:
 
     std::vector<std::shared_ptr<ConditionalMapBase<MemorySpace>>> comps_;
+    unsigned int maxChecks_;
 
 
+    /* Class for coordinating checkpoints during gradient evaluations. */
     class Checkpointer {
     public:
 
@@ -134,6 +142,14 @@ private:
         Kokkos::View<double**, Kokkos::LayoutLeft, MemorySpace> GetLayerInput(unsigned int layerInd);
 
     protected:
+
+        /** Given the current state of the checkpoints and a need to evaluate the input to layer layerInd, this 
+            function computes the next layer input that should be checkpointed.
+            @param[in] layerInd The index of the layer that we eventually want to get the input for.
+            @return An integer specifying the next layer index that should be checkpointed in a forward pass.
+        */
+        int GetNextCheckpoint(unsigned int layerInd) const;
+
         const unsigned int maxSaves_;
         
         Kokkos::View<double**, Kokkos::LayoutLeft, MemorySpace> workspace1_;

--- a/tests/Test_ComposedMap.cpp
+++ b/tests/Test_ComposedMap.cpp
@@ -9,7 +9,7 @@ using namespace mpart;
 using namespace Catch;
 using MemorySpace = Kokkos::HostSpace;
 
-TEST_CASE( "Testing 5 layer composed map", "[ComposedMap_Constructor]" ) {
+TEST_CASE( "Testing 2 layer composed map", "[ShallowComposedMap]" ) {
 
     MapOptions options;
     options.basisType = BasisTypes::ProbabilistHermite;
@@ -245,5 +245,157 @@ TEST_CASE( "Testing 5 layer composed map", "[ComposedMap_Constructor]" ) {
         }
 
     }
+
+}
+
+
+TEST_CASE( "Testing 10 layer composed map", "[DeepComposedMap]" ) {
+
+    MapOptions options;
+    options.basisType = BasisTypes::ProbabilistHermite;
+    
+    unsigned int dim = 2;
+    unsigned int numMaps = 8;
+    unsigned int order = 1;
+    unsigned int coeffSize = 0;
+    int numChecks = 3; // number of checkpoints to use (including storing initial points)
+
+    std::vector<std::shared_ptr<ConditionalMapBase<MemorySpace>>> maps(numMaps);
+    for(unsigned int i=0;i<numMaps;++i){
+
+        maps.at(i) = MapFactory::CreateTriangular<Kokkos::HostSpace>(dim, dim, order, options);
+        coeffSize += maps.at(i)->numCoeffs;
+    }
+
+    std::shared_ptr<ConditionalMapBase<MemorySpace>> composedMap = std::make_shared<ComposedMap<MemorySpace>>(maps, numChecks);
+
+    Eigen::RowVectorXd coeffs(composedMap->numCoeffs);
+    for(unsigned int i=0; i<composedMap->numCoeffs; ++i)
+        coeffs(i) = 0.1*(i+1);
+    
+
+    unsigned int numSamps = 10;
+    Kokkos::View<double**, Kokkos::HostSpace> in("Map Input", dim, numSamps);
+    //Eigen::RowMatrixXd in(dim, numSamps);
+    for(unsigned int i=0; i<dim; ++i){
+        for(unsigned int j=0; j<numSamps; ++j){
+            in(i,j) = double(i)/(dim) + double(j)/numSamps;
+        }
+    }
+
+    composedMap->SetCoeffs(coeffs);
+    auto out = composedMap->Evaluate(in);
+    
+    SECTION("Evaluate"){
+        Kokkos::View<double**, Kokkos::HostSpace> trueOut("True output", dim, numSamps);
+        Kokkos::deep_copy(trueOut, in);
+        for(auto& comp : maps)
+            trueOut = comp->Evaluate(trueOut);
+
+        for(unsigned int i=0; i<in.extent(0); ++i){
+            for(unsigned int j=0; j<numSamps; ++j)
+                CHECK( out(i,j) == Approx(trueOut(i,j)).epsilon(1e-7).margin(1e-7));
+        }
+    }
+
+    SECTION("LogDeterminant"){
+        auto logDet = composedMap->LogDeterminant(in);
+
+        REQUIRE(logDet.extent(0)==numSamps);
+        Kokkos::View<double*, Kokkos::HostSpace> truth("True Log Det", numSamps);
+        Kokkos::View<double*, Kokkos::HostSpace> partialDet("Partial log det", numSamps);
+        Kokkos::View<double**, Kokkos::HostSpace> currPts("intermediate points", in.extent(0), in.extent(1));
+        Kokkos::deep_copy(currPts, in);
+
+        for(auto& map : maps){
+            partialDet = map->LogDeterminant(currPts);
+            currPts = map->Evaluate(currPts);
+            truth += partialDet;
+        }
+
+        for(unsigned int j=0; j<numSamps; ++j)
+            CHECK(logDet(j) == Approx(truth(j)).epsilon(1e-10));
+
+    }
+
+    SECTION("CoeffGrad"){
+
+        Kokkos::View<double**,Kokkos::HostSpace> sens("Sensitivities", composedMap->outputDim, numSamps);
+        
+        for(unsigned int j=0; j<numSamps; ++j){
+            for(unsigned int i=0; i<composedMap->outputDim; ++i){
+                sens(i,j) = 1.0 + 0.1*i + j;
+            }
+        }
+
+        Kokkos::View<double**,Kokkos::HostSpace> evals = composedMap->Evaluate(in);
+        Kokkos::View<double**,Kokkos::HostSpace> evals2;
+
+        Kokkos::View<double**,Kokkos::HostSpace> coeffGrad = composedMap->CoeffGrad(in, sens);
+
+        REQUIRE(coeffGrad.extent(0)==composedMap->numCoeffs);
+        REQUIRE(coeffGrad.extent(1)==numSamps);
+
+        // Compare with finite differences
+        double fdstep = 1e-5;
+        for(unsigned int i=0; i<composedMap->numCoeffs; ++i){
+            coeffs(i) += fdstep;
+
+            composedMap->SetCoeffs(coeffs);
+            evals2 = composedMap->Evaluate(in);
+
+            for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd){
+                
+                double fdDeriv = 0.0;
+                for(unsigned int j=0; j<composedMap->outputDim; ++j)
+                    fdDeriv += sens(j,ptInd) * (evals2(j,ptInd)-evals(j,ptInd))/fdstep;
+
+                CHECK( coeffGrad(i,ptInd) == Approx(fdDeriv).margin(1e-3)); 
+            }
+            coeffs(i) -= fdstep;
+        }
+        
+    }
+
+
+    // SECTION("Input Gradient"){
+
+    //     Kokkos::View<double**,Kokkos::HostSpace> sens("Sensitivities", composedMap->outputDim, numSamps);
+    //     for(unsigned int j=0; j<numSamps; ++j){
+    //         for(unsigned int i=0; i<composedMap->outputDim; ++i){
+    //             sens(i,j) = 1.0 + 0.1*i + j;
+    //         }
+    //     }
+
+    //     Kokkos::View<double**,Kokkos::HostSpace> evals = composedMap->Evaluate(in);
+    //     Kokkos::View<double**,Kokkos::HostSpace> evals2;
+
+    //     Kokkos::View<double**,Kokkos::HostSpace> inputGrad = composedMap->Gradient(in, sens);
+
+    //     REQUIRE(inputGrad.extent(0)==composedMap->inputDim);
+    //     REQUIRE(inputGrad.extent(1)==numSamps);
+
+    //     // Compare with finite differences
+    //     double fdstep = 1e-5;
+    //     for(unsigned int i=0; i<composedMap->inputDim; ++i){
+    //         for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd)
+    //             in(i,ptInd) += fdstep;
+
+    //         evals2 = composedMap->Evaluate(in);
+
+    //         for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd){
+                
+    //             double fdDeriv = 0.0;
+    //             for(unsigned int j=0; j<composedMap->outputDim; ++j)
+    //                 fdDeriv += sens(j,ptInd) * (evals2(j,ptInd)-evals(j,ptInd))/fdstep;
+
+    //             CHECK( inputGrad(i,ptInd) == Approx(fdDeriv).margin(1e-3)); 
+    //         }
+
+    //         for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd)
+    //             in(i,ptInd) -= fdstep;
+    //     }
+        
+    // }
 
 }


### PR DESCRIPTION
Checkpointing based on the classic binomial approach of [[Griewank and Walther, 2000]](https://dl.acm.org/doi/10.1145/347837.347846) that seems to be used almost everywhere.   The number of checkpoints is passed to the constructor of the `ComposedMap` class and can be set based on the size of the problem and memory limitations.

There are two limiting cases:
1. If the number of checkpoints is set to 1, all previous layers are recomputed every step of the backward pass, just like we were doing before.
2. If the number of checkpoints is greater than or equal to the number of layers, then the inputs to every layer are stored.  This requires the least computation but the most memory.   

A limited amount of recomputation is  performed for any other number of checkpoints.   