### PR TITLE
Add slicing for `TriangularMap` class

### DIFF
--- a/MParT/MapFactory.h
+++ b/MParT/MapFactory.h
@@ -4,6 +4,7 @@
 #include "MParT/MapOptions.h"
 
 #include "MParT/ConditionalMapBase.h"
+#include "MParT/TriangularMap.h"
 #include "MParT/MultiIndices/FixedMultiIndexSet.h"
 
 #include <math.h>
@@ -34,7 +35,7 @@ namespace mpart{
     auto map = MapFactory::CreateTriangular<Kokkos::HostSpace>(inDim, outDim, totalOrder, options);
 
      @endcode
-     
+
      */
     namespace MapFactory{
 
@@ -61,7 +62,7 @@ namespace mpart{
             @param options Additional options that will be passed on to CreateComponent to construct each MonotoneComponent.
          */
         template<typename MemorySpace>
-        std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateTriangular(unsigned int inputDim,
+        std::shared_ptr<TriangularMap<MemorySpace>> CreateTriangular(unsigned int inputDim,
                                                                           unsigned int outputDim,
                                                                           unsigned int totalOrder,
                                                                           MapOptions options = MapOptions());
@@ -79,7 +80,7 @@ namespace mpart{
 
 
 
-        /** This struct is used to map the options to functions that can create a map component with types corresponding 
+        /** This struct is used to map the options to functions that can create a map component with types corresponding
             to the options.
         */
         template<typename MemorySpace>
@@ -98,14 +99,14 @@ namespace mpart{
                 auto iter = factoryMap->find(optionsKey);
                 if(iter == factoryMap->end())
                     throw std::runtime_error("Could not find registered factory method for given MapOptions.");
-                
+
                 return iter->second;
             }
 
             static std::shared_ptr<FactoryMapType> GetFactoryMap()
             {
                 static std::shared_ptr<FactoryMapType> map;
-                if( !map ) 
+                if( !map )
                     map = std::make_shared<FactoryMapType>();
                 return map;
             }

--- a/MParT/TriangularMap.h
+++ b/MParT/TriangularMap.h
@@ -58,14 +58,14 @@ public:
     #endif
 
     /** @brief Returns a subsection of the map
-     * @details This function returns a subsection (or "slice") of the map defined by some contiguous subset of the components.
+     * @details This function returns a subsection (or "slice") of the map defined by some contiguous subset of the components, python-style indices.
      * @param a The index of the first component to take
-     * @param b The index of the last component to take
+     * @param b The index AFTER the last component to take
      * @return A shared pointer to a new TriangularMap object containing the subsection of the map.
      */
     std::shared_ptr<TriangularMap<MemorySpace>> Slice(int a, int b) const {
         std::vector<std::shared_ptr<ConditionalMapBase<MemorySpace>>> components;
-        for(int i=a; i<=b; i++){
+        for(int i=a; i<b; i++){
             components.push_back(this->comps_[i]);
         }
         return std::make_shared<TriangularMap<MemorySpace>>(components);

--- a/MParT/TriangularMap.h
+++ b/MParT/TriangularMap.h
@@ -29,7 +29,7 @@ is positive definite.
  */
 template<typename MemorySpace>
 class TriangularMap : public ConditionalMapBase<MemorySpace>{
-        
+
 public:
 
     /** @brief Construct a block triangular map from a collection of other ConditionalMapBase objects.
@@ -55,8 +55,22 @@ public:
     #if defined(MPART_ENABLE_GPU)
     virtual void SetCoeffs(Kokkos::View<double*, Kokkos::DefaultExecutionSpace::memory_space> coeffs) override;
     virtual void WrapCoeffs(Kokkos::View<double*, mpart::DeviceSpace> coeffs) override;
-    #endif 
-    
+    #endif
+
+    /** @brief Returns a subsection of the map
+     * @details This function returns a subsection (or "slice") of the map defined by some contiguous subset of the components.
+     * @param a The index of the first component to take
+     * @param b The index of the last component to take
+     * @return A shared pointer to a new TriangularMap object containing the subsection of the map.
+     */
+    std::shared_ptr<TriangularMap<MemorySpace>> Slice(int a, int b) const {
+        std::vector<std::shared_ptr<ConditionalMapBase<MemorySpace>>> components;
+        for(int i=a; i<=b; i++){
+            components.push_back(this->comps_[i]);
+        }
+        return std::make_shared<TriangularMap<MemorySpace>>(components);
+    }
+
     virtual std::shared_ptr<ConditionalMapBase<MemorySpace>> GetComponent(unsigned int i){ return comps_.at(i);}
 
     /** @brief Computes the log determinant of the Jacobian matrix of this map.
@@ -80,10 +94,10 @@ public:
     void EvaluateImpl(StridedMatrix<const double, MemorySpace> const& pts,
                       StridedMatrix<double, MemorySpace>              output) override;
 
-    virtual void GradientImpl(StridedMatrix<const double, MemorySpace> const& pts,  
+    virtual void GradientImpl(StridedMatrix<const double, MemorySpace> const& pts,
                               StridedMatrix<const double, MemorySpace> const& sens,
                               StridedMatrix<double, MemorySpace>              output) override;
-    
+
     /** @brief Evaluates the map inverse.
 
     @details To understand this function, consider splitting the map input \f$x_{1:N}\f$ into two parts so that \f$x_{1:N} = [x_{1:N-M},x_{N-M+1:M}]\f$.  Note that the
@@ -105,15 +119,15 @@ public:
                                 StridedMatrix<const double, MemorySpace> const& r);
 
 
-    virtual void CoeffGradImpl(StridedMatrix<const double, MemorySpace> const& pts,  
+    virtual void CoeffGradImpl(StridedMatrix<const double, MemorySpace> const& pts,
                                StridedMatrix<const double, MemorySpace> const& sens,
                                StridedMatrix<double, MemorySpace>              output) override;
 
 
-    virtual void LogDeterminantCoeffGradImpl(StridedMatrix<const double, MemorySpace> const& pts, 
+    virtual void LogDeterminantCoeffGradImpl(StridedMatrix<const double, MemorySpace> const& pts,
                                              StridedMatrix<double, MemorySpace>              output) override;
-    
-    virtual void LogDeterminantInputGradImpl(StridedMatrix<const double, MemorySpace> const& pts, 
+
+    virtual void LogDeterminantInputGradImpl(StridedMatrix<const double, MemorySpace> const& pts,
                                              StridedMatrix<double, MemorySpace>              output) override;
 private:
 

--- a/bindings/julia/src/TriangularMap.cpp
+++ b/bindings/julia/src/TriangularMap.cpp
@@ -15,5 +15,6 @@ void mpart::binding::TriangularMapWrapper(jlcxx::Module &mod) {
             map.InverseInplace(JuliaToKokkos(x), JuliaToKokkos(r));
        })
        .method("GetComponent", &TriangularMap<Kokkos::HostSpace>::GetComponent)
+       .method("Slice", &TriangularMap<Kokkos::HostSpace>::Slice)
     ;
 }

--- a/bindings/julia/src/TriangularMap.cpp
+++ b/bindings/julia/src/TriangularMap.cpp
@@ -14,7 +14,7 @@ void mpart::binding::TriangularMapWrapper(jlcxx::Module &mod) {
        .method("InverseInplace", [](TriangularMap<Kokkos::HostSpace> &map, jlcxx::ArrayRef<double,2> x, jlcxx::ArrayRef<double,2> r){
             map.InverseInplace(JuliaToKokkos(x), JuliaToKokkos(r));
        })
-       .method("GetComponent", &TriangularMap<Kokkos::HostSpace>::GetComponent)
-       .method("Slice", &TriangularMap<Kokkos::HostSpace>::Slice)
+       .method("GetComponent", [](TriangularMap<Kokkos::HostSpace>& map, int i){ return map.GetComponent(i-1); })
+       .method("Slice", [](TriangularMap<Kokkos::HostSpace>& map, int begin, int end){ return map.Slice(begin-1, end); })
     ;
 }

--- a/bindings/python/src/TriangularMap.cpp
+++ b/bindings/python/src/TriangularMap.cpp
@@ -20,6 +20,12 @@ void mpart::binding::TriangularMapWrapper(py::module &m)
     py::class_<TriangularMap<MemorySpace>, ConditionalMapBase<MemorySpace>, std::shared_ptr<TriangularMap<MemorySpace>>>(m, tName.c_str())
         .def(py::init<std::vector<std::shared_ptr<ConditionalMapBase<MemorySpace>>>>())
         .def("GetComponent", &TriangularMap<MemorySpace>::GetComponent)
+        .def("Slice", &TriangularMap<MemorySpace>::Slice)
+        .def("__getitem__", &TriangularMap<MemorySpace>::GetComponent)
+        .def("__getitem__", [](const TriangularMap<MemorySpace> &m, const py::slice &s) {
+            if(s.stride() != 1) throw std::runtime_error("TriangularMap slice stride must be 1");
+            return m.Slice(s.start(), s.start() + s.size());
+        })
         ;
 
 }

--- a/bindings/python/src/TriangularMap.cpp
+++ b/bindings/python/src/TriangularMap.cpp
@@ -23,8 +23,10 @@ void mpart::binding::TriangularMapWrapper(py::module &m)
         .def("Slice", &TriangularMap<MemorySpace>::Slice)
         .def("__getitem__", &TriangularMap<MemorySpace>::GetComponent)
         .def("__getitem__", [](const TriangularMap<MemorySpace> &m, const py::slice &s) {
-            if(s.stride() != 1) throw std::runtime_error("TriangularMap slice stride must be 1");
-            return m.Slice(s.start(), s.start() + s.size());
+            size_t start = 0, stop = 0, step = 0, slicelength = 0;
+            s.compute(m.outputDim, &start, &stop, &step, &slicelength);
+            if(step != 1) throw std::runtime_error("TriangularMap slice stride must be 1");
+            return m.Slice(start, stop);
         })
         ;
 

--- a/src/MapFactory.cpp
+++ b/src/MapFactory.cpp
@@ -15,12 +15,12 @@ using namespace mpart;
 template<typename MemorySpace>
 std::shared_ptr<ConditionalMapBase<MemorySpace>> mpart::MapFactory::CreateComponent(FixedMultiIndexSet<MemorySpace> const& mset,
                                                            MapOptions                                   opts)
-{   
+{
     return CompFactoryImpl<MemorySpace>::GetFactoryFunction(opts)(mset,opts);
 }
 
 template<typename MemorySpace>
-std::shared_ptr<ConditionalMapBase<MemorySpace>> mpart::MapFactory::CreateTriangular(unsigned int inputDim,
+std::shared_ptr<TriangularMap<MemorySpace>> mpart::MapFactory::CreateTriangular(unsigned int inputDim,
                                                                          unsigned int outputDim,
                                                                          unsigned int totalOrder,
                                                                          MapOptions options)
@@ -41,14 +41,14 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> mpart::MapFactory::CreateTriang
 
 
 template<typename MemorySpace>
-std::shared_ptr<ParameterizedFunctionBase<MemorySpace>> mpart::MapFactory::CreateExpansion(unsigned int outputDim, 
+std::shared_ptr<ParameterizedFunctionBase<MemorySpace>> mpart::MapFactory::CreateExpansion(unsigned int outputDim,
                                                                                            FixedMultiIndexSet<MemorySpace> const& mset,
                                                                                            MapOptions                                   opts)
 {
     std::shared_ptr<ParameterizedFunctionBase<MemorySpace>> output;
 
     if(opts.basisType==BasisTypes::ProbabilistHermite){
-        
+
         if(isinf(opts.basisLB) && isinf(opts.basisUB)){
             ProbabilistHermite basis1d(opts.basisNorm);
             output = std::make_shared<MultivariateExpansion<ProbabilistHermite, MemorySpace>>(outputDim, mset, basis1d);
@@ -91,9 +91,9 @@ std::shared_ptr<ParameterizedFunctionBase<MemorySpace>> mpart::MapFactory::Creat
 
 template std::shared_ptr<ConditionalMapBase<Kokkos::HostSpace>> mpart::MapFactory::CreateComponent<Kokkos::HostSpace>(FixedMultiIndexSet<Kokkos::HostSpace> const&, MapOptions);
 template std::shared_ptr<ParameterizedFunctionBase<Kokkos::HostSpace>> mpart::MapFactory::CreateExpansion<Kokkos::HostSpace>(unsigned int, FixedMultiIndexSet<Kokkos::HostSpace> const&, MapOptions);
-template std::shared_ptr<ConditionalMapBase<Kokkos::HostSpace>> mpart::MapFactory::CreateTriangular<Kokkos::HostSpace>(unsigned int, unsigned int, unsigned int, MapOptions);
+template std::shared_ptr<TriangularMap<Kokkos::HostSpace>> mpart::MapFactory::CreateTriangular<Kokkos::HostSpace>(unsigned int, unsigned int, unsigned int, MapOptions);
 #if defined(MPART_ENABLE_GPU)
     template std::shared_ptr<ConditionalMapBase<Kokkos::DefaultExecutionSpace::memory_space>> mpart::MapFactory::CreateComponent<Kokkos::DefaultExecutionSpace::memory_space>(FixedMultiIndexSet<Kokkos::DefaultExecutionSpace::memory_space> const&, MapOptions);
     template std::shared_ptr<ParameterizedFunctionBase<Kokkos::DefaultExecutionSpace::memory_space>> mpart::MapFactory::CreateExpansion<Kokkos::DefaultExecutionSpace::memory_space>(unsigned int, FixedMultiIndexSet<Kokkos::DefaultExecutionSpace::memory_space> const&, MapOptions);
-    template std::shared_ptr<ConditionalMapBase<Kokkos::DefaultExecutionSpace::memory_space>> mpart::MapFactory::CreateTriangular<Kokkos::DefaultExecutionSpace::memory_space>(unsigned int, unsigned int, unsigned int, MapOptions);
+    template std::shared_ptr<TriangularMap<Kokkos::DefaultExecutionSpace::memory_space>> mpart::MapFactory::CreateTriangular<Kokkos::DefaultExecutionSpace::memory_space>(unsigned int, unsigned int, unsigned int, MapOptions);
 #endif

--- a/tests/Test_TriangularMap.cpp
+++ b/tests/Test_TriangularMap.cpp
@@ -221,12 +221,12 @@ TEST_CASE( "Testing 3d triangular map from MonotoneComponents", "[TriangularMap_
 
     SECTION("Slice"){
         int sliceBegin = 1;
-        int sliceEnd = 2;
+        int sliceEnd = 3;
         auto slice = triMap->Slice(sliceBegin, sliceEnd);
         REQUIRE(slice->inputDim == triMap->inputDim);
-        REQUIRE(slice->outputDim == (sliceEnd-sliceBegin+1));
+        REQUIRE(slice->outputDim == sliceEnd-sliceBegin);
         // Just test the evaluation
-        for(unsigned int i=sliceBegin; i<=sliceEnd; ++i){
+        for(unsigned int i=sliceBegin; i<sliceEnd; ++i){
 
             auto outBlock = blocks.at(i)->Evaluate(Kokkos::subview(in, std::make_pair(0,int(i+1+extraInputs)), Kokkos::ALL()));
 


### PR DESCRIPTION
This PR adds the ability to slice a `TriangularMap` (using a contiguous slice in Julia/Python). I added bindings for those two languages (sorry @rubiop, no matlab ), but I haven't tested Python yet.

I had to change the return type of `CreateTriangular` for this to actually work in practice, since you can't slice arbitrary objects of type `ConditionalMapBase` (or use `GetComponent`). If this presents a problem, or we used `ConditionalMapBase` for a particular purpose, then I'd be happy to figure out what the best way forward is. Tagging @mparno particularly for this reason.