### PR TITLE
Adapt MexPlus to enable interleaved complex

### DIFF
--- a/bindings/matlab/CMakeLists.txt
+++ b/bindings/matlab/CMakeLists.txt
@@ -15,7 +15,7 @@ set(MEX_SOURCE
     src/MexMapOptionsConversions.cpp
 )
 
-matlab_add_mex(NAME MParT_ SRC ${MEX_SOURCE} LINK_TO mpart Kokkos::kokkos Eigen3::Eigen)
+matlab_add_mex(NAME MParT_ SRC ${MEX_SOURCE} LINK_TO mpart Kokkos::kokkos Eigen3::Eigen R2017b)
 
 # Add an installation target for the matlab bindings
 install(TARGETS MParT_ DESTINATION matlab)

--- a/bindings/matlab/CMakeLists.txt
+++ b/bindings/matlab/CMakeLists.txt
@@ -4,9 +4,9 @@ include_directories(include)
 include_directories(external)
 include_directories(external/mexplus)
 
-set(MEX_SOURCE 
+set(MEX_SOURCE
     src/KokkosUtilities_mex.cpp
-    src/ConditionalMap_mex.cpp 
+    src/ConditionalMap_mex.cpp
     src/MultiIndexSet_mex.cpp
     src/MultiIndex_mex.cpp
     src/FixedMultiIndexSet_mex.cpp
@@ -15,7 +15,7 @@ set(MEX_SOURCE
     src/MexMapOptionsConversions.cpp
 )
 
-matlab_add_mex(NAME MParT_ SRC ${MEX_SOURCE} LINK_TO mpart Kokkos::kokkos Eigen3::Eigen R2017b)
+matlab_add_mex(NAME MParT_ SRC ${MEX_SOURCE} LINK_TO mpart Kokkos::kokkos Eigen3::Eigen)
 
 # Add an installation target for the matlab bindings
 install(TARGETS MParT_ DESTINATION matlab)

--- a/bindings/matlab/external/mexplus/mexplus/mxarray.h
+++ b/bindings/matlab/external/mexplus/mexplus/mxarray.h
@@ -931,8 +931,15 @@ class MxArray {
                          R
                        >::type* value) {
     if (mxIsComplex(array)) {
+      
+      #if MX_HAS_INTERLEAVED_COMPLEX
+      mxComplexDouble* pc = mxGetComplexDoubles(array);
+      T real_part = pc[index].real;
+      T imag_part = pc[index].imag;
+      #else
       T real_part = *(reinterpret_cast<T*>(mxGetPr(array)) + index);
       T imag_part = *(reinterpret_cast<T*>(mxGetPi(array)) + index);
+      #endif
       *value = std::abs(std::complex<R>(real_part, imag_part));
     } else {
       *value = *(reinterpret_cast<T*>(mxGetData(array)) + index);
@@ -950,8 +957,14 @@ class MxArray {
                        >::type* value) {
     typename R::value_type real_part, imag_part;
     if (mxIsComplex(array)) {
+      #if MX_HAS_INTERLEAVED_COMPLEX
+      mxComplexDouble* pc = mxGetComplexDoubles(array);
+      real_part = pc[index].real;
+      imag_part = pc[index].imag;
+      #else
       real_part = *(reinterpret_cast<T*>(mxGetPr(array)) + index);
       imag_part = *(reinterpret_cast<T*>(mxGetPi(array)) + index);
+      #endif
     } else {
       real_part = *(reinterpret_cast<T*>(mxGetData(array)) + index);
       imag_part = 0.0;
@@ -1009,6 +1022,14 @@ class MxArray {
       T* data_pointer = reinterpret_cast<T*>(mxGetData(array));
       value->assign(data_pointer, data_pointer + array_size);
     } else {
+      #if MX_HAS_INTERLEAVED_COMPLEX
+      mxComplexDouble* pc = mxGetComplexDoubles(array);
+      value->resize(array_size);
+      for (mwSize i = 0; i < array_size; ++i) {
+        double mag = std::abs(std::complex<double>(pc[i].real, pc[i].imag));
+        (*value)[i] = static_cast<T>(mag);
+      }
+      #else
       T* real_part = reinterpret_cast<T*>(mxGetPr(array));
       T* imag_part = reinterpret_cast<T*>(mxGetPi(array));
       value->resize(array_size);
@@ -1018,6 +1039,7 @@ class MxArray {
             static_cast<double>(*(imag_part++))));
         (*value)[i] = static_cast<T>(mag);
       }
+      #endif
     }
   }
   #pragma warning( pop )
@@ -1037,11 +1059,18 @@ class MxArray {
         (*value)[i] = typename R::value_type(*(data_pointer++), 0.0f);
       }
     } else {
+      #if MX_HAS_INTERLEAVED_COMPLEX
+      mxComplexDouble* pc = mxGetComplexDoubles(array);
+      for (mwSize i = 0; i < array_size; ++i) {
+        (*value)[i] = typename R::value_type(pc[i].real, pc[i].imag);
+      }
+      #else
       T* real_part = reinterpret_cast<T*>(mxGetPr(array));
       T* imag_part = reinterpret_cast<T*>(mxGetPi(array));
       for (mwSize i = 0; i < array_size; ++i) {
         (*value)[i] = typename R::value_type(*(real_part++), *(imag_part++));
       }
+      #endif
     }
   }
   /** Explicit char (signed) array assignment.
@@ -1098,8 +1127,14 @@ class MxArray {
                            T
                          >::type& value) {
     if (mxIsComplex(array)) {
+      #if MX_HAS_INTERLEAVED_COMPLEX
+      mxComplexDouble* pc = mxGetComplexDoubles(array);
+      pc[index].real = reinterpret_cast<R>(value);
+      pc[index].imag = 0.0;
+      #else
       *(reinterpret_cast<R*>(mxGetPr(array)) + index) = value;
       *(reinterpret_cast<R*>(mxGetPi(array)) + index) = 0.0;
+      #endif
     } else {
       *(reinterpret_cast<R*>(mxGetData(array)) + index) = value;
     }
@@ -1115,8 +1150,14 @@ class MxArray {
                            T
                          >::type& value) {
     if (mxIsComplex(array)) {
+      #if MX_HAS_INTERLEAVED_COMPLEX
+      mxComplexDouble* pc = mxGetComplexDoubles(array);
+      pc[index].real = reinterpret_cast<R>(value.real());
+      pc[index].imag = reinterpret_cast<R>(value.imag());
+      #else
       *(reinterpret_cast<R*>(mxGetPr(array)) + index) = value.real();
       *(reinterpret_cast<R*>(mxGetPi(array)) + index) = value.imag();
+      #endif
     } else {
       *(reinterpret_cast<R*>(mxGetData(array)) + index) = std::abs(value);
     }
@@ -1202,8 +1243,15 @@ mxArray* MxArray::fromInternal(const typename std::enable_if<
                                          MxTypes<T>::class_id,
                                          MxTypes<T>::complexity);
   MEXPLUS_CHECK_NOTNULL(array);
+  
+  #if MX_HAS_INTERLEAVED_COMPLEX
+  mxComplexDouble* pc = mxGetComplexDoubles(array);
+  (*pc).real = value.real();
+  (*pc).imag = value.imag();
+  #else
   *reinterpret_cast<typename T::value_type*>(mxGetPr(array)) = value.real();
   *reinterpret_cast<typename T::value_type*>(mxGetPi(array)) = value.imag();
+  #endif
 
   return array;
 }
@@ -1237,13 +1285,24 @@ mxArray* MxArray::fromInternal(const typename std::enable_if<
                                          MxTypes<ContainerValueType>::class_id,
                                          mxCOMPLEX);
   MEXPLUS_CHECK_NOTNULL(array);
+
+  #if MX_HAS_INTERLEAVED_COMPLEX
+  mxComplexDouble* pc = mxGetComplexDoubles(array);
+  for (const auto& v : value) {
+    (*pc).real = v.real();
+    (*pc).imag = v.imag();
+    ++pc;
+  }
+  #else
   ValueType* real = reinterpret_cast<ValueType*>(mxGetPr(array));
   ValueType* imag = reinterpret_cast<ValueType*>(mxGetPi(array));
+
   typename Container::const_iterator it;
   for (it = value.begin(); it != value.end(); it++) {
       *real++ = (*it).real();
       *imag++ = (*it).imag();
   }
+  #endif
   return array;
 }
 

--- a/bindings/matlab/external/mexplus/mexplus/mxarray.h
+++ b/bindings/matlab/external/mexplus/mexplus/mxarray.h
@@ -931,11 +931,11 @@ class MxArray {
                          R
                        >::type* value) {
     if (mxIsComplex(array)) {
-      
+
       #if MX_HAS_INTERLEAVED_COMPLEX
       mxComplexDouble* pc = mxGetComplexDoubles(array);
-      T real_part = pc[index].real;
-      T imag_part = pc[index].imag;
+      T real_part = static_cast<T>(pc[index].real);
+      T imag_part = static_cast<T>(pc[index].imag);
       #else
       T real_part = *(reinterpret_cast<T*>(mxGetPr(array)) + index);
       T imag_part = *(reinterpret_cast<T*>(mxGetPi(array)) + index);
@@ -959,8 +959,8 @@ class MxArray {
     if (mxIsComplex(array)) {
       #if MX_HAS_INTERLEAVED_COMPLEX
       mxComplexDouble* pc = mxGetComplexDoubles(array);
-      real_part = pc[index].real;
-      imag_part = pc[index].imag;
+      real_part = static_cast<T>(pc[index].real);
+      imag_part = static_cast<T>(pc[index].imag);
       #else
       real_part = *(reinterpret_cast<T*>(mxGetPr(array)) + index);
       imag_part = *(reinterpret_cast<T*>(mxGetPi(array)) + index);
@@ -1129,7 +1129,7 @@ class MxArray {
     if (mxIsComplex(array)) {
       #if MX_HAS_INTERLEAVED_COMPLEX
       mxComplexDouble* pc = mxGetComplexDoubles(array);
-      pc[index].real = reinterpret_cast<R>(value);
+      pc[index].real = value;
       pc[index].imag = 0.0;
       #else
       *(reinterpret_cast<R*>(mxGetPr(array)) + index) = value;
@@ -1152,8 +1152,8 @@ class MxArray {
     if (mxIsComplex(array)) {
       #if MX_HAS_INTERLEAVED_COMPLEX
       mxComplexDouble* pc = mxGetComplexDoubles(array);
-      pc[index].real = reinterpret_cast<R>(value.real());
-      pc[index].imag = reinterpret_cast<R>(value.imag());
+      pc[index].real = value.real();
+      pc[index].imag = value.imag();
       #else
       *(reinterpret_cast<R*>(mxGetPr(array)) + index) = value.real();
       *(reinterpret_cast<R*>(mxGetPi(array)) + index) = value.imag();
@@ -1243,7 +1243,7 @@ mxArray* MxArray::fromInternal(const typename std::enable_if<
                                          MxTypes<T>::class_id,
                                          MxTypes<T>::complexity);
   MEXPLUS_CHECK_NOTNULL(array);
-  
+
   #if MX_HAS_INTERLEAVED_COMPLEX
   mxComplexDouble* pc = mxGetComplexDoubles(array);
   (*pc).real = value.real();

--- a/bindings/matlab/external/mexplus/mexplus/mxarray.h
+++ b/bindings/matlab/external/mexplus/mexplus/mxarray.h
@@ -1619,7 +1619,12 @@ T* MxArray::getImagData() const {
   MEXPLUS_ASSERT(MxTypes<T>::class_id == classID(),
                  "Expected a %s array.",
                  typeid(T).name());
-  return reinterpret_cast<T*>(mxGetPi(array_));
+  #if MX_HAS_INTERLEAVED_COMPLEX
+    throw std::runtime_error("Retrieving imaginary data is not supported for interleaved complex data.");
+    return reinterpret_cast<T*>(nullptr);
+  #else
+    return reinterpret_cast<T*>(mxGetPi(array_));
+  #endif
 }
 
 template <typename T>


### PR DESCRIPTION
Long story short, Mathworks changed how complex numbers were represented in 2018. While we don't really use complex numbers, it was actually easier to adapt Mexplus to support the new complex numbers than it was to remove them from the library. The old way is deprecated but not removed (though it will be at some point). CMAKE defaults to compiling MEX with the old standard, so we haven't had an issue, but if you want to test this for both, change `bindings/matlab/CMakeLists:18` between

` matlab_add_mex(NAME MParT_ SRC ${MEX_SOURCE} LINK_TO mpart Kokkos::kokkos Eigen3::Eigen R2017b)`

and

` matlab_add_mex(NAME MParT_ SRC ${MEX_SOURCE} LINK_TO mpart Kokkos::kokkos Eigen3::Eigen R2018a)`

if they both compile correctly and you can run some simple files, then everything should be A-okay.