### PR TITLE
Make Inheritence in Maps abide by C.128

### DIFF
--- a/MParT/IdentityMap.h
+++ b/MParT/IdentityMap.h
@@ -13,8 +13,8 @@ namespace mpart{
 
 /**
  @brief Provides a definition of the identity map.
- @details 
-This class defines the identity map \f$I:\mathbb{R}^N\rightarrow \mathbb{R}^M\f$, i.e., a map such that \f$I(x_{1:N-M},x_{N-M:N}) = x_{N-M:N}\f$ 
+ @details
+This class defines the identity map \f$I:\mathbb{R}^N\rightarrow \mathbb{R}^M\f$, i.e., a map such that \f$I(x_{1:N-M},x_{N-M:N}) = x_{N-M:N}\f$
 
 
  */
@@ -32,31 +32,30 @@ public:
 
 
     void EvaluateImpl(StridedMatrix<const double, MemorySpace> const& pts,
-                      StridedMatrix<double, MemorySpace>              output);
+                      StridedMatrix<double, MemorySpace>              output) override;
 
     void InverseImpl(StridedMatrix<const double, MemorySpace> const& x1,
                      StridedMatrix<const double, MemorySpace> const& r,
-                     StridedMatrix<double, MemorySpace>              output);
+                     StridedMatrix<double, MemorySpace>              output) override;
 
 
     void LogDeterminantImpl(StridedMatrix<const double, MemorySpace> const& pts,
-                            StridedVector<double, MemorySpace>              output);
+                            StridedVector<double, MemorySpace>              output) override;
 
-    void CoeffGradImpl(StridedMatrix<const double, MemorySpace> const& pts,  
+    void CoeffGradImpl(StridedMatrix<const double, MemorySpace> const& pts,
                        StridedMatrix<const double, MemorySpace> const& sens,
-                       StridedMatrix<double, MemorySpace>              output);
-    
-    
-    void GradientImpl(StridedMatrix<const double, MemorySpace> const& pts,  
+                       StridedMatrix<double, MemorySpace>              output) override;
+
+    void GradientImpl(StridedMatrix<const double, MemorySpace> const& pts,
                        StridedMatrix<const double, MemorySpace> const& sens,
-                       StridedMatrix<double, MemorySpace>              output);
+                       StridedMatrix<double, MemorySpace>              output) override;
 
 
-    void LogDeterminantCoeffGradImpl(StridedMatrix<const double, MemorySpace> const& pts, 
-                                     StridedMatrix<double, MemorySpace>              output);
+    void LogDeterminantCoeffGradImpl(StridedMatrix<const double, MemorySpace> const& pts,
+                                     StridedMatrix<double, MemorySpace>              output) override;
 
-    void LogDeterminantInputGradImpl(StridedMatrix<const double, MemorySpace> const& pts, 
-                                     StridedMatrix<double, MemorySpace>              output);
+    void LogDeterminantInputGradImpl(StridedMatrix<const double, MemorySpace> const& pts,
+                                     StridedMatrix<double, MemorySpace>              output) override;
 
 }; // class IdentityMap
 

--- a/MParT/TriangularMap.h
+++ b/MParT/TriangularMap.h
@@ -29,7 +29,7 @@ is positive definite.
  */
 template<typename MemorySpace>
 class TriangularMap : public ConditionalMapBase<MemorySpace>{
-        
+
 public:
 
     /** @brief Construct a block triangular map from a collection of other ConditionalMapBase objects.
@@ -55,8 +55,8 @@ public:
     #if defined(MPART_ENABLE_GPU)
     virtual void SetCoeffs(Kokkos::View<double*, Kokkos::DefaultExecutionSpace::memory_space> coeffs) override;
     virtual void WrapCoeffs(Kokkos::View<double*, mpart::DeviceSpace> coeffs) override;
-    #endif 
-    
+    #endif
+
     virtual std::shared_ptr<ConditionalMapBase<MemorySpace>> GetComponent(unsigned int i){ return comps_.at(i);}
 
     /** @brief Computes the log determinant of the Jacobian matrix of this map.
@@ -80,10 +80,10 @@ public:
     void EvaluateImpl(StridedMatrix<const double, MemorySpace> const& pts,
                       StridedMatrix<double, MemorySpace>              output) override;
 
-    virtual void GradientImpl(StridedMatrix<const double, MemorySpace> const& pts,  
+    virtual void GradientImpl(StridedMatrix<const double, MemorySpace> const& pts,
                               StridedMatrix<const double, MemorySpace> const& sens,
                               StridedMatrix<double, MemorySpace>              output) override;
-    
+
     /** @brief Evaluates the map inverse.
 
     @details To understand this function, consider splitting the map input \f$x_{1:N}\f$ into two parts so that \f$x_{1:N} = [x_{1:N-M},x_{N-M+1:M}]\f$.  Note that the
@@ -96,25 +96,25 @@ public:
     @param r The map output \f$r_{1:M}\f$ to invert.
     @param output A matrix with \f$M\f$ rows to store the computed map inverse \f$x_{N-M+1:M}\f$.
     */
-    virtual void InverseImpl(StridedMatrix<const double, MemorySpace> const& x1,
-                             StridedMatrix<const double, MemorySpace> const& r,
-                             StridedMatrix<double, MemorySpace>              output) override;
+    void InverseImpl(StridedMatrix<const double, MemorySpace> const& x1,
+                     StridedMatrix<const double, MemorySpace> const& r,
+                     StridedMatrix<double, MemorySpace>              output) override;
 
 
     virtual void InverseInplace(StridedMatrix<double, MemorySpace>              x1,
                                 StridedMatrix<const double, MemorySpace> const& r);
 
 
-    virtual void CoeffGradImpl(StridedMatrix<const double, MemorySpace> const& pts,  
-                               StridedMatrix<const double, MemorySpace> const& sens,
-                               StridedMatrix<double, MemorySpace>              output) override;
+    void CoeffGradImpl(StridedMatrix<const double, MemorySpace> const& pts,
+                       StridedMatrix<const double, MemorySpace> const& sens,
+                       StridedMatrix<double, MemorySpace>              output) override;
 
 
-    virtual void LogDeterminantCoeffGradImpl(StridedMatrix<const double, MemorySpace> const& pts, 
-                                             StridedMatrix<double, MemorySpace>              output) override;
-    
-    virtual void LogDeterminantInputGradImpl(StridedMatrix<const double, MemorySpace> const& pts, 
-                                             StridedMatrix<double, MemorySpace>              output) override;
+    void LogDeterminantCoeffGradImpl(StridedMatrix<const double, MemorySpace> const& pts,
+                                     StridedMatrix<double, MemorySpace>              output) override;
+
+    void LogDeterminantInputGradImpl(StridedMatrix<const double, MemorySpace> const& pts,
+                                     StridedMatrix<double, MemorySpace>              output) override;
 private:
 
     std::vector<std::shared_ptr<ConditionalMapBase<MemorySpace>>> comps_;


### PR DESCRIPTION
This is a super mundane PR, but I noted that `IdentityMap` didn't mark functions as `override`. Of course, `g++` is smart enough to figure out they're inherited, but I just took a couple of minutes and cleaned house. Note that [c.128](http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines.html#c128-virtual-functions-should-specify-exactly-one-of-virtual-override-or-final) from the C++ standard says that you should mark functions as at most one of `virtual`, `override`, `final`, so I changed a couple of other classes while I was at it.

This strictly changes nothing about MParT, but makes a few classes a bit more readable and understandable.