### PR TITLE
Fix MParT to work with Kokkos 3.7

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -7,14 +7,14 @@ RUN --mount=type=cache,target=/opt/conda/pkgs conda env create -f MParT_/.docker
 
 SHELL ["conda", "run", "-n", "mpart", "/bin/bash", "-c"]
 
-RUN git clone https://github.com/kokkos/kokkos.git && \
+RUN git clone --depth=1 --branch 3.7.00 https://github.com/kokkos/kokkos.git && \
     mkdir kokkos/build && \
     cd kokkos/build && \
     cmake \
           -DKokkos_ENABLE_SERIAL=ON \
           -DKokkos_ENABLE_OPENMP=ON \
           -DBUILD_SHARED_LIBS=ON    \
-          -DKokkos_CXX_STANDARD=17  \
+          -DCMAKE_CXX_STANDARD=17   \
           ../ && \
     make -j$(nproc) && \
     make install && \
@@ -46,4 +46,4 @@ RUN echo 'export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib' >> ~/.bashrc &
     echo 'export PYTHONPATH=$PYTHONPATH:/usr/local/python' >> ~/.bashrc && \
     echo 'export OMP_PROC_BIND=spread' >> ~/.bashrc && \
     echo 'export OMP_PLACES=threads' >> ~/.bashrc && \
-    echo 'export KOKKOS_NUM_THREADS=`nproc`' >> ~/.bashrc 
+    echo 'export KOKKOS_NUM_THREADS=`nproc`' >> ~/.bashrc

--- a/.github/workflows/build-doc.yml
+++ b/.github/workflows/build-doc.yml
@@ -15,7 +15,7 @@ jobs:
           auto-update-conda: true
           python-version: "3.8"
           activate-environment: "test"
-          
+
       - name: Checkout MParT
         uses: actions/checkout@v1
 
@@ -24,23 +24,23 @@ jobs:
         with:
           image: quay.io/measuretransport/mpart_examples:latest
           path: /home/bayes/examples/python/.
-      
+
       - name: Move notebooks into documentation
         run: |
           mkdir ${{ github.workspace }}/docs/source/tutorials/python
           cp ${{ steps.extract.outputs.destination }}/*.nbconvert.ipynb ${{ github.workspace }}/docs/source/tutorials/python/
           for file in ${{ github.workspace }}/docs/source/tutorials/python/*.nbconvert.ipynb; do mv "${file}" "${file/nbconvert./}"; done
-        
+
       - name: Install sphinx extensions
         shell: bash -l {0}
         run: conda install -c conda-forge doxygen pygments sphinx sphinx-design breathe pydata-sphinx-theme nbsphinx jupytext pandoc ipykernel nbconvert
-         
+
       - name: Run CMake
         shell: bash -l {0}
         run: |
           cd ${{ github.workspace }}
           mkdir build && cd build
-          cmake -DKokkos_ENABLE_PTHREAD=ON -DKokkos_ENABLE_SERIAL=ON -DPYTHON_EXECUTABLE=`which python` -DMPART_BUILD_EXAMPLES=OFF ../
+          cmake -DKokkos_ENABLE_THREADS=ON -DKokkos_ENABLE_SERIAL=ON -DPYTHON_EXECUTABLE=`which python` -DMPART_BUILD_EXAMPLES=OFF ../
 
       - name: Build Docs
         shell: bash -l {0}

--- a/.github/workflows/build-external-lib-tests.yml
+++ b/.github/workflows/build-external-lib-tests.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           repository: kokkos/kokkos
           path: kokkos
+          ref: '3.7.00'
 
       - name: Install Kokkos
         run: |

--- a/.github/workflows/build-external-lib-tests.yml
+++ b/.github/workflows/build-external-lib-tests.yml
@@ -39,7 +39,7 @@ jobs:
                 -DKokkos_CXX_STANDARD=17   \
                 -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/KOKKOS_INSTALL/ \
                 ../
-          sudo make install
+          sudo make -j2 install
 
       - name: Install Eigen, Catch2, Pybind11
         shell: bash -l {0}
@@ -54,7 +54,7 @@ jobs:
 
       - name: Build MParT
         shell: bash -l {0}
-        run: cd $GITHUB_WORKSPACE/mpart/build; make
+        run: cd $GITHUB_WORKSPACE/mpart/build; make -j2
 
       - name: Run Tests
         shell: bash -l {0}

--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -21,7 +21,7 @@ jobs:
           cmake -DKokkos_ENABLE_THREADS=ON -DKokkos_ENABLE_SERIAL=ON ../
 
       - name: Build
-        run: cd build; make
+        run: cd build; make -j2
 
       - name: Run Tests
         run: cd build; ./RunTests --kokkos-threads=2 --reporter junit -o test-results.xml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ option(MPART_JULIA "Build julia bindings with CxxWrap.jl" ON)
 option(MPART_FETCH_DEPS "If CMake should be allowed to fetch and build external dependencies that weren't found." ON)
 
 ##############################################################
-# Installation path configuration 
+# Installation path configuration
 Include(SetInstallPaths)
 
 ##############################################################
@@ -85,7 +85,7 @@ if(NOT Kokkos_FOUND)
         FetchContent_Declare(
             kokkos
             GIT_REPOSITORY https://github.com/kokkos/kokkos
-            GIT_TAG 3.5.00
+            GIT_TAG 3.7.00
             GIT_SHALLOW TRUE
         )
         FetchContent_MakeAvailable(kokkos)
@@ -161,7 +161,7 @@ if(MPART_JULIA)
     message(WARNING "Requested Julia bindings but CMake could not find Julia executable.  Setting MPART_JULIA=OFF.")
   else()
 
-    # Get a hint for the location of JlCxx 
+    # Get a hint for the location of JlCxx
     get_filename_component(PARENT_DIR ${Julia_LIBRARY_DIR} DIRECTORY)
 
     # Use JlCxx_DIR to tell where CxxWrap is located

--- a/MParT/Utilities/ArrayConversions.h
+++ b/MParT/Utilities/ArrayConversions.h
@@ -2,7 +2,6 @@
 #define ARRAYCONVERSIONS_H
 
 #include <Kokkos_Core.hpp>
-#include <Kokkos_Layout.hpp>
 #include <Eigen/Core>
 
 #include "GPUtils.h"

--- a/bindings/matlab/src/KokkosUtilities_mex.cpp
+++ b/bindings/matlab/src/KokkosUtilities_mex.cpp
@@ -13,8 +13,8 @@ MEX_DEFINE(Kokkos_Initialize) (int nlhs, mxArray* plhs[],
                                int nrhs, const mxArray* prhs[]) {
   InputArguments input(nrhs, prhs, 1);
   OutputArguments output(nlhs, plhs, 0);
-  Kokkos::InitArguments args;
-  args.num_threads = input.get<int>(0);
+  Kokkos::InitializationSettings args ();
+  args.set_num_threads(input.get<int>(0));
   mpart::Initialize(args);
 }
 

--- a/bindings/python/src/CommonPybindUtilities.cpp
+++ b/bindings/python/src/CommonPybindUtilities.cpp
@@ -14,31 +14,16 @@ using namespace mpart::binding;
 // Define a wrapper around Kokkos::Initialize that accepts a python dictionary instead of argc and argv.
 void mpart::binding::Initialize(py::dict opts) {
 
-    Kokkos::InitArguments args;
+    std::vector<std::string> args;
 
     pybind11::object keys = pybind11::list(opts.attr("keys")());
     std::vector<std::string> keysCpp = keys.cast<std::vector<std::string>>();
 
     for(auto& key : keysCpp){
-        
-        if((key=="num_threads")||(key=="kokkos-threads")){
-            args.num_threads = py::cast<int>(opts.attr("get")(key));
-        }else if(key=="num_numa"){
-            args.num_numa = py::cast<int>(opts.attr("get")(key));
-        }else if(key=="device_id"){
-            args.device_id = py::cast<int>(opts.attr("get")(key));
-        }else if(key=="ndevices"){
-            args.ndevices = py::cast<int>(opts.attr("get")(key));
-        }else if(key=="skip_device"){
-            args.skip_device = py::cast<int>(opts.attr("get")(key));
-        }else if(key=="disable_warnings"){
-            args.disable_warnings = py::cast<bool>(opts.attr("get")(key));
-        }else{
-            std::cout << "WARNING: Kokkos initialization argument \"" << key << "\" was not used." << std::endl;
-        }
+        args.push_back("--" + key + "=" + py::cast<std::string>(opts.attr("get")(key)));
     }
 
-    mpart::Initialize(args);
+    mpart::binding::Initialize(args);
 };
 
 void mpart::binding::CommonUtilitiesWrapper(py::module &m)

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -184,15 +184,16 @@ The following cmake command can be used to compile Kokkos with the CUDA backend 
         -DCMAKE_INSTALL_PREFIX=</new/kokkos/install/path> \
         -DBUILD_SHARED_LIBS=ON                            \
         -DKokkos_ENABLE_SERIAL=OFF                        \
-        -DKokkos_ENABLE_OPENMP=ON                         \
+        -DKokkos_ENABLE_THREADS=ON                        \
         -DKokkos_ENABLE_CUDA=ON                           \
-        -DKokkos_ARCH_VOLTA70=ON                          \
         -DKokkos_ENABLE_CUDA_LAMBDA=ON                    \
-        -DKokkos_CUDA_DIR=<cuda/install/path>             \
-        -DKokkos_CXX_STANDARD=17                          \
+        -DCMAKE_CXX_STANDARD=17                           \
     ../
 
 Replace the :code:`Kokkos_ARCH_VOLTA70` as needed with whatever other arch the compute resource uses that Kokkos supports. If you aren't sure, try omitting this as Kokkos has some machinery to detect such architecture.
+
+.. tip::
+    If Kokkos may not be able to find your GPU information automatically, consider including :code:`-DKokkos_ARCH_<ARCH><VERSION>=ON` where :code:`<ARCH>` and :code:`<VERSION>` are determined by `the Kokkos documentation <https://kokkos.github.io/kokkos-core-wiki/keywords.html?highlight=volta70#architecture-keywords>`_. If Kokkos cannot find CUDA, or you wish to use a particular version, use :code:`-DKokkos_CUDA_DIR=/your/cuda/path`.
 
 .. tip::
     If you're getting an error about C++ standards, try using a new version of your compiler; :code:`g++`, for example, does not support the flag :code:`--std=c++17` below version 8. For more details, see `this issue <https://github.com/kokkos/kokkos/issues/5157>`_ in Kokkos.

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -38,7 +38,7 @@ MParT uses CMake to handle dependencies and compiler configurations.   A basic b
    cd build
    cmake                                               \
      -DCMAKE_INSTALL_PREFIX=<your/MParT/install/path>  \
-     -DKokkos_ENABLE_PTHREAD=ON                        \
+     -DKokkos_ENABLE_THREADS=ON                        \
    ..
    make install
 
@@ -53,7 +53,7 @@ This installation should also automatically install and build Kokkos, Eigen, and
      -DKokkos_ROOT=<your/kokkos/install/root>          \
      -DEigen3_ROOT=<your/eigen3/install/root>          \
      -DCatch2_ROOT=<your/catch2/install/root>          \
-     -DKokkos_ENABLE_PTHREAD=ON                        \
+     -DKokkos_ENABLE_THREADS=ON                        \
      -DKokkos_ENABLE_SERIAL=ON                         \
    ..
 
@@ -67,14 +67,14 @@ Note that if you do not wish to compile bindings for Python, Julia, or Matlab, y
 
     cmake                                              \
      -DCMAKE_INSTALL_PREFIX=<your/MParT/install/path>  \
-     -DKokkos_ENABLE_PTHREAD=ON                        \
+     -DKokkos_ENABLE_THREADS=ON                        \
      -DMPART_PYTHON=OFF                                \
      -DMPART_MATLAB=OFF                                \
      -DMPART_JULIA=OFF                                 \
    ..
 
 
-MParT is built on Kokkos, which provides a single interface to many different multithreading capabilities like pthreads, OpenMP, CUDA, and OpenCL.   A list of available backends can be found on the [Kokkos wiki](https://github.com/kokkos/kokkos/blob/master/BUILD.md#device-backends).   The `Kokkos_ENABLE_PTHREAD` option in the CMake configuration above can be changed to reflect different choices in device backends.   The OSX-provided clang compiler does not support OpenMP, so `PTHREAD` is a natural choice for CPU-based multithreading on OSX.   However, you may find that OpenMP has slightly better performance with other compilers and operating systems.
+MParT is built on Kokkos, which provides a single interface to many different multithreading capabilities like pthreads, OpenMP, CUDA, and OpenCL.   A list of available backends can be found on the [Kokkos wiki](https://github.com/kokkos/kokkos/blob/master/BUILD.md#device-backends).   The `Kokkos_ENABLE_THREADS` option in the CMake configuration above can be changed to reflect different choices in device backends.   The OSX-provided clang compiler does not support OpenMP, so `PTHREAD` is a natural choice for CPU-based multithreading on OSX.   However, you may find that OpenMP has slightly better performance with other compilers and operating systems.
 
 Tests
 ---------
@@ -169,7 +169,7 @@ Make sure that this file includes a full installation path from root! At this po
 Compiling with CUDA Support
 ----------------------------
 
-Building the Kokkos Dependency 
+Building the Kokkos Dependency
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 To support a GPU at the moment, you need a few special requirements. Due to the way that Kokkos handles GPU code, MParT must be compiled using a special wrapper around NVCC that Kokkos provides.  Because of this, MParT cannot use an internal build of Kokkos and Kokkos must therefore be compiled (or otherwise installed) manually.
 
@@ -197,24 +197,24 @@ Replace the :code:`Kokkos_ARCH_VOLTA70` as needed with whatever other arch the c
 .. tip::
     If you're getting an error about C++ standards, try using a new version of your compiler; :code:`g++`, for example, does not support the flag :code:`--std=c++17` below version 8. For more details, see `this issue <https://github.com/kokkos/kokkos/issues/5157>`_ in Kokkos.
 
-Installing cublas and cusolver 
+Installing cublas and cusolver
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-MParT uses the CUBLAS and CUSOLVER components of the `NVIDIA CUDA Toolkit <https://developer.nvidia.com/cuda-toolkit>`_ for GPU-accelerated linear algebra.   
+MParT uses the CUBLAS and CUSOLVER components of the `NVIDIA CUDA Toolkit <https://developer.nvidia.com/cuda-toolkit>`_ for GPU-accelerated linear algebra.
 
 NVIDIA's `Cuda installation guide <https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html>`_ provides detailed instructions on how to install CUDA.   For Debian-based x86_64 systems, we have been able to successfully install cuda, cublas, and cusparse for CUDA 11.4 using the command below.  Notice the installation of :code:`*-dev` packages, which are required to obtain the necessary header files.  Similar commands may be useful on other systems.
 
-.. code-block:: bash 
+.. code-block:: bash
 
     export CUDA_VERSION=11.4
     export CUDA_COMPAT_VERSION=470.129.06-1
     export CUDA_CUDART_VERSION=11.4.148-1
 
-    curl -sL "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/7fa2af80.pub" | apt-key add - 
-    echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/ /" > /etc/apt/sources.list.d/cuda.list 
-    sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A4B469963BF863CC 
-    
-    sudo apt-get -yq update 
+    curl -sL "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/7fa2af80.pub" | apt-key add -
+    echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/ /" > /etc/apt/sources.list.d/cuda.list
+    sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A4B469963BF863CC
+
+    sudo apt-get -yq update
     sudo apt-get -yq install --no-install-recommends \
         cuda-compat-${CUDA_VERSION/./-}=${CUDA_COMPAT_VERSION} \
         cuda-cudart-${CUDA_VERSION/./-}=${CUDA_CUDART_VERSION} \


### PR DESCRIPTION
Currently, our build breaks with the new version of Kokkos. This makes that not happen.