### PR TITLE
279 triangularmap handing map components without coefficients like identitymap

### DIFF
--- a/src/TriangularMap.cpp
+++ b/src/TriangularMap.cpp
@@ -245,14 +245,19 @@ void TriangularMap<MemorySpace>::CoeffGradImpl(StridedMatrix<const double, Memor
     int startParamDim = 0;
     for(unsigned int i=0; i<comps_.size(); ++i){
 
-        subPts = Kokkos::subview(pts, std::make_pair(0,int(comps_.at(i)->inputDim)), Kokkos::ALL());
-        subSens = Kokkos::subview(sens, std::make_pair(startOutDim,int(startOutDim+comps_.at(i)->outputDim)), Kokkos::ALL());
+        if(comps_.at(i)->numCoeffs != 0){
 
-        subOut = Kokkos::subview(output, std::make_pair(startParamDim,int(startParamDim+comps_.at(i)->numCoeffs)), Kokkos::ALL());
-        comps_.at(i)->CoeffGradImpl(subPts, subSens, subOut);
+            subPts = Kokkos::subview(pts, std::make_pair(0,int(comps_.at(i)->inputDim)), Kokkos::ALL());
+            subSens = Kokkos::subview(sens, std::make_pair(startOutDim,int(startOutDim+comps_.at(i)->outputDim)), Kokkos::ALL());
+
+            subOut = Kokkos::subview(output, std::make_pair(startParamDim,int(startParamDim+comps_.at(i)->numCoeffs)), Kokkos::ALL());
+            comps_.at(i)->CoeffGradImpl(subPts, subSens, subOut);
+
+            
+            startParamDim += comps_.at(i)->numCoeffs;
+        }
 
         startOutDim += comps_.at(i)->outputDim;
-        startParamDim += comps_.at(i)->numCoeffs;
     }
 }
 
@@ -266,13 +271,15 @@ void TriangularMap<MemorySpace>::LogDeterminantCoeffGradImpl(StridedMatrix<const
 
     int startParamDim = 0;
     for(unsigned int i=0; i<comps_.size(); ++i){
+        if(comps_.at(i)->numCoeffs != 0){
 
-        subPts = Kokkos::subview(pts, std::make_pair(0,int(comps_.at(i)->inputDim)), Kokkos::ALL());
+            subPts = Kokkos::subview(pts, std::make_pair(0,int(comps_.at(i)->inputDim)), Kokkos::ALL());
 
-        subOut = Kokkos::subview(output, std::make_pair(startParamDim,int(startParamDim+comps_.at(i)->numCoeffs)), Kokkos::ALL());
-        comps_.at(i)->LogDeterminantCoeffGradImpl(subPts, subOut);
+            subOut = Kokkos::subview(output, std::make_pair(startParamDim,int(startParamDim+comps_.at(i)->numCoeffs)), Kokkos::ALL());
+            comps_.at(i)->LogDeterminantCoeffGradImpl(subPts, subOut);
 
-        startParamDim += comps_.at(i)->numCoeffs;
+            startParamDim += comps_.at(i)->numCoeffs;
+        }
     }
 }
 

--- a/tests/Test_TriangularMap.cpp
+++ b/tests/Test_TriangularMap.cpp
@@ -75,7 +75,7 @@ TEST_CASE( "Testing 3d triangular map from MonotoneComponents", "[TriangularMap_
             REQUIRE(outBlock.extent(1)==numSamps);
             REQUIRE(outBlock.extent(0)==1);
             for(unsigned int j=0; j<numSamps; ++j)
-                CHECK( out(i,j) == Approx(outBlock(0,j)).epsilon(1e-6));
+                CHECK( out(i,j) == Approx(outBlock(0,j)).margin(1e-6));
         }
     }
 
@@ -86,7 +86,7 @@ TEST_CASE( "Testing 3d triangular map from MonotoneComponents", "[TriangularMap_
 
         for(unsigned int i=0; i<numBlocks; ++i){
             for(unsigned int j=0; j<numSamps; ++j)
-                CHECK( inv(i,j) == Approx(in(i+extraInputs,j)).epsilon(1e-6));
+                CHECK( inv(i,j) == Approx(in(i+extraInputs,j)).margin(1e-6));
         }
     }
 
@@ -104,7 +104,7 @@ TEST_CASE( "Testing 3d triangular map from MonotoneComponents", "[TriangularMap_
         }
 
         for(unsigned int j=0; j<numSamps; ++j)
-            CHECK(logDet(j) == Approx(truth(j)).epsilon(1e-10));
+            CHECK(logDet(j) == Approx(truth(j)).margin(1e-10));
 
     }
 
@@ -139,7 +139,7 @@ TEST_CASE( "Testing 3d triangular map from MonotoneComponents", "[TriangularMap_
                 for(unsigned int j=0; j<triMap->outputDim; ++j)
                     fdDeriv += sens(j,ptInd) * (evals2(j,ptInd)-evals(j,ptInd))/fdstep;
 
-                CHECK( coeffGrad(i,ptInd) == Approx(fdDeriv).epsilon(1e-3)); 
+                CHECK( coeffGrad(i,ptInd) == Approx(fdDeriv).margin(1e-3)); 
             }
             coeffs(i) -= fdstep;
         }
@@ -178,7 +178,7 @@ TEST_CASE( "Testing 3d triangular map from MonotoneComponents", "[TriangularMap_
                 for(unsigned int j=0; j<triMap->outputDim; ++j)
                     fdDeriv += sens(j,ptInd) * (evals2(j,ptInd)-evals(j,ptInd))/fdstep;
 
-                CHECK( inputGrad(i,ptInd) == Approx(fdDeriv).epsilon(1e-3)); 
+                CHECK( inputGrad(i,ptInd) == Approx(fdDeriv).margin(1e-3)); 
             }
 
             for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd)
@@ -212,7 +212,7 @@ TEST_CASE( "Testing 3d triangular map from MonotoneComponents", "[TriangularMap_
             logDet2 = triMap->LogDeterminant(in);
 
             for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd)
-                CHECK( detGrad(i,ptInd) == Approx((logDet2(ptInd)-logDet(ptInd))/fdstep).epsilon(1e-4)); 
+                CHECK( detGrad(i,ptInd) == Approx((logDet2(ptInd)-logDet(ptInd))/fdstep).margin(1e-4)); 
             
             coeffs(i) -= fdstep;
         }
@@ -440,6 +440,221 @@ TEST_CASE( "Testing TriangularMap made from smaller TriangularMaps", "[Triangula
 
             for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd)
                 CHECK( detGrad(i,ptInd) == Approx((logDet2(ptInd)-logDet(ptInd))/fdstep).epsilon(1e-4)); 
+            
+            coeffs(i) -= fdstep;
+        }
+
+    }
+
+}
+
+
+
+TEST_CASE( "Testing TriangularMap made using CreateSingleEntryMap", "[TriangularMap_CreateSingleEntryMap]" ) {
+
+    MapOptions options;
+    options.basisType = BasisTypes::ProbabilistHermite;
+    unsigned int dim = 7;
+    unsigned int activeInd = 3;
+    unsigned int maxDegree = 3;
+    FixedMultiIndexSet<MemorySpace> mset(activeInd, maxDegree);
+    std::shared_ptr<ConditionalMapBase<MemorySpace>> comp = MapFactory::CreateComponent<MemorySpace>(mset, options);
+
+    std::shared_ptr<ConditionalMapBase<MemorySpace>> triMap = MapFactory::CreateSingleEntryMap<MemorySpace>(dim, activeInd, comp);
+
+    CHECK(triMap->outputDim == dim);
+    CHECK(triMap->inputDim == dim);
+    CHECK(triMap->numCoeffs == comp->numCoeffs);
+
+
+
+    Kokkos::View<double*,Kokkos::HostSpace> coeffs("Coefficients", triMap->numCoeffs);
+    for(unsigned int i=0; i<triMap->numCoeffs; ++i)
+        coeffs(i) = 0.1*(i+1);
+        
+    SECTION("Coefficients"){
+        
+        // Set the coefficients of the triangular map
+        triMap->SetCoeffs(coeffs);
+
+        // Now make sure that the coefficients of each block were set
+        unsigned int cumCoeffInd = 0;
+        for(unsigned int i=0; i<triMap->numCoeffs; ++i){
+                CHECK(comp->Coeffs()(i) == triMap->Coeffs()(i)); // Values of coefficients should be equal
+                CHECK(&comp->Coeffs()(i) == &triMap->Coeffs()(i)); // Memory location should also be the same (no copy)
+        }
+        
+    }
+
+    unsigned int numSamps = 10;
+    Kokkos::View<double**, Kokkos::HostSpace> in("Map Input", dim, numSamps);
+    for(unsigned int i=0; i<dim; ++i){
+        for(unsigned int j=0; j<numSamps; ++j){
+            in(i,j) = double(i)/dim + double(j)/numSamps;
+        }
+    }
+
+    triMap->SetCoeffs(coeffs);
+    auto out = triMap->Evaluate(in);
+    
+    SECTION("Evaluation"){
+
+        unsigned int start = 0;
+
+
+        auto inTop = Kokkos::subview(in, std::make_pair(0, int(activeInd-1)), Kokkos::ALL());
+        auto inTopAndMid = Kokkos::subview(in, std::make_pair(0, int(activeInd)), Kokkos::ALL());
+        auto inBot = Kokkos::subview(in, std::make_pair(int(activeInd), int(dim)), Kokkos::ALL());
+
+        auto outTop = Kokkos::subview(out, std::make_pair(0, int(activeInd-1)), Kokkos::ALL());
+        auto outMid = Kokkos::subview(out, std::make_pair(int(activeInd-1), int(activeInd)), Kokkos::ALL());
+        auto outBot = Kokkos::subview(out, std::make_pair(int(activeInd), int(dim)), Kokkos::ALL());
+
+        for(unsigned int i=0; i<outTop.extent(0); ++i)
+            for(unsigned int j=0; j<outTop.extent(1); ++j)
+                CHECK( outTop(i,j) == Approx(inTop(i,j)).epsilon(1e-6));
+
+        for(unsigned int i=0; i<outBot.extent(0); ++i)
+            for(unsigned int j=0; j<outBot.extent(1); ++j)
+                CHECK( outBot(i,j) == Approx(inBot(i,j)).epsilon(1e-6));
+
+
+        auto compOut = comp->Evaluate(inTopAndMid);
+        for(unsigned int i=0; i<outMid.extent(0); ++i)
+            for(unsigned int j=0; j<outMid.extent(1); ++j)
+                CHECK( outMid(i,j) == Approx(compOut(i,j)).margin(1e-6));
+    }
+
+
+    SECTION("Inverse"){
+
+        auto inv = triMap->Inverse(in,out);
+
+        for(unsigned int i=0; i<dim; ++i){
+            for(unsigned int j=0; j<numSamps; ++j)
+                CHECK( inv(i,j) == Approx(in(i,j)).margin(1e-3));
+        }
+    }
+
+    SECTION("LogDeterminant"){
+        
+        auto inTopAndMid = Kokkos::subview(in, std::make_pair(0, int(activeInd)), Kokkos::ALL());
+        
+        auto logDet = triMap->LogDeterminant(in);
+        auto logDet_ = comp->LogDeterminant(inTopAndMid);
+
+        REQUIRE(logDet.extent(0)==numSamps);
+
+        for(unsigned int j=0; j<numSamps; ++j)
+            CHECK(logDet(j) == Approx(logDet_(j)).margin(1e-5));
+
+    }
+
+    SECTION("CoeffGrad"){
+
+        Kokkos::View<double**,Kokkos::HostSpace> sens("Sensitivities", triMap->outputDim, numSamps);
+        for(unsigned int j=0; j<numSamps; ++j){
+            for(unsigned int i=0; i<triMap->outputDim; ++i){
+                sens(i,j) = 1.0 + 0.1*i + j;
+            }
+        }
+
+        Kokkos::View<double**,Kokkos::HostSpace> evals = triMap->Evaluate(in);
+        Kokkos::View<double**,Kokkos::HostSpace> evals2;
+
+        Kokkos::View<double**,Kokkos::HostSpace> coeffGrad = triMap->CoeffGrad(in, sens);
+
+        REQUIRE(coeffGrad.extent(0)==triMap->numCoeffs);
+        REQUIRE(coeffGrad.extent(1)==numSamps);
+
+        // Compare with finite differences
+        double fdstep = 1e-5;
+        for(unsigned int i=0; i<triMap->numCoeffs; ++i){
+            coeffs(i) += fdstep;
+
+            triMap->SetCoeffs(coeffs);
+            evals2 = triMap->Evaluate(in);
+
+            for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd){
+                
+                double fdDeriv = 0.0;
+                for(unsigned int j=0; j<triMap->outputDim; ++j)
+                    fdDeriv += sens(j,ptInd) * (evals2(j,ptInd)-evals(j,ptInd))/fdstep;
+
+                CHECK( coeffGrad(i,ptInd) == Approx(fdDeriv).margin(1e-3)); 
+            }
+            coeffs(i) -= fdstep;
+        }
+        
+    }
+
+
+    SECTION("Input Gradient"){
+
+        Kokkos::View<double**,Kokkos::HostSpace> sens("Sensitivities", triMap->outputDim, numSamps);
+        for(unsigned int j=0; j<numSamps; ++j){
+            for(unsigned int i=0; i<triMap->outputDim; ++i){
+                sens(i,j) = 1.0 + 0.1*i + j;
+            }
+        }
+
+        Kokkos::View<double**,Kokkos::HostSpace> evals = triMap->Evaluate(in);
+        Kokkos::View<double**,Kokkos::HostSpace> evals2;
+
+        Kokkos::View<double**,Kokkos::HostSpace> inputGrad = triMap->Gradient(in, sens);
+
+        REQUIRE(inputGrad.extent(0)==triMap->inputDim);
+        REQUIRE(inputGrad.extent(1)==numSamps);
+
+        // Compare with finite differences
+        double fdstep = 1e-5;
+        for(unsigned int i=0; i<triMap->inputDim; ++i){
+            for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd)
+                in(i,ptInd) += fdstep;
+
+            evals2 = triMap->Evaluate(in);
+
+            for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd){
+                
+                double fdDeriv = 0.0;
+                for(unsigned int j=0; j<triMap->outputDim; ++j)
+                    fdDeriv += sens(j,ptInd) * (evals2(j,ptInd)-evals(j,ptInd))/fdstep;
+
+                CHECK( inputGrad(i,ptInd) == Approx(fdDeriv).margin(1e-3)); 
+            }
+
+            for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd)
+                in(i,ptInd) -= fdstep;
+        }
+        
+    }
+
+    SECTION("LogDeterminantCoeffGrad"){
+
+        Kokkos::View<double**,Kokkos::HostSpace> sens("Sensitivities", triMap->outputDim, numSamps);
+        for(unsigned int j=0; j<numSamps; ++j){
+            for(unsigned int i=0; i<triMap->outputDim; ++i){
+                sens(i,j) = 1.0 + 0.1*i + j;
+            }
+        }
+
+        Kokkos::View<double**,Kokkos::HostSpace> detGrad = triMap->LogDeterminantCoeffGrad(in);
+        REQUIRE(detGrad.extent(0)==triMap->numCoeffs);
+        REQUIRE(detGrad.extent(1)==numSamps);
+        
+        Kokkos::View<double*,Kokkos::HostSpace> logDet = triMap->LogDeterminant(in);
+        Kokkos::View<double*,Kokkos::HostSpace> logDet2;
+
+        // Compare with finite differences
+        double fdstep = 1e-5;
+        for(unsigned int i=0; i<triMap->numCoeffs; ++i){
+            coeffs(i) += fdstep;
+
+            triMap->SetCoeffs(coeffs);
+            logDet2 = triMap->LogDeterminant(in);
+
+            for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd)
+                CHECK( detGrad(i,ptInd) == Approx((logDet2(ptInd)-logDet(ptInd))/fdstep).margin(1e-4)); 
             
             coeffs(i) -= fdstep;
         }


### PR DESCRIPTION
This adds checks to the CoeffGrad and LogDeterminantCoeffGrad functions in `TriangularMap` so that components with no coefficients are skipped. It also adds a test for `SingleEntryMap` that presented the issue.