### PR TITLE
Changing integration of `MapObjective`

### DIFF
--- a/MParT/AdaptiveTransportMap.h
+++ b/MParT/AdaptiveTransportMap.h
@@ -20,9 +20,9 @@ struct ATMOptions: public MapOptions, public TrainOptions {
     MultiIndex maxDegrees;
 };
 
-template<typename MemorySpace,typename ObjectiveType>
+template<typename MemorySpace>
 std::shared_ptr<ConditionalMapBase<MemorySpace>> AdaptiveTransportMap(std::vector<MultiIndexSet> &mset0,
-    ObjectiveType &objective,
+    std::shared_ptr<MapObjective<MemorySpace>> objective,
     ATMOptions options);
 
 // template<typename MemorySpace>

--- a/MParT/MapObjective.h
+++ b/MParT/MapObjective.h
@@ -62,9 +62,17 @@ class MapObjective {
      * @brief Shortcut to calculate the error of the map on the testing dataset
      *
      * @param map Map to calculate the error on
+     * @return double testing error
+     */
+    double TestError(std::shared_ptr<ConditionalMapBase<MemorySpace>> map) const;
+
+    /**
+     * @brief Shortcut to calculate the error of the map on the training dataset
+     *
+     * @param map Map to calculate the error on
      * @return double training error
      */
-    double TestError(std::shared_ptr<ConditionalMapBase<MemorySpace>> map);
+    double TrainError(std::shared_ptr<ConditionalMapBase<MemorySpace>> map) const;
 
     /**
      * @brief Get the gradient of the map objective with respect to map coefficients on the training dataset
@@ -72,7 +80,7 @@ class MapObjective {
      * @param map Map to use in this objective gradient
      * @return StridedVector<double, MemorySpace> Gradient of the map on the training dataset
      */
-    StridedVector<double, MemorySpace> TrainCoeffGrad(std::shared_ptr<ConditionalMapBase<MemorySpace>> map);
+    StridedVector<double, MemorySpace> TrainCoeffGrad(std::shared_ptr<ConditionalMapBase<MemorySpace>> map) const;
 
     /**
      * @brief Objective value of map at data

--- a/MParT/MapObjective.h
+++ b/MParT/MapObjective.h
@@ -5,6 +5,7 @@
 #include "Distributions/PullbackDensity.h"
 #include "Utilities/ArrayConversions.h"
 #include "Utilities/LinearAlgebra.h"
+#include "Distributions/GaussianSamplerDensity.h"
 
 namespace mpart {
 template<typename MemorySpace>
@@ -49,6 +50,11 @@ class KLObjective: public MapObjective<MemorySpace> {
     private:
     std::shared_ptr<DensityBase<MemorySpace>> density_;
 };
+
+namespace ObjectiveFactory {
+template<typename MemorySpace>
+std::shared_ptr<MapObjective<MemorySpace>> CreateGaussianKLObjective(StridedMatrix<const double, MemorySpace> train, StridedMatrix<const double, MemorySpace> test);
+} // namespace ObjectiveFactory
 
 } // namespace mpart
 

--- a/MParT/MapObjective.h
+++ b/MParT/MapObjective.h
@@ -89,7 +89,8 @@ class MapObjective {
      * @param map map to calculate objective with respect to
      * @return double Objective value of map at data
      */
-    virtual double ObjectiveImpl(StridedMatrix<const double, MemorySpace> data, std::shared_ptr<ConditionalMapBase<MemorySpace>> map) = 0;
+    virtual double ObjectiveImpl(StridedMatrix<const double, MemorySpace> data, std::shared_ptr<ConditionalMapBase<MemorySpace>> map) const = 0;
+
     /**
      * @brief Gradient of the objective at the data with respect to the coefficients of the map
      *
@@ -97,7 +98,15 @@ class MapObjective {
      * @param grad storage for calculating gradient inplace
      * @param map map with coefficients to take gradient on
      */
-    virtual void CoeffGradImpl(StridedMatrix<const double, MemorySpace> data, StridedVector<double, MemorySpace> grad, std::shared_ptr<ConditionalMapBase<MemorySpace>> map) = 0;
+    virtual void CoeffGradImpl(StridedMatrix<const double, MemorySpace> data, StridedVector<double, MemorySpace> grad, std::shared_ptr<ConditionalMapBase<MemorySpace>> map) const = 0;
+
+    /**
+     * @brief Gradient of the objective at the training data with respect to the coefficients of the map
+     *
+     * @param grad storage for calculating gradient inplace
+     * @param map map with coefficients to take gradient on
+     */
+    virtual void TrainCoeffGradImpl(StridedVector<double, MemorySpace> grad, std::shared_ptr<ConditionalMapBase<MemorySpace>> map) const = 0;
 
     /**
      * @brief Implementation of objective and gradient objective calculation (gradient w.r.t. map coefficients), inplace. Default uses `ObjectiveImpl` and `CoeffGradImpl`,
@@ -108,7 +117,7 @@ class MapObjective {
      * @param map Map to evaluate on
      * @return double objective value on the map at the dataset
      */
-    virtual double ObjectivePlusCoeffGradImpl(StridedMatrix<const double, MemorySpace> data, StridedVector<double, MemorySpace> grad, std::shared_ptr<ConditionalMapBase<MemorySpace>> map){
+    virtual double ObjectivePlusCoeffGradImpl(StridedMatrix<const double, MemorySpace> data, StridedVector<double, MemorySpace> grad, std::shared_ptr<ConditionalMapBase<MemorySpace>> map) const {
         CoeffGradImpl(data, grad, map);
         return ObjectiveImpl(data, map);
     }

--- a/MParT/MapObjective.h
+++ b/MParT/MapObjective.h
@@ -53,6 +53,9 @@ class KLObjective: public MapObjective<MemorySpace> {
 
 namespace ObjectiveFactory {
 template<typename MemorySpace>
+std::shared_ptr<MapObjective<MemorySpace>> CreateGaussianKLObjective(StridedMatrix<const double, MemorySpace> train);
+
+template<typename MemorySpace>
 std::shared_ptr<MapObjective<MemorySpace>> CreateGaussianKLObjective(StridedMatrix<const double, MemorySpace> train, StridedMatrix<const double, MemorySpace> test);
 } // namespace ObjectiveFactory
 

--- a/MParT/MapObjective.h
+++ b/MParT/MapObjective.h
@@ -47,6 +47,9 @@ class MapObjective {
      */
     MapObjective(StridedMatrix<const double, MemorySpace> train, StridedMatrix<const double, MemorySpace> test): train_(train), test_(test) {}
 
+    unsigned int Dim(){return train_.extent(0);}
+    unsigned int NumSamples(){return train_.extent(1);}
+
     /**
      * @brief Exposed functor-like function to calculate objective value and its gradient
      *

--- a/MParT/MapObjective.h
+++ b/MParT/MapObjective.h
@@ -101,12 +101,12 @@ class MapObjective {
     virtual void CoeffGradImpl(StridedMatrix<const double, MemorySpace> data, StridedVector<double, MemorySpace> grad, std::shared_ptr<ConditionalMapBase<MemorySpace>> map) const = 0;
 
     /**
-     * @brief Gradient of the objective at the training data with respect to the coefficients of the map
+     * @brief Shortcut to calculate the gradient of the objective on the training dataset w.r.t. the map coefficients
      *
-     * @param grad storage for calculating gradient inplace
-     * @param map map with coefficients to take gradient on
+     * @param map Map to calculate the gradient with respect to
+     * @param grad storage for the gradient
      */
-    virtual void TrainCoeffGradImpl(StridedVector<double, MemorySpace> grad, std::shared_ptr<ConditionalMapBase<MemorySpace>> map) const = 0;
+    void TrainCoeffGradImpl(std::shared_ptr<ConditionalMapBase<MemorySpace>> map, StridedVector<double, MemorySpace> grad) const;
 
     /**
      * @brief Implementation of objective and gradient objective calculation (gradient w.r.t. map coefficients), inplace. Default uses `ObjectiveImpl` and `CoeffGradImpl`,

--- a/MParT/TrainMap.h
+++ b/MParT/TrainMap.h
@@ -39,8 +39,8 @@ struct TrainOptions {
     }
 };
 
-template<typename ObjectiveType>
-double TrainMap(std::shared_ptr<ConditionalMapBase<Kokkos::HostSpace>> map, ObjectiveType &objective, TrainOptions options);
+template<typename MemorySpace>
+double TrainMap(std::shared_ptr<ConditionalMapBase<MemorySpace>> map, std::shared_ptr<MapObjective<MemorySpace>> objective, TrainOptions options);
 
 } // namespace mpart
 

--- a/bindings/julia/src/MapObjective.cpp
+++ b/bindings/julia/src/MapObjective.cpp
@@ -16,7 +16,8 @@ namespace jlcxx {
 
 void mpart::binding::MapObjectiveWrapper(jlcxx::Module &mod) {
     using MemorySpace = Kokkos::HostSpace;
-    std::string tName = "GaussianKLObjective";
+    std::string tName = "KLObjective";
+    std::string mName = "CreateGaussian"+tName;
 
     mod.add_type<MapObjective<MemorySpace>>("MapObjective")
         .method("TrainError", &MapObjective<MemorySpace>::TrainError)
@@ -24,14 +25,14 @@ void mpart::binding::MapObjectiveWrapper(jlcxx::Module &mod) {
     ;
 
     mod.add_type<KLObjective<MemorySpace>>(tName,jlcxx::julia_base_type<MapObjective<MemorySpace>>());
-    mod.method("Create"+tName, [](jlcxx::ArrayRef<double,2> train) {
+    mod.method(mName, [](jlcxx::ArrayRef<double,2> train) {
         StridedMatrix<const double, MemorySpace> trainView = JuliaToKokkos(train);
         Kokkos::View<double**,MemorySpace> storeTrain ("Training data", trainView.extent(0), trainView.extent(1));
         Kokkos::deep_copy(storeTrain, trainView);
         trainView = storeTrain;
         return ObjectiveFactory::CreateGaussianKLObjective(trainView);
     });
-    mod.method("Create"+tName, [](jlcxx::ArrayRef<double,2> train, jlcxx::ArrayRef<double,2> test) {
+    mod.method(mName, [](jlcxx::ArrayRef<double,2> train, jlcxx::ArrayRef<double,2> test) {
         StridedMatrix<const double, MemorySpace> trainView = JuliaToKokkos(train);
         StridedMatrix<const double, MemorySpace> testView = JuliaToKokkos(test);
         Kokkos::View<double**,MemorySpace> storeTrain ("Training data", trainView.extent(0), trainView.extent(1));

--- a/bindings/julia/src/TrainMap.cpp
+++ b/bindings/julia/src/TrainMap.cpp
@@ -17,5 +17,5 @@ void mpart::binding::TrainMapWrapper(jlcxx::Module &mod) {
     mod.unset_override_module();
 
     // TrainMap
-    mod.method("TrainMap", &mpart::TrainMap<KLObjective<Kokkos::HostSpace>>);
+    mod.method("TrainMap", &mpart::TrainMap<Kokkos::HostSpace>);
 }

--- a/bindings/matlab/include/MexWrapperTypes.h
+++ b/bindings/matlab/include/MexWrapperTypes.h
@@ -77,7 +77,7 @@ public:
 // Instance manager for ConditionalMap.
 template class mexplus::Session<ConditionalMapMex>;
 template class mexplus::Session<ParameterizedFunctionMex>;
-template class mexplus::Session<MapObjectiveMex>
+template class mexplus::Session<MapObjectiveMex>;
 
 
 #endif // MPART_MEXWRAPPERTYPES_H

--- a/bindings/matlab/include/MexWrapperTypes.h
+++ b/bindings/matlab/include/MexWrapperTypes.h
@@ -1,0 +1,84 @@
+#ifndef MPART_MEXWRAPPERTYPES_H
+#define MPART_MEXWRAPPERTYPES_H
+
+#include <fstream>
+#include <mexplus.h>
+#include "MParT/ConditionalMapBase.h"
+#include "MParT/TriangularMap.h"
+#include "MParT/ComposedMap.h"
+#include "MParT/AffineMap.h"
+#include "MParT/MapObjective.h"
+
+
+using namespace mpart;
+using namespace mpart::binding;
+using namespace mexplus;
+using MemorySpace = Kokkos::HostSpace;
+
+class ConditionalMapMex {       // The class
+public:
+  std::shared_ptr<ConditionalMapBase<MemorySpace>> map_ptr;
+
+  ConditionalMapMex(FixedMultiIndexSet<MemorySpace> const& mset,
+                    MapOptions                             opts){
+    map_ptr = MapFactory::CreateComponent<MemorySpace>(mset,opts);
+  }
+
+  ConditionalMapMex(std::shared_ptr<ConditionalMapBase<MemorySpace>> init_ptr){
+    map_ptr = init_ptr;
+  }
+
+  ConditionalMapMex(std::vector<std::shared_ptr<ConditionalMapBase<MemorySpace>>> blocks){
+    map_ptr = std::make_shared<TriangularMap<MemorySpace>>(blocks);
+  }
+
+  ConditionalMapMex(unsigned int inputDim, unsigned int outputDim, unsigned int totalOrder, MapOptions opts){
+    map_ptr = MapFactory::CreateTriangular<MemorySpace>(inputDim,outputDim,totalOrder,opts);
+  }
+
+  ConditionalMapMex(std::vector<std::shared_ptr<ConditionalMapBase<MemorySpace>>> triMaps,std::string typeMap){
+    map_ptr = std::make_shared<ComposedMap<MemorySpace>>(triMaps);
+  }
+
+  ConditionalMapMex(StridedMatrix<double,MemorySpace> A, StridedVector<double,MemorySpace> b){
+    map_ptr = std::make_shared<AffineMap<MemorySpace>>(A,b);
+  }
+
+  ConditionalMapMex(StridedMatrix<double,MemorySpace> A){
+    map_ptr = std::make_shared<AffineMap<MemorySpace>>(A);
+  }
+
+  ConditionalMapMex(StridedVector<double,MemorySpace> b){
+    map_ptr = std::make_shared<AffineMap<MemorySpace>>(b);
+  }
+
+}; //end class
+
+class ParameterizedFunctionMex {       // The class
+public:
+  std::shared_ptr<ParameterizedFunctionBase<MemorySpace>> fun_ptr;
+
+  ParameterizedFunctionMex(unsigned int outputDim, FixedMultiIndexSet<MemorySpace> const& mset,
+                    MapOptions opts){
+    fun_ptr = MapFactory::CreateExpansion<MemorySpace>(outputDim,mset,opts);
+  }
+
+  ParameterizedFunctionMex(std::shared_ptr<ParameterizedFunctionBase<MemorySpace>> init_ptr){
+    fun_ptr = init_ptr;
+  }
+}; //end class
+
+class MapObjectiveMex {       // The class
+public:
+    std::shared_ptr<MapObjective<MemorySpace>> obj_ptr;
+
+    MapObjectiveMex(std::shared_ptr<MapObjective<MemorySpace>> init_ptr): obj_ptr(init_ptr) {};
+}
+
+// Instance manager for ConditionalMap.
+template class mexplus::Session<ConditionalMapMex>;
+template class mexplus::Session<ParameterizedFunctionMex>;
+template class mexplus::Session<MapObjectiveMex>
+
+
+#endif // MPART_MEXWRAPPERTYPES_H

--- a/bindings/matlab/include/MexWrapperTypes.h
+++ b/bindings/matlab/include/MexWrapperTypes.h
@@ -11,7 +11,6 @@
 
 
 using namespace mpart;
-using namespace mpart::binding;
 using namespace mexplus;
 using MemorySpace = Kokkos::HostSpace;
 
@@ -73,7 +72,7 @@ public:
     std::shared_ptr<MapObjective<MemorySpace>> obj_ptr;
 
     MapObjectiveMex(std::shared_ptr<MapObjective<MemorySpace>> init_ptr): obj_ptr(init_ptr) {};
-}
+};
 
 // Instance manager for ConditionalMap.
 template class mexplus::Session<ConditionalMapMex>;

--- a/bindings/matlab/mat/GaussianKLObjective.m
+++ b/bindings/matlab/mat/GaussianKLObjective.m
@@ -14,13 +14,13 @@ methods
     end
 
     function delete(this)
-        MParT_('GaussianKLObjective_delete',this.id_);
+        MParT_('MapObjective_delete',this.id_);
     end
 
     function result = TestError(this, map)
         result = MParT_('GaussianKLObjective_TestError',this.id_,map.get_id());
     end
-    
+
     function result = TrainError(this, map)
         result = MParT_('GaussianKLObjective_TrainError',this.id_,map.get_id());
     end
@@ -29,7 +29,7 @@ methods
         result = zeros(map.numCoeffs,1);
         MParT_('GaussianKLObjective_TrainCoeffGrad', this.id_, map.get_id(),result);
     end
-    
+
     function result = get_id(this)
         result = this.id_;
     end

--- a/bindings/matlab/src/ConditionalMap_mex.cpp
+++ b/bindings/matlab/src/ConditionalMap_mex.cpp
@@ -96,7 +96,7 @@ MEX_DEFINE(ConditionalMap_newTotalTriMap) (int nlhs, mxArray* plhs[],
   unsigned int outputDim = input.get<unsigned int>(1);
   unsigned int totalOrder = input.get<unsigned int>(2);
 
-  MapOptions opts = MapOptionsFromMatlab(input.get<std::string>(3),input.get<std::string>(4),
+  MapOptions opts = binding::MapOptionsFromMatlab(input.get<std::string>(3),input.get<std::string>(4),
                                          input.get<std::string>(5),input.get<double>(6),
                                          input.get<double>(7),input.get<unsigned int>(8),
                                          input.get<unsigned int>(9),input.get<unsigned int>(10),
@@ -111,7 +111,7 @@ MEX_DEFINE(ConditionalMap_newMap) (int nlhs, mxArray* plhs[],
   InputArguments input(nrhs, prhs, 13);
   OutputArguments output(nlhs, plhs, 1);
   const MultiIndexSet& mset = Session<MultiIndexSet>::getConst(input.get(0));
-  MapOptions opts = MapOptionsFromMatlab(input.get<std::string>(1),input.get<std::string>(2),
+  MapOptions opts = binding::MapOptionsFromMatlab(input.get<std::string>(1),input.get<std::string>(2),
                                          input.get<std::string>(3),input.get<double>(4),
                                          input.get<double>(5),input.get<unsigned int>(6),
                                          input.get<unsigned int>(7),input.get<unsigned int>(8),
@@ -126,7 +126,7 @@ MEX_DEFINE(ConditionalMap_newMapFixed) (int nlhs, mxArray* plhs[],
   InputArguments input(nrhs, prhs, 13);
   OutputArguments output(nlhs, plhs, 1);
   const FixedMultiIndexSet<MemorySpace>& mset = Session<FixedMultiIndexSet<MemorySpace>>::getConst(input.get(0));
-  MapOptions opts = MapOptionsFromMatlab(input.get<std::string>(1),input.get<std::string>(2),
+  MapOptions opts = binding::MapOptionsFromMatlab(input.get<std::string>(1),input.get<std::string>(2),
                                          input.get<std::string>(3),input.get<double>(4),
                                          input.get<double>(5),input.get<unsigned int>(6),
                                          input.get<unsigned int>(7),input.get<unsigned int>(8),

--- a/bindings/matlab/src/ConditionalMap_mex.cpp
+++ b/bindings/matlab/src/ConditionalMap_mex.cpp
@@ -12,7 +12,6 @@
 #include "MexOptionsConversions.h"
 
 using namespace mpart;
-using namespace mpart::binding;
 using namespace mexplus;
 using MemorySpace = Kokkos::HostSpace;
 
@@ -173,14 +172,15 @@ MEX_DEFINE(ConditionalMap_TrainMap) (int nlhs, mxArray* plhs[],
     OutputArguments output(nlhs, plhs, 0);
     ConditionalMapMex *condMap = Session<ConditionalMapMex>::get(input.get(0));
     std::shared_ptr<ConditionalMapBase<MemorySpace>> condMap_ptr = condMap->map_ptr;
-    KLObjective<MemorySpace>& obj = *Session<KLObjective<MemorySpace>>::get(input.get(1));
+    MapObjectiveMex *obj = Session<MapObjectiveMex>::get(input.get(1));
+    std::shared_ptr<MapObjective<MemorySpace>> obj_ptr = obj->obj->ptr;
 
     TrainOptions opts {input.get<std::string>(2),input.get<double>(3),
                       input.get<double>(4), input.get<double>(5),
                       input.get<double>(6), input.get<double>(7),
                       input.get<int>(8), input.get<double>(9), input.get<bool>(10)};
 
-    TrainMap<KLObjective<MemorySpace>>(condMap_ptr, obj, opts);
+    TrainMap<MemorySpace>(condMap_ptr, obj_ptr, opts);
   }
 
 // Defines MEX API for delete.

--- a/bindings/matlab/src/ConditionalMap_mex.cpp
+++ b/bindings/matlab/src/ConditionalMap_mex.cpp
@@ -204,31 +204,31 @@ MEX_DEFINE(GaussianKLObjective_TestError) (int nlhs, mxArray* plhs[],
                     int nrhs, const mxArray* prhs[]) {
   InputArguments input(nrhs, prhs, 2);
   OutputArguments output(nlhs, plhs, 1);
-  const KLObjective<MemorySpace>& obj = Session<KLObjective<MemorySpace>>::getConst(input.get(0));
+  const MapObjectiveMex& obj = Session<MapObjective<MemorySpace>>::getConst(input.get(0));
   ConditionalMapMex *condMap = Session<ConditionalMapMex>::get(input.get(1));
   std::shared_ptr<ConditionalMapBase<MemorySpace>> condMap_ptr = condMap->map_ptr;
-  output.set(0, obj.TestError(condMap_ptr));
+  output.set(0, obj.obj_ptr->TestError(condMap_ptr));
 }
 
 MEX_DEFINE(GaussianKLObjective_TrainCoeffGrad) (int nlhs, mxArray* plhs[],
                     int nrhs, const mxArray* prhs[]) {
   InputArguments input(nrhs, prhs, 3);
   
-  const KLObjective<MemorySpace>& obj = Session<KLObjective<MemorySpace>>::getConst(input.get(0));
+  const MapObjectiveMex& obj = Session<MapObjective<MemorySpace>>::getConst(input.get(0));
   ConditionalMapMex *condMap = Session<ConditionalMapMex>::get(input.get(1));
   std::shared_ptr<ConditionalMapBase<MemorySpace>> condMap_ptr = condMap->map_ptr;
   StridedVector<double, Kokkos::HostSpace> out = MexToKokkos1d(prhs[2]);
-  obj.TrainCoeffGradImpl(condMap_ptr, out);
+  obj.obj_ptr->TrainCoeffGradImpl(condMap_ptr, out);
 }
 
 MEX_DEFINE(GaussianKLObjective_TrainError) (int nlhs, mxArray* plhs[],
                     int nrhs, const mxArray* prhs[]) {
   InputArguments input(nrhs, prhs, 2);
   OutputArguments output(nlhs, plhs, 1);
-  const KLObjective<MemorySpace>& obj = Session<KLObjective<MemorySpace>>::getConst(input.get(0));
+  const MapObjectiveMex& obj = Session<MapObjective<MemorySpace>>::getConst(input.get(0));
   ConditionalMapMex *condMap = Session<ConditionalMapMex>::get(input.get(1));
   std::shared_ptr<ConditionalMapBase<MemorySpace>> condMap_ptr = condMap->map_ptr;
-  output.set(0, obj.TrainError(condMap_ptr));
+  output.set(0, obj.obj_ptr->TrainError(condMap_ptr));
 }
 
 MEX_DEFINE(ConditionalMap_TrainMap) (int nlhs, mxArray* plhs[],

--- a/bindings/matlab/src/ConditionalMap_mex.cpp
+++ b/bindings/matlab/src/ConditionalMap_mex.cpp
@@ -173,7 +173,7 @@ MEX_DEFINE(ConditionalMap_TrainMap) (int nlhs, mxArray* plhs[],
     ConditionalMapMex *condMap = Session<ConditionalMapMex>::get(input.get(0));
     std::shared_ptr<ConditionalMapBase<MemorySpace>> condMap_ptr = condMap->map_ptr;
     MapObjectiveMex *obj = Session<MapObjectiveMex>::get(input.get(1));
-    std::shared_ptr<MapObjective<MemorySpace>> obj_ptr = obj->obj->ptr;
+    std::shared_ptr<MapObjective<MemorySpace>> obj_ptr = obj->obj_ptr;
 
     TrainOptions opts {input.get<std::string>(2),input.get<double>(3),
                       input.get<double>(4), input.get<double>(5),

--- a/bindings/matlab/src/MapObjective_mex.cpp
+++ b/bindings/matlab/src/MapObjective_mex.cpp
@@ -1,7 +1,10 @@
-#include "MParT/MultiIndices/FixedMultiIndexSet.h"
-#include "MParT/MapObjective.h"
 #include "MParT/Utilities/ArrayConversions.h"
+#include "MParT/MultiIndices/FixedMultiIndexSet.h"
+#include "MParT/MapOptions.h"
+#include "MParT/MapFactory.h"
 #include "MParT/Distributions/GaussianSamplerDensity.h"
+#include "MParT/MapObjective.h"
+#include "MParT/TrainMap.h"
 
 #include "MexWrapperTypes.h"
 #include "MexArrayConversions.h"
@@ -18,8 +21,8 @@ namespace {
 
         InputArguments input(nrhs, prhs, 1);
         OutputArguments output(nlhs, plhs, 1);
-        auto train = MexToKokkos2d(prhs[0]);
-        auto objective = ObjectiveFactory::CreateGaussianKLObjective(train);
+        StridedMatrix<const double, MemorySpace> train = MexToKokkos2d(prhs[0]);
+        std::shared_ptr<MapObjective<MemorySpace>> objective = ObjectiveFactory::CreateGaussianKLObjective(train);
         output.set(0, Session<MapObjectiveMex>::create(new MapObjectiveMex(objective)));
     }
 
@@ -29,9 +32,9 @@ namespace {
 
         InputArguments input(nrhs, prhs, 2);
         OutputArguments output(nlhs, plhs, 1);
-        auto train = MexToKokkos2d(prhs[0]);
-        auto test = MexToKokkos2d(prhs[1]);
-        auto objective = ObjectiveFactory::CreateGaussianKLObjective(train, test);
+        StridedMatrix<const double, MemorySpace> train = MexToKokkos2d(prhs[0]);
+        StridedMatrix<const double, MemorySpace> test = MexToKokkos2d(prhs[1]);
+        std::shared_ptr<MapObjective<MemorySpace>> objective = ObjectiveFactory::CreateGaussianKLObjective(train, test);
         output.set(0, Session<MapObjectiveMex>::create(new MapObjectiveMex(objective));
     }
 

--- a/bindings/matlab/src/MapObjective_mex.cpp
+++ b/bindings/matlab/src/MapObjective_mex.cpp
@@ -11,31 +11,35 @@ using namespace mexplus;
 using MemorySpace = Kokkos::HostSpace;
 
 // Instance manager for KL objective.
-template class mexplus::Session<KLObjective<Kokkos::HostSpace>>;
+template class mexplus::Session<MapObjective<Kokkos::HostSpace>>;
+class MapObjectiveMex {       // The class
+public:
+    std::shared_ptr<MapObjective<MemorySpace>> obj_ptr;
 
+    MapObjectiveMex(std::shared_ptr<MapObjective<MemorySpace>> init_ptr): obj_ptr(init_ptr) {};
+}
 namespace {
     // Defines MEX API for new.
     MEX_DEFINE(GaussianKLObjective_newTrain) (int nlhs, mxArray* plhs[],
                                               int nrhs, const mxArray* prhs[]) {
-  
+
         InputArguments input(nrhs, prhs, 1);
         OutputArguments output(nlhs, plhs, 1);
         auto train = MexToKokkos2d(prhs[0]);
-        unsigned int dim = train.extent(0);
-        std::shared_ptr<mpart::GaussianSamplerDensity<MemorySpace>> density = std::make_shared<mpart::GaussianSamplerDensity<MemorySpace>>(dim);
-        output.set(0, Session<KLObjective<MemorySpace>>::create(new KLObjective<MemorySpace>(train, density)));
+        auto objective = ObjectiveFactory::CreateGaussianKLObjective(train);
+        output.set(0, Session<KLObjective<MemorySpace>>::create(new MapObjectiveMex(objective)));
     }
+
     // Defines MEX API for new.
     MEX_DEFINE(GaussianKLObjective_newTrainTest) (int nlhs, mxArray* plhs[],
                                               int nrhs, const mxArray* prhs[]) {
-  
+
         InputArguments input(nrhs, prhs, 2);
         OutputArguments output(nlhs, plhs, 1);
         auto train = MexToKokkos2d(prhs[0]);
         auto test = MexToKokkos2d(prhs[1]);
-        unsigned int dim = train.extent(0);
-        std::shared_ptr<mpart::GaussianSamplerDensity<MemorySpace>> density = std::make_shared<mpart::GaussianSamplerDensity<MemorySpace>>(dim);
-        output.set(0, Session<KLObjective<MemorySpace>>::create(new KLObjective<MemorySpace>(train, test, density)));
+        auto objective = ObjectiveFactory::CreateGaussianKLObjective(train, test);
+        output.set(0, Session<KLObjective<MemorySpace>>::create(new MapObjectiveMex(objective));
     }
 
     // Defines MEX API for delete.

--- a/bindings/matlab/src/MapObjective_mex.cpp
+++ b/bindings/matlab/src/MapObjective_mex.cpp
@@ -1,23 +1,16 @@
-#include <mexplus.h>
-#include "MexArrayConversions.h"
-#include "mexplus_eigen.h"
 #include "MParT/MultiIndices/FixedMultiIndexSet.h"
 #include "MParT/MapObjective.h"
 #include "MParT/Utilities/ArrayConversions.h"
 #include "MParT/Distributions/GaussianSamplerDensity.h"
 
+#include "MexWrapperTypes.h"
+#include "MexArrayConversions.h"
+#include "mexplus_eigen.h"
+
 using namespace mpart;
 using namespace mexplus;
 using MemorySpace = Kokkos::HostSpace;
 
-// Instance manager for KL objective.
-template class mexplus::Session<MapObjective<Kokkos::HostSpace>>;
-class MapObjectiveMex {       // The class
-public:
-    std::shared_ptr<MapObjective<MemorySpace>> obj_ptr;
-
-    MapObjectiveMex(std::shared_ptr<MapObjective<MemorySpace>> init_ptr): obj_ptr(init_ptr) {};
-}
 namespace {
     // Defines MEX API for new.
     MEX_DEFINE(GaussianKLObjective_newTrain) (int nlhs, mxArray* plhs[],
@@ -27,7 +20,7 @@ namespace {
         OutputArguments output(nlhs, plhs, 1);
         auto train = MexToKokkos2d(prhs[0]);
         auto objective = ObjectiveFactory::CreateGaussianKLObjective(train);
-        output.set(0, Session<MapObjective<MemorySpace>>::create(new MapObjectiveMex(objective)));
+        output.set(0, Session<MapObjectiveMex>::create(new MapObjectiveMex(objective)));
     }
 
     // Defines MEX API for new.
@@ -39,7 +32,7 @@ namespace {
         auto train = MexToKokkos2d(prhs[0]);
         auto test = MexToKokkos2d(prhs[1]);
         auto objective = ObjectiveFactory::CreateGaussianKLObjective(train, test);
-        output.set(0, Session<MapObjective<MemorySpace>>::create(new MapObjectiveMex(objective));
+        output.set(0, Session<MapObjectiveMex>::create(new MapObjectiveMex(objective));
     }
 
     // Defines MEX API for delete.
@@ -47,7 +40,7 @@ namespace {
                         int nrhs, const mxArray* prhs[]) {
     InputArguments input(nrhs, prhs, 1);
     OutputArguments output(nlhs, plhs, 0);
-    Session<MapObjective<MemorySpace>>::destroy(input.get(0));
+    Session<MapObjectiveMex>::destroy(input.get(0));
     }
 
 }

--- a/bindings/matlab/src/MapObjective_mex.cpp
+++ b/bindings/matlab/src/MapObjective_mex.cpp
@@ -27,7 +27,7 @@ namespace {
         OutputArguments output(nlhs, plhs, 1);
         auto train = MexToKokkos2d(prhs[0]);
         auto objective = ObjectiveFactory::CreateGaussianKLObjective(train);
-        output.set(0, Session<KLObjective<MemorySpace>>::create(new MapObjectiveMex(objective)));
+        output.set(0, Session<MapObjective<MemorySpace>>::create(new MapObjectiveMex(objective)));
     }
 
     // Defines MEX API for new.
@@ -39,15 +39,15 @@ namespace {
         auto train = MexToKokkos2d(prhs[0]);
         auto test = MexToKokkos2d(prhs[1]);
         auto objective = ObjectiveFactory::CreateGaussianKLObjective(train, test);
-        output.set(0, Session<KLObjective<MemorySpace>>::create(new MapObjectiveMex(objective));
+        output.set(0, Session<MapObjective<MemorySpace>>::create(new MapObjectiveMex(objective));
     }
 
     // Defines MEX API for delete.
-    MEX_DEFINE(GaussianKLObjective_delete) (int nlhs, mxArray* plhs[],
+    MEX_DEFINE(MapObjective_delete) (int nlhs, mxArray* plhs[],
                         int nrhs, const mxArray* prhs[]) {
     InputArguments input(nrhs, prhs, 1);
     OutputArguments output(nlhs, plhs, 0);
-    Session<KLObjective<MemorySpace>>::destroy(input.get(0));
+    Session<MapObjective<MemorySpace>>::destroy(input.get(0));
     }
 
 }

--- a/bindings/matlab/src/MapObjective_mex.cpp
+++ b/bindings/matlab/src/MapObjective_mex.cpp
@@ -35,7 +35,7 @@ namespace {
         StridedMatrix<const double, MemorySpace> train = MexToKokkos2d(prhs[0]);
         StridedMatrix<const double, MemorySpace> test = MexToKokkos2d(prhs[1]);
         std::shared_ptr<MapObjective<MemorySpace>> objective = ObjectiveFactory::CreateGaussianKLObjective(train, test);
-        output.set(0, Session<MapObjectiveMex>::create(new MapObjectiveMex(objective));
+        output.set(0, Session<MapObjectiveMex>::create(new MapObjectiveMex(objective)));
     }
 
     // Defines MEX API for delete.

--- a/bindings/python/src/MapObjective.cpp
+++ b/bindings/python/src/MapObjective.cpp
@@ -25,24 +25,25 @@ void mpart::binding::MapObjectiveWrapper(py::module &m) {
         .def("TrainError", &KLObjective<MemorySpace>::TrainError)
     ;
 
-    py::class_<KLObjective<MemorySpace>, MapObjective<MemorySpace>, std::shared_ptr<KLObjective<MemorySpace>>>(m, tName.c_str())
-        .def(py::init( [](Eigen::Ref<Eigen::MatrixXd> &train){
-            StridedMatrix<double, MemorySpace> trainView = MatToKokkos<double, MemorySpace>(train);
+    py::class_<KLObjective<MemorySpace>, MapObjective<MemorySpace>, std::shared_ptr<KLObjective<MemorySpace>>>(m, tName.c_str());
+    m.def(("Create"+tName).c_str(), [](Eigen::Ref<Eigen::MatrixXd> &train){
+            StridedMatrix<const double, MemorySpace> trainView = MatToKokkos<double, MemorySpace>(train);
             Kokkos::View<double**,MemorySpace> storeTrain ("Training data store", trainView.extent(0), trainView.extent(1));
             Kokkos::deep_copy(storeTrain, trainView);
-            std::shared_ptr<GaussianSamplerDensity<MemorySpace>> density = std::make_shared<GaussianSamplerDensity<MemorySpace>>(trainView.extent(0));
-            return std::make_shared<KLObjective<MemorySpace>>(storeTrain, density);
-        }))
-        .def(py::init( [](Eigen::Ref<Eigen::MatrixXd> &train, Eigen::Ref<Eigen::MatrixXd> &test){
-            StridedMatrix<double, MemorySpace> trainView = MatToKokkos<double, MemorySpace>(train);
-            StridedMatrix<double, MemorySpace> testView = MatToKokkos<double, MemorySpace>(test);
+            trainView = storeTrain;
+            return ObjectiveFactory::CreateGaussianKLObjective(trainView);
+        })
+        .def(("Create"+tName).c_str(), [](Eigen::Ref<Eigen::MatrixXd> &trainEig, Eigen::Ref<Eigen::MatrixXd> &testEig){
+            StridedMatrix<const double, MemorySpace> trainView = MatToKokkos<double, MemorySpace>(trainEig);
+            StridedMatrix<const double, MemorySpace> testView = MatToKokkos<double, MemorySpace>(testEig);
             Kokkos::View<double**,MemorySpace> storeTrain ("Training data store", trainView.extent(0), trainView.extent(1));
             Kokkos::View<double**,MemorySpace> storeTest ("Testing data store", testView.extent(0), testView.extent(1));
             Kokkos::deep_copy(storeTrain, trainView);
             Kokkos::deep_copy(storeTest, testView);
-            std::shared_ptr<GaussianSamplerDensity<MemorySpace>> density = std::make_shared<GaussianSamplerDensity<MemorySpace>>(trainView.extent(0));
-            return std::make_shared<KLObjective<MemorySpace>>(storeTrain, storeTest, density);
-        }))
+            trainView = storeTrain;
+            testView = storeTest;
+            return ObjectiveFactory::CreateGaussianKLObjective(trainView, testView);
+        })
     ;
 }
 

--- a/bindings/python/src/TrainMap.cpp
+++ b/bindings/python/src/TrainMap.cpp
@@ -42,9 +42,7 @@ void mpart::binding::TrainMapWrapper(py::module &m) {
     std::string tName = "TrainMap";
     if(!std::is_same<MemorySpace,Kokkos::HostSpace>::value) tName = "d" + tName;
 
-    m.def(tName.c_str(), [](std::shared_ptr<ConditionalMapBase<MemorySpace>> map, std::shared_ptr<KLObjective<MemorySpace>> kl, TrainOptions opts){
-        TrainMap(map, *kl, opts);
-    })
+    m.def(tName.c_str(), &TrainMap<Kokkos::HostSpace>)
     ;
 }
 

--- a/bindings/python/src/Wrapper.cpp
+++ b/bindings/python/src/Wrapper.cpp
@@ -20,10 +20,12 @@ PYBIND11_MODULE(pympart, m) {
     IdentityMapWrapper<Kokkos::HostSpace>(m);
     // DebugMapWrapper<Kokkos::HostSpace>(m);
 
+#if defined(MPART_HAS_NLOPT)
     MapObjectiveWrapper<Kokkos::HostSpace>(m);
     TrainOptionsWrapper(m);
     TrainMapWrapper<Kokkos::HostSpace>(m);
     MapFactoryWrapper<Kokkos::HostSpace>(m);
+#endif // MPART_HAS_NLOPT
 
 #if defined(MPART_HAS_CEREAL)
     DeserializeWrapper<Kokkos::HostSpace>(m);

--- a/bindings/python/tests/test_TrainMap.py
+++ b/bindings/python/tests/test_TrainMap.py
@@ -17,7 +17,7 @@ test_samples = target_samples[:,:testPts]
 train_samples = target_samples[:,testPts:]
 
 # Create training objective
-obj = mpart.GaussianKLObjective(np.asfortranarray(train_samples),np.asfortranarray(test_samples))
+obj = mpart.CreateGaussianKLObjective(np.asfortranarray(train_samples),np.asfortranarray(test_samples))
 
 # Create untrained map
 map_options = mpart.MapOptions()

--- a/src/AdaptiveTransportMap.cpp
+++ b/src/AdaptiveTransportMap.cpp
@@ -42,11 +42,11 @@ void maxDegreeRMFilter(std::vector<MultiIndexSet> const &msets, MultiIndex const
 
 template<>
 std::shared_ptr<ConditionalMapBase<Kokkos::HostSpace>> mpart::AdaptiveTransportMap(std::vector<MultiIndexSet> &mset0,
-        KLObjective<Kokkos::HostSpace> &objective,
+        std::shared_ptr<MapObjective<Kokkos::HostSpace>> objective,
         ATMOptions options) {
 
     // Dimensions
-    unsigned int inputDim = objective.Dim();
+    unsigned int inputDim = objective->Dim();
     unsigned int outputDim = mset0.size();
 
     std::vector<unsigned int> mset_sizes (outputDim);
@@ -120,7 +120,7 @@ std::shared_ptr<ConditionalMapBase<Kokkos::HostSpace>> mpart::AdaptiveTransportM
         std::cout << "Initial map:" << std::endl;
     }
     TrainMap(map, objective, options);
-    double bestError = objective.TestError(map);
+    double bestError = objective->TestError(map);
 
     if(options.verbose) {
         std::cout << "Initial map test error: " << bestError << std::endl;
@@ -159,7 +159,7 @@ std::shared_ptr<ConditionalMapBase<Kokkos::HostSpace>> mpart::AdaptiveTransportM
         // Create a temporary map
         std::shared_ptr<ConditionalMapBase<Kokkos::HostSpace>> mapTmp = std::make_shared<TriangularMap<Kokkos::HostSpace>>(mapBlocksTmp, true);
         // Calculate the gradient of the map with expanded margins
-        StridedVector<double, Kokkos::HostSpace> gradCoeff = objective.TrainCoeffGrad(mapTmp);
+        StridedVector<double, Kokkos::HostSpace> gradCoeff = objective->TrainCoeffGrad(mapTmp);
         int coeffIdx = 0;
         if(options.verbose > 1) {
             for(int output=0; output<outputDim; output++){
@@ -213,7 +213,7 @@ std::shared_ptr<ConditionalMapBase<Kokkos::HostSpace>> mpart::AdaptiveTransportM
         // Train a map with the new MultiIndex
         double train_error = TrainMap(map, objective, options);
         // Get the testing error and assess the best map
-        double test_error = objective.TestError(map);
+        double test_error = objective->TestError(map);
 
         // Finish this step
         currPatience++;
@@ -246,7 +246,7 @@ std::shared_ptr<ConditionalMapBase<Kokkos::HostSpace>> mpart::AdaptiveTransportM
     // Train a map with the new MultiIndex
     double train_error = TrainMap(map, objective, options);
     // Get the testing error and assess the best map
-    double test_error = objective.TestError(map);
+    double test_error = objective->TestError(map);
 
     if(options.verbose) {
         std::cout << "\nFinal training error: " << train_error << ", final testing error: " << test_error;

--- a/src/MapObjective.cpp
+++ b/src/MapObjective.cpp
@@ -36,6 +36,12 @@ StridedVector<double, MemorySpace> MapObjective<MemorySpace>::TrainCoeffGrad(std
 }
 
 template<typename MemorySpace>
+std::shared_ptr<MapObjective<MemorySpace>> ObjectiveFactory::CreateGaussianKLObjective(StridedMatrix<const double, MemorySpace> train) {
+    std::shared_ptr<GaussianSamplerDensity<MemorySpace>> density = std::make_shared<GaussianSamplerDensity<MemorySpace>>(train.extent(0));
+    return std::make_shared<KLObjective<MemorySpace>>(train, density);
+}
+
+template<typename MemorySpace>
 std::shared_ptr<MapObjective<MemorySpace>> ObjectiveFactory::CreateGaussianKLObjective(StridedMatrix<const double, MemorySpace> train, StridedMatrix<const double, MemorySpace> test) {
     std::shared_ptr<GaussianSamplerDensity<MemorySpace>> density = std::make_shared<GaussianSamplerDensity<MemorySpace>>(train.extent(0));
     return std::make_shared<KLObjective<MemorySpace>>(train, test, density);
@@ -81,9 +87,11 @@ void KLObjective<MemorySpace>::CoeffGradImpl(StridedMatrix<const double, MemoryS
 // Explicit template instantiation
 template class mpart::MapObjective<Kokkos::HostSpace>;
 template class mpart::KLObjective<Kokkos::HostSpace>;
-template std::shared_ptr<MapObjective<Kokkos::HostSpace>> mpart::ObjectiveFactory::CreateGaussianKLObjective<Kokkos::HostSpace>(StridedMatrix<const double, Kokkos::HostSpace> train, StridedMatrix<const double, Kokkos::HostSpace> test);
+template std::shared_ptr<MapObjective<Kokkos::HostSpace>> mpart::ObjectiveFactory::CreateGaussianKLObjective<Kokkos::HostSpace>(StridedMatrix<const double, Kokkos::HostSpace>);
+template std::shared_ptr<MapObjective<Kokkos::HostSpace>> mpart::ObjectiveFactory::CreateGaussianKLObjective<Kokkos::HostSpace>(StridedMatrix<const double, Kokkos::HostSpace>, StridedMatrix<const double, Kokkos::HostSpace>);
 #if defined(MPART_ENABLE_GPU)
     template class mpart::MapObjective<DeviceSpace>;
     template class mpart::KLObjective<DeviceSpace>;
+    template std::shared_ptr<MapObjective<DeviceSpace>> mpart::ObjectiveFactory::CreateGaussianKLObjective<DeviceSpace>(StridedMatrix<const double, DeviceSpace>);
     template std::shared_ptr<MapObjective<DeviceSpace>> mpart::ObjectiveFactory::CreateGaussianKLObjective<DeviceSpace>(StridedMatrix<const double, DeviceSpace>, StridedMatrix<const double, DeviceSpace>);
 #endif

--- a/src/MapObjective.cpp
+++ b/src/MapObjective.cpp
@@ -36,7 +36,7 @@ StridedVector<double, MemorySpace> MapObjective<MemorySpace>::TrainCoeffGrad(std
 }
 
 template<typename MemorySpace>
-std::shared_ptr<KLObjective<MemorySpace>> GaussianKLObjective(StridedMatrix<const double, MemorySpace> train, StridedMatrix<const double, MemorySpace> test) {
+std::shared_ptr<MapObjective<MemorySpace>> ObjectiveFactory::CreateGaussianKLObjective(StridedMatrix<const double, MemorySpace> train, StridedMatrix<const double, MemorySpace> test) {
     std::shared_ptr<GaussianSamplerDensity<MemorySpace>> density = std::make_shared<GaussianSamplerDensity<MemorySpace>>(train.extent(0));
     return std::make_shared<KLObjective<MemorySpace>>(train, test, density);
 }
@@ -81,7 +81,9 @@ void KLObjective<MemorySpace>::CoeffGradImpl(StridedMatrix<const double, MemoryS
 // Explicit template instantiation
 template class mpart::MapObjective<Kokkos::HostSpace>;
 template class mpart::KLObjective<Kokkos::HostSpace>;
+template std::shared_ptr<MapObjective<Kokkos::HostSpace>> mpart::ObjectiveFactory::CreateGaussianKLObjective<Kokkos::HostSpace>(StridedMatrix<const double, Kokkos::HostSpace> train, StridedMatrix<const double, Kokkos::HostSpace> test);
 #if defined(MPART_ENABLE_GPU)
     template class mpart::MapObjective<DeviceSpace>;
     template class mpart::KLObjective<DeviceSpace>;
+    template std::shared_ptr<MapObjective<DeviceSpace>> mpart::ObjectiveFactory::CreateGaussianKLObjective<DeviceSpace>(StridedMatrix<const double, DeviceSpace>, StridedMatrix<const double, DeviceSpace>);
 #endif

--- a/src/MapObjective.cpp
+++ b/src/MapObjective.cpp
@@ -35,6 +35,11 @@ StridedVector<double, MemorySpace> MapObjective<MemorySpace>::TrainCoeffGrad(std
     return grad;
 }
 
+template<typename MemorySpace>
+std::shared_ptr<KLObjective<MemorySpace>> GaussianKLObjective(StridedMatrix<const double, MemorySpace> train, StridedMatrix<const double, MemorySpace> test) {
+    std::shared_ptr<GaussianSamplerDensity<MemorySpace>> density = std::make_shared<GaussianSamplerDensity<MemorySpace>>(train.extent(0));
+    return std::make_shared<KLObjective<MemorySpace>>(train, test, density);
+}
 
 template<typename MemorySpace>
 double KLObjective<MemorySpace>::ObjectivePlusCoeffGradImpl(StridedMatrix<const double, MemorySpace> data, StridedVector<double, MemorySpace> grad, std::shared_ptr<ConditionalMapBase<MemorySpace>> map) const {

--- a/src/TrainMap.cpp
+++ b/src/TrainMap.cpp
@@ -56,8 +56,8 @@ nlopt::opt SetupOptimization(unsigned int dim, TrainOptions options) {
     return opt;
 }
 
-template<typename ObjectiveType>
-double mpart::TrainMap(std::shared_ptr<ConditionalMapBase<Kokkos::HostSpace>> map, ObjectiveType &objective, TrainOptions options) {
+template<>
+double mpart::TrainMap(std::shared_ptr<ConditionalMapBase<Kokkos::HostSpace>> map, std::shared_ptr<MapObjective<Kokkos::HostSpace>> objective, TrainOptions options) {
     if(map->Coeffs().extent(0) == 0) {
         std::cout << "TrainMap: Initializing map coeffs to 1." << std::endl;
         Kokkos::View<double*, Kokkos::HostSpace> coeffs ("Default coeffs", map->numCoeffs);
@@ -70,7 +70,7 @@ double mpart::TrainMap(std::shared_ptr<ConditionalMapBase<Kokkos::HostSpace>> ma
 
     // Since objective is (rightfully) separate from the map, we use std::bind to create a functor
     // from objective::operator() that keeps the map argument held.
-    std::function<double(unsigned, const double*, double*)> functor = std::bind(objective, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, map);
+    std::function<double(unsigned, const double*, double*)> functor = std::bind(&MapObjective<Kokkos::HostSpace>::operator(), objective, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, map);
     opt.set_min_objective(functor_wrapper, reinterpret_cast<void*>(&functor));
 
     // Get the initial guess at the coefficients
@@ -99,7 +99,3 @@ double mpart::TrainMap(std::shared_ptr<ConditionalMapBase<Kokkos::HostSpace>> ma
     }
     return error;
 }
-
-// Explicitly instantiate the function for HostSpace-- it doesn't work for device, since NLopt is CPU-based.
-template double mpart::TrainMap(std::shared_ptr<ConditionalMapBase<Kokkos::HostSpace>> map, KLObjective<Kokkos::HostSpace> &objective, TrainOptions options);
-

--- a/tests/Test_AdaptiveTransportMap.cpp
+++ b/tests/Test_AdaptiveTransportMap.cpp
@@ -52,9 +52,9 @@ TEST_CASE("Adaptive Transport Map","[ATM]") {
         });
         NormalizeSamples(targetSamples);
 
-        StridedMatrix<double, Kokkos::HostSpace> testSamples = Kokkos::subview(targetSamples, Kokkos::ALL, Kokkos::pair<unsigned int, unsigned int>(0, testPts));
-        StridedMatrix<double, Kokkos::HostSpace> trainSamples = Kokkos::subview(targetSamples, Kokkos::ALL, Kokkos::pair<unsigned int, unsigned int>(testPts, numPts));
-        KLObjective<Kokkos::HostSpace> objective {trainSamples,testSamples,g_sampler};
+        StridedMatrix<const double, Kokkos::HostSpace> testSamples = Kokkos::subview(targetSamples, Kokkos::ALL, Kokkos::pair<unsigned int, unsigned int>(0, testPts));
+        StridedMatrix<const double, Kokkos::HostSpace> trainSamples = Kokkos::subview(targetSamples, Kokkos::ALL, Kokkos::pair<unsigned int, unsigned int>(testPts, numPts));
+        auto objective = ObjectiveFactory::CreateGaussianKLObjective(trainSamples,testSamples);
 
         std::vector<MultiIndexSet> mset0 {MultiIndexSet::CreateTotalOrder(1,0), MultiIndexSet::CreateTotalOrder(2,0)};
         MultiIndexSet correctMset1 = MultiIndexSet::CreateTotalOrder(1,1);
@@ -90,9 +90,9 @@ TEST_CASE("Adaptive Transport Map","[ATM]") {
             }
         });
         NormalizeSamples(targetSamples);
-        StridedMatrix<double, Kokkos::HostSpace> testSamples = Kokkos::subview(targetSamples, Kokkos::ALL, Kokkos::pair<unsigned int, unsigned int>(0, testPts));
-        StridedMatrix<double, Kokkos::HostSpace> trainSamples = Kokkos::subview(targetSamples, Kokkos::ALL, Kokkos::pair<unsigned int, unsigned int>(testPts, numPts));
-        KLObjective<Kokkos::HostSpace> objective {trainSamples,testSamples,g_sampler};
+        StridedMatrix<const double, Kokkos::HostSpace> testSamples = Kokkos::subview(targetSamples, Kokkos::ALL, Kokkos::pair<unsigned int, unsigned int>(0, testPts));
+        StridedMatrix<const double, Kokkos::HostSpace> trainSamples = Kokkos::subview(targetSamples, Kokkos::ALL, Kokkos::pair<unsigned int, unsigned int>(testPts, numPts));
+        auto objective = ObjectiveFactory::CreateGaussianKLObjective(trainSamples,testSamples);
 
         ATMOptions opts;
         opts.maxSize = 5;
@@ -112,9 +112,9 @@ TEST_CASE("Adaptive Transport Map","[ATM]") {
         });
         NormalizeSamples(targetSamples);
 
-        StridedMatrix<double, Kokkos::HostSpace> testSamples = Kokkos::subview(targetSamples, Kokkos::ALL, Kokkos::pair<unsigned int, unsigned int>(0, testPts));
-        StridedMatrix<double, Kokkos::HostSpace> trainSamples = Kokkos::subview(targetSamples, Kokkos::ALL, Kokkos::pair<unsigned int, unsigned int>(testPts, numPts));
-        KLObjective<Kokkos::HostSpace> objective {trainSamples,testSamples,g_sampler};
+        StridedMatrix<const double, Kokkos::HostSpace> testSamples = Kokkos::subview(targetSamples, Kokkos::ALL, Kokkos::pair<unsigned int, unsigned int>(0, testPts));
+        StridedMatrix<const double, Kokkos::HostSpace> trainSamples = Kokkos::subview(targetSamples, Kokkos::ALL, Kokkos::pair<unsigned int, unsigned int>(testPts, numPts));
+        auto objective = ObjectiveFactory::CreateGaussianKLObjective(trainSamples,testSamples);
 
         std::vector<MultiIndexSet> mset0 {MultiIndexSet::CreateTotalOrder(1,0), MultiIndexSet::CreateTotalOrder(2,0)};
         MultiIndexSet correctMset1 = MultiIndexSet::CreateTotalOrder(1,1);

--- a/tests/Test_TrainMap.cpp
+++ b/tests/Test_TrainMap.cpp
@@ -25,12 +25,11 @@ TEST_CASE("Test_TrainMap", "[TrainMap]") {
         targetSamples(0,i) = samples(0,i);
         targetSamples(1,i) = samples(1,i) + samples(0,i)*samples(0,i);
     });
-    StridedMatrix<double, Kokkos::HostSpace> testSamps = Kokkos::subview(targetSamples, Kokkos::ALL, Kokkos::pair<unsigned int, unsigned int>(0, testPts));
-    StridedMatrix<double, Kokkos::HostSpace> trainSamps = Kokkos::subview(targetSamples, Kokkos::ALL, Kokkos::pair<unsigned int, unsigned int>(testPts, numPts));
-    KLObjective<Kokkos::HostSpace> obj {trainSamps, testSamps, sampler};
+    StridedMatrix<const double, Kokkos::HostSpace> testSamps = Kokkos::subview(targetSamples, Kokkos::ALL, Kokkos::pair<unsigned int, unsigned int>(0, testPts));
+    StridedMatrix<const double, Kokkos::HostSpace> trainSamps = Kokkos::subview(targetSamples, Kokkos::ALL, Kokkos::pair<unsigned int, unsigned int>(testPts, numPts));
+    auto obj = ObjectiveFactory::CreateGaussianKLObjective(trainSamps, testSamps);
 
     MapOptions map_options;
-    map_options.basisType = BasisTypes::ProbabilistHermite;
     auto map = MapFactory::CreateTriangular<Kokkos::HostSpace>(dim, dim, 2, map_options);
 
     TrainOptions train_options;


### PR DESCRIPTION
I wasn't particularly satisfied with how `MapObjective` was used in the previous PRs, so I made a small change here that's kind of separate from the previous PRs. Now, I'm working to make `MapObjective` stays in shared pointers so we don't get weird necessary explicit templates like we did for `TrainMap<ObjectiveType>` (since `MapObjective` was an abstract type, you couldn't use it in the function declaration for `TrainMap`). I didn't realize how to fix it until after I submitted the PR, so it's better to just make a new one.