### PR TITLE
Bindings for ATM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build
+*.egg-info*
 .vscode
 docs/_build
 bin

--- a/MParT/AdaptiveTransportMap.h
+++ b/MParT/AdaptiveTransportMap.h
@@ -14,8 +14,8 @@ namespace mpart {
 
 // Options specifically for ATM algorithm, with map eval opts -> training opts-> ATM specific opts
 struct ATMOptions: public MapOptions, public TrainOptions {
-    int maxPatience = 10;
-    int maxSize = 10;
+    unsigned int maxPatience = 10;
+    unsigned int maxSize = 10;
     MultiIndex maxDegrees;
     std::string String() override {
         std::string md_str = maxDegrees.String();

--- a/MParT/AdaptiveTransportMap.h
+++ b/MParT/AdaptiveTransportMap.h
@@ -12,12 +12,20 @@
 
 namespace mpart {
 
-// Options specifically for ATM algorithm
-// 0. indicates that MParT uses the optimization's default value
+// Options specifically for ATM algorithm, with map eval opts -> training opts-> ATM specific opts
 struct ATMOptions: public MapOptions, public TrainOptions {
     int maxPatience = 10;
     int maxSize = 10;
     MultiIndex maxDegrees;
+    std::string String() override {
+        std::string md_str = maxDegrees.String();
+        std::stringstream ss;
+        ss << MapOptions::String() << "\n" << TrainOptions::String() << "\n";
+        ss << "maxPatience = " << maxPatience << "\n";
+        ss << "maxSize = " << maxSize << "\n";
+        ss << "maxDegrees = " << maxDegrees.String();
+        return ss.str();
+    }
 };
 
 template<typename MemorySpace>
@@ -26,9 +34,9 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> AdaptiveTransportMap(std::vecto
     ATMOptions options);
 
 // template<typename MemorySpace>
-// std::shared_ptr<ConditionalMapBase<MemorySpace>> AdaptiveTransportMap(StridedMatrix<double, MemorySpace> train_x, StridedMatrix<double, MemorySpace> test_x, ATMOptions options = ATMOptions()) {
+// std::tuple<std::shared_ptr<ConditionalMapBase<MemorySpace>>,std::vector<MultiIndexSet>> AdaptiveTransportMap(StridedMatrix<double, MemorySpace> train_x, StridedMatrix<double, MemorySpace> test_x, ATMOptions options = ATMOptions()) {
 //     unsigned int dim = train_x.extent(0);
-//     MultiIndexSet mset0 = MultiIndexSet::CreateTotalOrder(dim, 0);
+
 //     return AdaptiveTransportMap(mset0, train_x, test_x, options);
 // }
 

--- a/MParT/MapObjective.h
+++ b/MParT/MapObjective.h
@@ -91,14 +91,6 @@ class MapObjective {
     StridedVector<double, MemorySpace> TrainCoeffGrad(std::shared_ptr<ConditionalMapBase<MemorySpace>> map) const;
 
     /**
-     * @brief Shortcut to calculate the error of the map on the training dataset
-     *
-     * @param map Map to calculate the error on
-     * @return double training error
-     */
-    double TrainError(std::shared_ptr<ConditionalMapBase<MemorySpace>> map) const;
-
-    /**
      * @brief Shortcut to calculate the gradient of the objective on the training dataset w.r.t. the map coefficients
      *
      * @param map Map to calculate the gradient with respect to

--- a/MParT/MapObjective.h
+++ b/MParT/MapObjective.h
@@ -53,10 +53,10 @@ class KLObjective: public MapObjective<MemorySpace> {
 
 namespace ObjectiveFactory {
 template<typename MemorySpace>
-std::shared_ptr<MapObjective<MemorySpace>> CreateGaussianKLObjective(StridedMatrix<const double, MemorySpace> train);
+std::shared_ptr<MapObjective<MemorySpace>> CreateGaussianKLObjective(StridedMatrix<const double, MemorySpace> train, unsigned int dim=0);
 
 template<typename MemorySpace>
-std::shared_ptr<MapObjective<MemorySpace>> CreateGaussianKLObjective(StridedMatrix<const double, MemorySpace> train, StridedMatrix<const double, MemorySpace> test);
+std::shared_ptr<MapObjective<MemorySpace>> CreateGaussianKLObjective(StridedMatrix<const double, MemorySpace> train, StridedMatrix<const double, MemorySpace> test, unsigned int dim=0);
 } // namespace ObjectiveFactory
 
 } // namespace mpart

--- a/MParT/MapObjective.h
+++ b/MParT/MapObjective.h
@@ -53,6 +53,9 @@ class KLObjective: public MapObjective<MemorySpace> {
 
 namespace ObjectiveFactory {
 template<typename MemorySpace>
+std::shared_ptr<MapObjective<MemorySpace>> CreateGaussianKLObjective(StridedMatrix<const double, MemorySpace> train);
+
+template<typename MemorySpace>
 std::shared_ptr<MapObjective<MemorySpace>> CreateGaussianKLObjective(StridedMatrix<const double, MemorySpace> train, StridedMatrix<const double, MemorySpace> test);
 } // namespace ObjectiveFactory
 

--- a/MParT/MapOptions.h
+++ b/MParT/MapOptions.h
@@ -121,7 +121,7 @@ namespace mpart{
             return ret;
         }
 
-        std::string String() {
+        virtual std::string String() {
             std::string btypes[3] = {"ProbabilistHermite", "PhysicistHermite", "HermiteFunctions"};
             std::string pftypes[2] = {"Exp", "SoftPlus"};
             std::string qtypes[3] = {"ClenshawCurtis", "AdaptiveSimpson", "AdaptiveClenshawCurtis"};

--- a/MParT/TrainMap.h
+++ b/MParT/TrainMap.h
@@ -24,7 +24,7 @@ struct TrainOptions {
     int opt_maxeval = 30;
     double opt_maxtime = 100.;
     int verbose = 0;
-    std::string String() {
+    virtual std::string String() {
         std::stringstream ss;
         ss << "opt_alg = " << opt_alg << "\n";
         ss << "opt_stopval = " << opt_stopval << "\n";

--- a/MParT/TrainMap.h
+++ b/MParT/TrainMap.h
@@ -15,6 +15,7 @@ namespace mpart {
  *
  */
 struct TrainOptions {
+    TrainOptions() = default;
     std::string opt_alg = "LD_SLSQP";
     double opt_stopval = -std::numeric_limits<double>::infinity();
     double opt_ftol_rel = 1e-3;

--- a/MParT/TrainMap.h
+++ b/MParT/TrainMap.h
@@ -15,7 +15,6 @@ namespace mpart {
  *
  */
 struct TrainOptions {
-    TrainOptions() = default;
     std::string opt_alg = "LD_SLSQP";
     double opt_stopval = -std::numeric_limits<double>::infinity();
     double opt_ftol_rel = 1e-3;

--- a/bindings/julia/CMakeLists.txt
+++ b/bindings/julia/CMakeLists.txt
@@ -17,6 +17,7 @@ if(MPART_OPT)
   set(JULIA_BINDING_SOURCES ${JULIA_BINDING_SOURCES}
       src/MapObjective.cpp
       src/TrainMap.cpp
+      src/AdaptiveTransportMap.cpp
   )
 endif()
 

--- a/bindings/julia/include/CommonJuliaUtilities.h
+++ b/bindings/julia/include/CommonJuliaUtilities.h
@@ -71,6 +71,8 @@ void MapFactoryWrapper(jlcxx::Module&);
  */
 void ComposedMapWrapper(jlcxx::Module &);
 
+#if defined(MPART_HAS_NLOPT)
+
 /**
  * @brief Adds MapObjective bindings to the existing module m.
  * @param mod CxxWrap.jl module
@@ -82,6 +84,14 @@ void MapObjectiveWrapper(jlcxx::Module &);
  * @param mod CxxWrap.jl module
  */
 void TrainMapWrapper(jlcxx::Module&);
+
+/**
+ * @brief Adds AdaptiveTransportMap and ATMOptions to the existing module m.
+ * @param mod CxxWrap.jl module
+*/
+void AdaptiveTransportMapWrapper(jlcxx::Module&);
+
+#endif // defined(MPART_HAS_NLOPT)
 
 #if defined(MPART_ENABLE_GPU)
 void ConditionalMapBaseDeviceWrapper(jlcxx::Module&);

--- a/bindings/julia/src/AdaptiveTransportMap.cpp
+++ b/bindings/julia/src/AdaptiveTransportMap.cpp
@@ -24,12 +24,14 @@ void mpart::binding::AdaptiveTransportMapWrapper(jlcxx::Module &mod) {
         .method("__opt_xtol_abs!", [](ATMOptions &opts, double tol){opts.opt_xtol_abs = tol;})
         .method("__opt_maxeval!", [](ATMOptions &opts, int eval){opts.opt_maxeval = eval;})
         .method("__verbose!", [](ATMOptions &opts, int verbose){opts.verbose = verbose;})
+        .method("__maxPatience!", [](ATMOptions &opts, int maxPatience){opts.maxPatience = maxPatience;})
+        .method("__maxSize!", [](ATMOptions &opts, int maxSize){opts.maxSize = maxSize;})
+        .method("__maxDegrees!", [](ATMOptions &opts, MultiIndex &maxDegrees){opts.maxDegrees = maxDegrees;})
         .method("TrainOptions", [](ATMOptions &opts){ return static_cast<TrainOptions>(opts);})
     ;
 
 
-    mod.method("AdaptiveTransportMap", [](jlcxx::ArrayRef<MultiIndexSet> arr, std::shared_ptr<MapObjective<Kokkos::HostSpace>> objective,
-    ATMOptions options) {
+    mod.method("AdaptiveTransportMap", [](jlcxx::ArrayRef<MultiIndexSet> arr, std::shared_ptr<MapObjective<Kokkos::HostSpace>> objective, ATMOptions options) {
         std::vector<MultiIndexSet> vec (arr.begin(), arr.end());
         auto map = AdaptiveTransportMap(vec, objective, options);
         std::copy(vec.begin(), vec.end(), arr.begin());

--- a/bindings/julia/src/AdaptiveTransportMap.cpp
+++ b/bindings/julia/src/AdaptiveTransportMap.cpp
@@ -34,7 +34,7 @@ void mpart::binding::AdaptiveTransportMapWrapper(jlcxx::Module &mod) {
     mod.method("AdaptiveTransportMap", [](jlcxx::ArrayRef<MultiIndexSet> arr, std::shared_ptr<MapObjective<Kokkos::HostSpace>> objective, ATMOptions options) {
         std::vector<MultiIndexSet> vec (arr.begin(), arr.end());
         auto map = AdaptiveTransportMap(vec, objective, options);
-        std::copy(vec.begin(), vec.end(), arr.begin());
+        for(int i = 0; i < vec.size(); i++) arr[i] = vec[i];
         return map;
     });
 }

--- a/bindings/julia/src/AdaptiveTransportMap.cpp
+++ b/bindings/julia/src/AdaptiveTransportMap.cpp
@@ -1,0 +1,38 @@
+#include "CommonJuliaUtilities.h"
+#include "MParT/MapOptions.h"
+#include "MParT/MapObjective.h"
+#include "MParT/TrainMap.h"
+#include "MParT/AdaptiveTransportMap.h"
+
+#include <Kokkos_Core.hpp>
+
+using namespace mpart;
+
+namespace jlcxx {
+    // Tell CxxWrap.jl the supertype structure for ConditionalMapBase
+    template<> struct SuperType<mpart::ATMOptions> {typedef mpart::MapOptions type;};
+}
+
+void mpart::binding::AdaptiveTransportMapWrapper(jlcxx::Module &mod) {
+    // Can only do single inheritence, so I arbitrarily picked inheritence from MapOptions
+    // If you need to convert to TrainOptions, I allow a conversion
+    mod.add_type<ATMOptions>("__ATMOptions", jlcxx::julia_base_type<MapOptions>())
+        .method("__opt_alg!", [](ATMOptions &opts, std::string alg){opts.opt_alg = alg;})
+        .method("__opt_ftol_rel!", [](ATMOptions &opts, double tol){opts.opt_ftol_rel = tol;})
+        .method("__opt_ftol_abs!", [](ATMOptions &opts, double tol){opts.opt_ftol_abs = tol;})
+        .method("__opt_xtol_rel!", [](ATMOptions &opts, double tol){opts.opt_xtol_rel = tol;})
+        .method("__opt_xtol_abs!", [](ATMOptions &opts, double tol){opts.opt_xtol_abs = tol;})
+        .method("__opt_maxeval!", [](ATMOptions &opts, int eval){opts.opt_maxeval = eval;})
+        .method("__verbose!", [](ATMOptions &opts, int verbose){opts.verbose = verbose;})
+        .method("TrainOptions", [](ATMOptions &opts){ return static_cast<TrainOptions>(opts);})
+    ;
+
+
+    mod.method("AdaptiveTransportMap", [](jlcxx::ArrayRef<MultiIndexSet> arr, std::shared_ptr<MapObjective<Kokkos::HostSpace>> objective,
+    ATMOptions options) {
+        std::vector<MultiIndexSet> vec (arr.begin(), arr.end());
+        auto map = AdaptiveTransportMap(vec, objective, options);
+        std::copy(vec.begin(), vec.end(), arr.begin());
+        return map;
+    });
+}

--- a/bindings/julia/src/ComposedMap.cpp
+++ b/bindings/julia/src/ComposedMap.cpp
@@ -13,10 +13,10 @@ using namespace mpart;
 
 void mpart::binding::ComposedMapWrapper(jlcxx::Module &mod)
 {
-    mod.add_type<ComposedMap<Kokkos::HostSpace>>("ComposedMap", jlcxx::julia_base_type<ConditionalMapBase<Kokkos::HostSpace>>())
-        .constructor<std::vector<std::shared_ptr<ConditionalMapBase<Kokkos::HostSpace>>> const&>()
-        // .method("EvaluateUntilK", [](ComposedMap<Kokkos::HostSpace> &map, int k, jlcxx::ArrayRef<double,2>& intPts, jlcxx::ArrayRef<double,2>& output){
-        //     return KokkosToJulia(map.EvaluateUntilK(k, JuliaToKokkos(intPts), JuliaToKokkos(output)));
-        // })
-        ;
+    mod.add_type<ComposedMap<Kokkos::HostSpace>>("ComposedMap", jlcxx::julia_base_type<ConditionalMapBase<Kokkos::HostSpace>>());
+    mod.method("ComposedMap", [](std::vector<std::shared_ptr<ConditionalMapBase<Kokkos::HostSpace>>> const& maps){
+        std::shared_ptr<ConditionalMapBase<Kokkos::HostSpace>> ret =  std::make_shared<ComposedMap<Kokkos::HostSpace>>(maps);
+        return ret;
+    })
+    ;
 }

--- a/bindings/julia/src/MapObjective.cpp
+++ b/bindings/julia/src/MapObjective.cpp
@@ -25,14 +25,14 @@ void mpart::binding::MapObjectiveWrapper(jlcxx::Module &mod) {
     ;
 
     mod.add_type<KLObjective<MemorySpace>>(tName,jlcxx::julia_base_type<MapObjective<MemorySpace>>());
-    mod.method(mName, [](jlcxx::ArrayRef<double,2> train, unsigned int dim=0) {
+    mod.method(mName, [](jlcxx::ArrayRef<double,2> train, unsigned int dim) {
         StridedMatrix<const double, MemorySpace> trainView = JuliaToKokkos(train);
         Kokkos::View<double**,MemorySpace> storeTrain ("Training data", trainView.extent(0), trainView.extent(1));
         Kokkos::deep_copy(storeTrain, trainView);
         trainView = storeTrain;
         return ObjectiveFactory::CreateGaussianKLObjective(trainView, dim);
     });
-    mod.method(mName, [](jlcxx::ArrayRef<double,2> train, jlcxx::ArrayRef<double,2> test, unsigned int dim = 0) {
+    mod.method(mName, [](jlcxx::ArrayRef<double,2> train, jlcxx::ArrayRef<double,2> test, unsigned int dim) {
         StridedMatrix<const double, MemorySpace> trainView = JuliaToKokkos(train);
         StridedMatrix<const double, MemorySpace> testView = JuliaToKokkos(test);
         Kokkos::View<double**,MemorySpace> storeTrain ("Training data", trainView.extent(0), trainView.extent(1));

--- a/bindings/julia/src/MapObjective.cpp
+++ b/bindings/julia/src/MapObjective.cpp
@@ -25,14 +25,14 @@ void mpart::binding::MapObjectiveWrapper(jlcxx::Module &mod) {
     ;
 
     mod.add_type<KLObjective<MemorySpace>>(tName,jlcxx::julia_base_type<MapObjective<MemorySpace>>());
-    mod.method(mName, [](jlcxx::ArrayRef<double,2> train) {
+    mod.method(mName, [](jlcxx::ArrayRef<double,2> train, unsigned int dim=0) {
         StridedMatrix<const double, MemorySpace> trainView = JuliaToKokkos(train);
         Kokkos::View<double**,MemorySpace> storeTrain ("Training data", trainView.extent(0), trainView.extent(1));
         Kokkos::deep_copy(storeTrain, trainView);
         trainView = storeTrain;
-        return ObjectiveFactory::CreateGaussianKLObjective(trainView);
+        return ObjectiveFactory::CreateGaussianKLObjective(trainView, dim);
     });
-    mod.method(mName, [](jlcxx::ArrayRef<double,2> train, jlcxx::ArrayRef<double,2> test) {
+    mod.method(mName, [](jlcxx::ArrayRef<double,2> train, jlcxx::ArrayRef<double,2> test, unsigned int dim = 0) {
         StridedMatrix<const double, MemorySpace> trainView = JuliaToKokkos(train);
         StridedMatrix<const double, MemorySpace> testView = JuliaToKokkos(test);
         Kokkos::View<double**,MemorySpace> storeTrain ("Training data", trainView.extent(0), trainView.extent(1));
@@ -41,7 +41,7 @@ void mpart::binding::MapObjectiveWrapper(jlcxx::Module &mod) {
         Kokkos::deep_copy(storeTest, testView);
         trainView = storeTrain;
         testView = storeTest;
-        return ObjectiveFactory::CreateGaussianKLObjective(trainView, testView);
+        return ObjectiveFactory::CreateGaussianKLObjective(trainView, testView, dim);
     });
 }
 

--- a/bindings/julia/src/Wrapper.cpp
+++ b/bindings/julia/src/Wrapper.cpp
@@ -27,6 +27,9 @@ JLCXX_MODULE MParT_julia_module(jlcxx::Module& mod)
     binding::AffineMapWrapper(mod);
     binding::AffineFunctionWrapper(mod);
     binding::MapFactoryWrapper(mod);
+#if defined(MPART_HAS_NLOPT)
     binding::MapObjectiveWrapper(mod);
     binding::TrainMapWrapper(mod);
+    binding::AdaptiveTransportMapWrapper(mod);
+#endif // MPART_HAS_NLOPT
 }

--- a/bindings/matlab/include/MexOptionsConversions.h
+++ b/bindings/matlab/include/MexOptionsConversions.h
@@ -29,7 +29,7 @@ namespace binding{
                                     double opt_ftol_rel, double opt_ftol_abs,
                                     double opt_xtol_rel, double opt_xtol_abs,
                                     int opt_maxeval, double opt_maxtime, int verbose,
-                                    unsigned int maxPatience, unsigned int maxSize, MultiIndex maxDegrees)
+                                    unsigned int maxPatience, unsigned int maxSize, MultiIndex maxDegrees);
 #endif // defined(MPART_HAS_NLOPT)
 }
 }

--- a/bindings/matlab/include/MexOptionsConversions.h
+++ b/bindings/matlab/include/MexOptionsConversions.h
@@ -19,8 +19,8 @@ namespace binding{
 
     void MapOptionsToMatlab(MapOptions opts, mexplus::OutputArguments &output, int start = 0);
 #if defined(MPART_HAS_NLOPT)
-    TrainOptions TrainOptionsFromMatlab(InputArguments &input, unsigned int start);
-    ATMOptions ATMOptionsFromMatlab(InputArguments &input, unsigned int start);
+    TrainOptions TrainOptionsFromMatlab(mexplus::InputArguments &input, unsigned int start);
+    ATMOptions ATMOptionsFromMatlab(mexplus::InputArguments &input, unsigned int start);
     ATMOptions ATMOptionsFromMatlab(std::string basisType, std::string posFuncType,
                                     std::string quadType, double quadAbsTol,
                                     double quadRelTol, unsigned int quadMaxSub,

--- a/bindings/matlab/include/MexOptionsConversions.h
+++ b/bindings/matlab/include/MexOptionsConversions.h
@@ -30,7 +30,7 @@ namespace binding{
                                     double opt_ftol_rel, double opt_ftol_abs,
                                     double opt_xtol_rel, double opt_xtol_abs,
                                     int opt_maxeval, double opt_maxtime, int verbose,
-                                    unsigned int maxPatience, unsigned int maxSize, MultiIndex maxDegrees);
+                                    unsigned int maxPatience, unsigned int maxSize, MultiIndex& maxDegrees);
 #endif // defined(MPART_HAS_NLOPT)
 }
 }

--- a/bindings/matlab/include/MexOptionsConversions.h
+++ b/bindings/matlab/include/MexOptionsConversions.h
@@ -4,22 +4,35 @@
 #include <iostream>
 #include <mexplus.h>
 #include "MParT/MapOptions.h"
+#if defined(MPART_HAS_NLOPT)
+#include "MParT/AdaptiveTransportMap.h"
+#endif // defined(MPART_HAS_NLOPT)
 
 namespace mpart{
 namespace binding{
 
-    /** Converts a real-valued matlab vector to a Kokkos::View.  The memory in matlab vector is not copied for performance
-        reasons.  However, this means that the user is responsible for ensuring the vector is not freed before the view.
-    */
-    MapOptions  MapOptionsFromMatlab(std::string basisType, std::string posFuncType, 
-                                        std::string quadType, double quadAbsTol,
-                                        double quadRelTol, unsigned int quadMaxSub, 
-                                        unsigned int quadMinSub,unsigned int quadPts, 
-                                        bool contDeriv, double basisLB, double basisUB, bool basisNorm);
+    MapOptions  MapOptionsFromMatlab(std::string basisType, std::string posFuncType,
+                                     std::string quadType, double quadAbsTol,
+                                     double quadRelTol, unsigned int quadMaxSub,
+                                     unsigned int quadMinSub,unsigned int quadPts,
+                                     bool contDeriv, double basisLB, double basisUB, bool basisNorm);
 
     void MapOptionsToMatlab(MapOptions opts, mexplus::OutputArguments &output, int start = 0);
+#if defined(MPART_HAS_NLOPT)
+    ATMOptions ATMOptionsFromMatlab(InputArguments input, unsigned int start);
+    ATMOptions ATMOptionsFromMatlab(std::string basisType, std::string posFuncType,
+                                    std::string quadType, double quadAbsTol,
+                                    double quadRelTol, unsigned int quadMaxSub,
+                                    unsigned int quadMinSub,unsigned int quadPts,
+                                    bool contDeriv, double basisLB, double basisUB, bool basisNorm,
+                                    std::string opt_alg, double opt_stopval,
+                                    double opt_ftol_rel, double opt_ftol_abs,
+                                    double opt_xtol_rel, double opt_xtol_abs,
+                                    int opt_maxeval, double opt_maxtime, int verbose,
+                                    unsigned int maxPatience, unsigned int maxSize, MultiIndex maxDegrees)
+#endif // defined(MPART_HAS_NLOPT)
 }
 }
 
 
-#endif 
+#endif

--- a/bindings/matlab/include/MexOptionsConversions.h
+++ b/bindings/matlab/include/MexOptionsConversions.h
@@ -19,7 +19,8 @@ namespace binding{
 
     void MapOptionsToMatlab(MapOptions opts, mexplus::OutputArguments &output, int start = 0);
 #if defined(MPART_HAS_NLOPT)
-    ATMOptions ATMOptionsFromMatlab(InputArguments input, unsigned int start);
+    TrainOptions TrainOptionsFromMatlab(InputArguments &input, unsigned int start);
+    ATMOptions ATMOptionsFromMatlab(InputArguments &input, unsigned int start);
     ATMOptions ATMOptionsFromMatlab(std::string basisType, std::string posFuncType,
                                     std::string quadType, double quadAbsTol,
                                     double quadRelTol, unsigned int quadMaxSub,

--- a/bindings/matlab/include/MexWrapperTypes.h
+++ b/bindings/matlab/include/MexWrapperTypes.h
@@ -77,7 +77,7 @@ public:
 // Instance manager for ConditionalMap.
 template class mexplus::Session<ConditionalMapMex>;
 template class mexplus::Session<ParameterizedFunctionMex>;
-template class mexplus::Session<MapObjectiveMex>
+template class mexplus::Session<MapObjectiveMex>;
 
 
 #endif // MPART_MEXWRAPPERTYPES_H

--- a/bindings/matlab/mat/ATMOptions.m
+++ b/bindings/matlab/mat/ATMOptions.m
@@ -1,4 +1,4 @@
-classdef TrainOptions < TrainOptions & MapOptions
+classdef ATMOptions < TrainOptions & MapOptions
     properties (Access = public)
         maxPatience = 10;
         maxSize = 10;
@@ -36,6 +36,9 @@ classdef TrainOptions < TrainOptions & MapOptions
             optionsArray{12+7} = obj.opt_maxeval;
             optionsArray{12+8} = obj.opt_maxtime;
             optionsArray{12+9} = obj.verbose;
+            optionsArray{12+9+1} = obj.maxPatience;
+            optionsArray{12+9+2} = obj.maxSize;
+            optionsArray{12+9+3} = obj.maxDegrees;
         end
     end
 end

--- a/bindings/matlab/mat/ATMOptions.m
+++ b/bindings/matlab/mat/ATMOptions.m
@@ -2,7 +2,7 @@ classdef ATMOptions < TrainOptions & MapOptions
     properties (Access = public)
         maxPatience = 10;
         maxSize = 10;
-        maxDegrees;
+        maxDegrees = MultiIndex(0);
     end
     methods
         function obj = set.maxPatience(obj,value)
@@ -38,7 +38,7 @@ classdef ATMOptions < TrainOptions & MapOptions
             optionsArray{12+9} = obj.verbose;
             optionsArray{12+9+1} = obj.maxPatience;
             optionsArray{12+9+2} = obj.maxSize;
-            optionsArray{12+9+3} = obj.maxDegrees;
+            optionsArray{12+9+3} = obj.maxDegrees.get_id();
         end
     end
 end

--- a/bindings/matlab/mat/ATMOptions.m
+++ b/bindings/matlab/mat/ATMOptions.m
@@ -1,0 +1,41 @@
+classdef TrainOptions < TrainOptions & MapOptions
+    properties (Access = public)
+        maxPatience = 10;
+        maxSize = 10;
+        maxDegrees;
+    end
+    methods
+        function obj = set.maxPatience(obj,value)
+            obj.maxPatience = value;
+        end
+        function obj = set.maxSize(obj,value)
+            obj.maxSize = value;
+        end
+        function obj = set.maxDegrees(obj,value)
+            obj.maxDegrees = value;
+        end
+        function optionsArray = getMexOptions(obj)
+            optionsArray{1} = char(obj.basisType);
+            optionsArray{2} = char(obj.posFuncType);
+            optionsArray{3} = char(obj.quadType);
+            optionsArray{4} = obj.quadAbsTol;
+            optionsArray{5} = obj.quadRelTol;
+            optionsArray{6} = obj.quadMaxSub;
+            optionsArray{7} = obj.quadMinSub;
+            optionsArray{8} = obj.quadPts;
+            optionsArray{9} = obj.contDeriv;
+            optionsArray{10} = obj.basisLB;
+            optionsArray{11} = obj.basisUB;
+            optionsArray{12} = obj.basisNorm;
+            optionsArray{12+1} = char(obj.opt_alg);
+            optionsArray{12+2} = obj.opt_stopval;
+            optionsArray{12+3} = obj.opt_ftol_rel;
+            optionsArray{12+4} = obj.opt_ftol_abs;
+            optionsArray{12+5} = obj.opt_xtol_rel;
+            optionsArray{12+6} = obj.opt_xtol_abs;
+            optionsArray{12+7} = obj.opt_maxeval;
+            optionsArray{12+8} = obj.opt_maxtime;
+            optionsArray{12+9} = obj.verbose;
+        end
+    end
+end

--- a/bindings/matlab/mat/AdaptiveTransportMap.m
+++ b/bindings/matlab/mat/AdaptiveTransportMap.m
@@ -1,11 +1,11 @@
 function map = AdaptiveTransportMap(mset0, objective, atm_options)
     mexOptions = atm_options.getMexOptions;
-    input_str=['map = MParT_(',char(39),'ConditionalMap_AdaptiveTransportMap',char(39),',mset0.get_id(),objective.get_id()'];
-    for o=1:length(mexOptions)-1
+    mset_ids = arrayfun(@(mset) mset.get_id(), mset0)
+    input_str=['map = MParT_(',char(39),'ConditionalMap_AdaptiveTransportMap',char(39),',mset_ids,objective.get_id()'];
+    for o=1:length(mexOptions)
         input_o=[',mexOptions{',num2str(o),'}'];
         input_str=[input_str,input_o];
     end
-    maxDegrees = mexOptions{24}.get_id()
-    input_str=[input_str,'maxDegrees)'];
+    input_str=[input_str,')'];
     eval(input_str);
 end

--- a/bindings/matlab/mat/AdaptiveTransportMap.m
+++ b/bindings/matlab/mat/AdaptiveTransportMap.m
@@ -1,10 +1,11 @@
 function map = AdaptiveTransportMap(mset0, objective, atm_options)
     mexOptions = atm_options.getMexOptions;
-    input_str=['map = MParT_(',char(39),'ConditionalMap_AdaptiveTransportMap',char(39),',map.get_id(),objective.get_id()'];
-    for o=1:length(mexOptions)
+    input_str=['map = MParT_(',char(39),'ConditionalMap_AdaptiveTransportMap',char(39),',mset0.get_id(),objective.get_id()'];
+    for o=1:length(mexOptions)-1
         input_o=[',mexOptions{',num2str(o),'}'];
         input_str=[input_str,input_o];
     end
-    input_str=[input_str,')'];
+    maxDegrees = mexOptions{24}.get_id()
+    input_str=[input_str,'maxDegrees)'];
     eval(input_str);
 end

--- a/bindings/matlab/mat/AdaptiveTransportMap.m
+++ b/bindings/matlab/mat/AdaptiveTransportMap.m
@@ -1,0 +1,10 @@
+function map = AdaptiveTransportMap(mset0, objective, atm_options)
+    mexOptions = atm_options.getMexOptions;
+    input_str=['map = MParT_(',char(39),'ConditionalMap_AdaptiveTransportMap',char(39),',map.get_id(),objective.get_id()'];
+    for o=1:length(mexOptions)
+        input_o=[',mexOptions{',num2str(o),'}'];
+        input_str=[input_str,input_o];
+    end
+    input_str=[input_str,')'];
+    eval(input_str);
+end

--- a/bindings/matlab/mat/AdaptiveTransportMap.m
+++ b/bindings/matlab/mat/AdaptiveTransportMap.m
@@ -1,11 +1,12 @@
 function map = AdaptiveTransportMap(mset0, objective, atm_options)
     mexOptions = atm_options.getMexOptions;
-    mset_ids = arrayfun(@(mset) mset.get_id(), mset0)
-    input_str=['map = MParT_(',char(39),'ConditionalMap_AdaptiveTransportMap',char(39),',mset_ids,objective.get_id()'];
+    mset_ids = arrayfun(@(mset) mset.get_id(), mset0);
+    input_str=['map_ptr = MParT_(',char(39),'ConditionalMap_AdaptiveTransportMap',char(39),',mset_ids,objective.get_id()'];
     for o=1:length(mexOptions)
         input_o=[',mexOptions{',num2str(o),'}'];
         input_str=[input_str,input_o];
     end
-    input_str=[input_str,')'];
+    input_str=[input_str,');'];
     eval(input_str);
+    map = ConditionalMap(map_ptr,"id");
 end

--- a/bindings/matlab/mat/GaussianKLObjective.m
+++ b/bindings/matlab/mat/GaussianKLObjective.m
@@ -7,11 +7,11 @@ end
 methods
     function this = GaussianKLObjective(train, test, dim)
         if(nargin==1)
-            this.id_ = MParT_('GaussianKLObjective_newTrain',train);
+            this.id_ = MParT_('GaussianKLObjective_newTrain',train,0);
         elseif(isinteger(test))
             this.id_ = MParT_('GaussianKLObjective_newTrain',train,test);
         elseif(nargin==2)
-            this.id_ = MParT_('GaussianKLObjective_newTrainTest',train,test);
+            this.id_ = MParT_('GaussianKLObjective_newTrainTest',train,test,0);
         else
             this.id_ = MParT_('GaussianKLObjective_newTrainTest',train,test,dim);
         end

--- a/bindings/matlab/mat/GaussianKLObjective.m
+++ b/bindings/matlab/mat/GaussianKLObjective.m
@@ -5,11 +5,15 @@ properties (Access = private)
 end
 
 methods
-    function this = GaussianKLObjective(varargin)
+    function this = GaussianKLObjective(train, test, dim)
         if(nargin==1)
-            this.id_ = MParT_('GaussianKLObjective_newTrain',varargin{1});
+            this.id_ = MParT_('GaussianKLObjective_newTrain',train);
+        elseif(isinteger(test))
+            this.id_ = MParT_('GaussianKLObjective_newTrain',train,test);
+        elseif(nargin==2)
+            this.id_ = MParT_('GaussianKLObjective_newTrainTest',train,test);
         else
-            this.id_ = MParT_('GaussianKLObjective_newTrainTest',varargin{1},varargin{2});
+            this.id_ = MParT_('GaussianKLObjective_newTrainTest',train,test,dim);
         end
     end
 

--- a/bindings/matlab/mat/MapOptions/MapOptions.m
+++ b/bindings/matlab/mat/MapOptions/MapOptions.m
@@ -1,9 +1,6 @@
 classdef MapOptions
     properties (Access = public)
         basisType = BasisTypes.ProbabilistHermite;
-        basisLB = log(0);
-        basisUB = 1.0/0.0;
-        basisNorm = true;
         posFuncType = PosFuncTypes.SoftPlus;
         quadType = QuadTypes.AdaptiveSimpson;
         quadAbsTol = 1e-6;
@@ -12,6 +9,9 @@ classdef MapOptions
         quadMinSub = 0;
         quadPts = 5;
         contDeriv = true;
+        basisLB = log(0);
+        basisUB = 1.0/0.0;
+        basisNorm = true;
     end
 
     methods

--- a/bindings/matlab/mat/TrainOptions.m
+++ b/bindings/matlab/mat/TrainOptions.m
@@ -1,6 +1,6 @@
 classdef TrainOptions
     properties (Access = public)
-        opt_alg = "LD_LBFGS"
+        opt_alg = "LD_SLSQP"
         opt_stopval = log(0)
         opt_ftol_rel = 1e-3
         opt_ftol_abs = 1e-3

--- a/bindings/matlab/mat/TrainOptions.m
+++ b/bindings/matlab/mat/TrainOptions.m
@@ -7,7 +7,7 @@ classdef TrainOptions
         opt_xtol_rel = 1e-4
         opt_xtol_abs = 1e-4
         opt_maxeval = 30
-        opt_maxtime = 100
+        opt_maxtime = 1e2
         verbose = 0
     end
 

--- a/bindings/matlab/src/ConditionalMap_mex.cpp
+++ b/bindings/matlab/src/ConditionalMap_mex.cpp
@@ -96,7 +96,7 @@ MEX_DEFINE(ConditionalMap_newTotalTriMap) (int nlhs, mxArray* plhs[],
   unsigned int outputDim = input.get<unsigned int>(1);
   unsigned int totalOrder = input.get<unsigned int>(2);
 
-  MapOptions opts = MapOptionsFromMatlab(input.get<std::string>(3),input.get<std::string>(4),
+  MapOptions opts = binding::MapOptionsFromMatlab(input.get<std::string>(3),input.get<std::string>(4),
                                          input.get<std::string>(5),input.get<double>(6),
                                          input.get<double>(7),input.get<unsigned int>(8),
                                          input.get<unsigned int>(9),input.get<unsigned int>(10),
@@ -111,7 +111,7 @@ MEX_DEFINE(ConditionalMap_newMap) (int nlhs, mxArray* plhs[],
   InputArguments input(nrhs, prhs, 13);
   OutputArguments output(nlhs, plhs, 1);
   const MultiIndexSet& mset = Session<MultiIndexSet>::getConst(input.get(0));
-  MapOptions opts = MapOptionsFromMatlab(input.get<std::string>(1),input.get<std::string>(2),
+  MapOptions opts = binding::MapOptionsFromMatlab(input.get<std::string>(1),input.get<std::string>(2),
                                          input.get<std::string>(3),input.get<double>(4),
                                          input.get<double>(5),input.get<unsigned int>(6),
                                          input.get<unsigned int>(7),input.get<unsigned int>(8),
@@ -126,7 +126,7 @@ MEX_DEFINE(ConditionalMap_newMapFixed) (int nlhs, mxArray* plhs[],
   InputArguments input(nrhs, prhs, 13);
   OutputArguments output(nlhs, plhs, 1);
   const FixedMultiIndexSet<MemorySpace>& mset = Session<FixedMultiIndexSet<MemorySpace>>::getConst(input.get(0));
-  MapOptions opts = MapOptionsFromMatlab(input.get<std::string>(1),input.get<std::string>(2),
+  MapOptions opts = binding::MapOptionsFromMatlab(input.get<std::string>(1),input.get<std::string>(2),
                                          input.get<std::string>(3),input.get<double>(4),
                                          input.get<double>(5),input.get<unsigned int>(6),
                                          input.get<unsigned int>(7),input.get<unsigned int>(8),

--- a/bindings/matlab/src/ConditionalMap_mex.cpp
+++ b/bindings/matlab/src/ConditionalMap_mex.cpp
@@ -54,7 +54,7 @@ MEX_DEFINE(ConditionalMap_AdaptiveTransportMap) (int nlhs, mxArray* plhs[],
   ATMOptions opts = binding::ATMOptionsFromMatlab(input, 2);
   std::shared_ptr<ConditionalMapBase<Kokkos::HostSpace>> map = AdaptiveTransportMap(mset0, obj_ptr, opts);
   for(unsigned int i=0;i<numBlocks;++i){
-    MultiIndexSet *mset_i = Session<MultiIndexSet>::get(list_id.at(i));
+    MultiIndexSet *mset_i = Session<MultiIndexSet>::get(list_id_mset.at(i));
     *mset_i = mset0[i];
   }
   output.set(0, Session<ConditionalMapMex>::create(new ConditionalMapMex(map)));
@@ -202,10 +202,7 @@ MEX_DEFINE(ConditionalMap_TrainMap) (int nlhs, mxArray* plhs[],
     MapObjectiveMex *obj = Session<MapObjectiveMex>::get(input.get(1));
     std::shared_ptr<MapObjective<MemorySpace>> obj_ptr = obj->obj_ptr;
 
-    TrainOptions opts {input.get<std::string>(2),input.get<double>(3),
-                      input.get<double>(4), input.get<double>(5),
-                      input.get<double>(6), input.get<double>(7),
-                      input.get<int>(8), input.get<double>(9), input.get<int>(10)};
+    TrainOptions opts  = TrainOptionsFromMatlab(input, 2);
 
     TrainMap<MemorySpace>(condMap_ptr, obj_ptr, opts);
 }

--- a/bindings/matlab/src/ConditionalMap_mex.cpp
+++ b/bindings/matlab/src/ConditionalMap_mex.cpp
@@ -202,7 +202,7 @@ MEX_DEFINE(ConditionalMap_TrainMap) (int nlhs, mxArray* plhs[],
     MapObjectiveMex *obj = Session<MapObjectiveMex>::get(input.get(1));
     std::shared_ptr<MapObjective<MemorySpace>> obj_ptr = obj->obj_ptr;
 
-    TrainOptions opts  = TrainOptionsFromMatlab(input, 2);
+    TrainOptions opts  = binding::TrainOptionsFromMatlab(input, 2);
 
     TrainMap<MemorySpace>(condMap_ptr, obj_ptr, opts);
 }

--- a/bindings/matlab/src/ConditionalMap_mex.cpp
+++ b/bindings/matlab/src/ConditionalMap_mex.cpp
@@ -173,7 +173,7 @@ MEX_DEFINE(ConditionalMap_TrainMap) (int nlhs, mxArray* plhs[],
     ConditionalMapMex *condMap = Session<ConditionalMapMex>::get(input.get(0));
     std::shared_ptr<ConditionalMapBase<MemorySpace>> condMap_ptr = condMap->map_ptr;
     MapObjectiveMex *obj = Session<MapObjectiveMex>::get(input.get(1));
-    std::shared_ptr<MapObjective<MemorySpace>> obj_ptr = obj->obj->ptr;
+    std::shared_ptr<MapObjective<MemorySpace>> obj_ptr = obj->obj_ptr;
 
     TrainOptions opts {input.get<std::string>(2),input.get<double>(3),
                       input.get<double>(4), input.get<double>(5),

--- a/bindings/matlab/src/ConditionalMap_mex.cpp
+++ b/bindings/matlab/src/ConditionalMap_mex.cpp
@@ -39,7 +39,7 @@ MEX_DEFINE(ConditionalMap_newTriMap) (int nlhs, mxArray* plhs[],
 MEX_DEFINE(ConditionalMap_AdaptiveTransportMap) (int nlhs, mxArray* plhs[],
                                       int nrhs, const mxArray* prhs[]) {
 
-  InputArguments input(nrhs, prhs, 25);
+  InputArguments input(nrhs, prhs, 26);
   OutputArguments output(nlhs, plhs, 1);
 
   std::vector<intptr_t> list_id_mset = input.get<std::vector<intptr_t>>(0);

--- a/bindings/matlab/src/ConditionalMap_mex.cpp
+++ b/bindings/matlab/src/ConditionalMap_mex.cpp
@@ -43,14 +43,15 @@ MEX_DEFINE(ConditionalMap_AdaptiveTransportMap) (int nlhs, mxArray* plhs[],
   OutputArguments output(nlhs, plhs, 1);
 
   std::vector<intptr_t> list_id_mset = input.get<std::vector<intptr_t>>(0);
+  unsigned int numBlocks = list_id_mset.size();
   std::vector<MultiIndexSet> mset0 {};
   for(unsigned int i=0;i<numBlocks;++i){
-    MultiIndexSet *mset_i = Session<MultiIndexSet>::get(list_id.at(i));
+    MultiIndexSet *mset_i = Session<MultiIndexSet>::get(list_id_mset.at(i));
     mset0.push_back(*mset_i);
   }
   MapObjectiveMex *obj = Session<MapObjectiveMex>::get(input.get(1));
   std::shared_ptr<MapObjective<MemorySpace>> obj_ptr = obj->obj_ptr;
-  ATMOptions opts = ATMOptionsFromMatlab(input, 2);
+  ATMOptions opts = binding::ATMOptionsFromMatlab(input, 2);
   std::shared_ptr<ConditionalMapBase<Kokkos::HostSpace>> map = AdaptiveTransportMap(mset0, obj_ptr, opts);
   for(unsigned int i=0;i<numBlocks;++i){
     MultiIndexSet *mset_i = Session<MultiIndexSet>::get(list_id.at(i));

--- a/bindings/matlab/src/ConditionalMap_mex.cpp
+++ b/bindings/matlab/src/ConditionalMap_mex.cpp
@@ -35,6 +35,31 @@ MEX_DEFINE(ConditionalMap_newTriMap) (int nlhs, mxArray* plhs[],
   output.set(0, Session<ConditionalMapMex>::create(new ConditionalMapMex(blocks)));
 }
 
+#if defined(MPART_HAS_NLOPT)
+MEX_DEFINE(ConditionalMap_AdaptiveTransportMap) (int nlhs, mxArray* plhs[],
+                                      int nrhs, const mxArray* prhs[]) {
+
+  InputArguments input(nrhs, prhs, 25);
+  OutputArguments output(nlhs, plhs, 1);
+
+  std::vector<intptr_t> list_id_mset = input.get<std::vector<intptr_t>>(0);
+  std::vector<MultiIndexSet> mset0 {};
+  for(unsigned int i=0;i<numBlocks;++i){
+    MultiIndexSet *mset_i = Session<MultiIndexSet>::get(list_id.at(i));
+    mset0.push_back(*mset_i);
+  }
+  MapObjectiveMex *obj = Session<MapObjectiveMex>::get(input.get(1));
+  std::shared_ptr<MapObjective<MemorySpace>> obj_ptr = obj->obj_ptr;
+  ATMOptions opts = ATMOptionsFromMatlab(input, 2);
+  std::shared_ptr<ConditionalMapBase<Kokkos::HostSpace>> map = AdaptiveTransportMap(mset0, obj_ptr, opts);
+  for(unsigned int i=0;i<numBlocks;++i){
+    MultiIndexSet *mset_i = Session<MultiIndexSet>::get(list_id.at(i));
+    *mset_i = mset0[i];
+  }
+  output.set(0, Session<ConditionalMapMex>::create(new ConditionalMapMex(map)));
+}
+#endif // defined(MPART_HAS_NLOPT)
+
 MEX_DEFINE(ConditionalMap_newComposedMap) (int nlhs, mxArray* plhs[],
                                       int nrhs, const mxArray* prhs[]) {
 
@@ -166,6 +191,7 @@ MEX_DEFINE(GaussianKLObjective_TrainError) (int nlhs, mxArray* plhs[],
   output.set(0, obj.obj_ptr->TrainError(condMap_ptr));
 }
 
+#if defined(MPART_HAS_NLOPT)
 MEX_DEFINE(ConditionalMap_TrainMap) (int nlhs, mxArray* plhs[],
                                      int nrhs, const mxArray* prhs[]) {
     InputArguments input(nrhs, prhs, 11);
@@ -178,10 +204,11 @@ MEX_DEFINE(ConditionalMap_TrainMap) (int nlhs, mxArray* plhs[],
     TrainOptions opts {input.get<std::string>(2),input.get<double>(3),
                       input.get<double>(4), input.get<double>(5),
                       input.get<double>(6), input.get<double>(7),
-                      input.get<int>(8), input.get<double>(9), input.get<bool>(10)};
+                      input.get<int>(8), input.get<double>(9), input.get<int>(10)};
 
     TrainMap<MemorySpace>(condMap_ptr, obj_ptr, opts);
-  }
+}
+#endif //defined(MPART_HAS_NLOPT)
 
 // Defines MEX API for delete.
 MEX_DEFINE(ConditionalMap_deleteMap) (int nlhs, mxArray* plhs[],

--- a/bindings/matlab/src/MapObjective_mex.cpp
+++ b/bindings/matlab/src/MapObjective_mex.cpp
@@ -1,7 +1,10 @@
-#include "MParT/MultiIndices/FixedMultiIndexSet.h"
-#include "MParT/MapObjective.h"
 #include "MParT/Utilities/ArrayConversions.h"
+#include "MParT/MultiIndices/FixedMultiIndexSet.h"
+#include "MParT/MapOptions.h"
+#include "MParT/MapFactory.h"
 #include "MParT/Distributions/GaussianSamplerDensity.h"
+#include "MParT/MapObjective.h"
+#include "MParT/TrainMap.h"
 
 #include "MexWrapperTypes.h"
 #include "MexArrayConversions.h"
@@ -18,8 +21,8 @@ namespace {
 
         InputArguments input(nrhs, prhs, 1);
         OutputArguments output(nlhs, plhs, 1);
-        auto train = MexToKokkos2d(prhs[0]);
-        auto objective = ObjectiveFactory::CreateGaussianKLObjective(train);
+        StridedMatrix<const double, MemorySpace> train = MexToKokkos2d(prhs[0]);
+        std::shared_ptr<MapObjective<MemorySpace>> objective = ObjectiveFactory::CreateGaussianKLObjective(train);
         output.set(0, Session<MapObjectiveMex>::create(new MapObjectiveMex(objective)));
     }
 
@@ -29,9 +32,9 @@ namespace {
 
         InputArguments input(nrhs, prhs, 2);
         OutputArguments output(nlhs, plhs, 1);
-        auto train = MexToKokkos2d(prhs[0]);
-        auto test = MexToKokkos2d(prhs[1]);
-        auto objective = ObjectiveFactory::CreateGaussianKLObjective(train, test);
+        StridedMatrix<const double, MemorySpace> train = MexToKokkos2d(prhs[0]);
+        StridedMatrix<const double, MemorySpace> test = MexToKokkos2d(prhs[1]);
+        std::shared_ptr<MapObjective<MemorySpace>> objective = ObjectiveFactory::CreateGaussianKLObjective(train, test);
         output.set(0, Session<MapObjectiveMex>::create(new MapObjectiveMex(objective));
     }
 

--- a/bindings/matlab/src/MapObjective_mex.cpp
+++ b/bindings/matlab/src/MapObjective_mex.cpp
@@ -22,7 +22,7 @@ namespace {
         InputArguments input(nrhs, prhs, 1, 1, "dim");
         OutputArguments output(nlhs, plhs, 1);
         StridedMatrix<const double, MemorySpace> train = MexToKokkos2d(prhs[0]);
-        unsigned int dim = input.get<unsigned int>("dim", 0)
+        unsigned int dim = input.get<unsigned int>("dim", 0);
         std::shared_ptr<MapObjective<MemorySpace>> objective = ObjectiveFactory::CreateGaussianKLObjective(train, dim);
         output.set(0, Session<MapObjectiveMex>::create(new MapObjectiveMex(objective)));
     }
@@ -35,7 +35,7 @@ namespace {
         OutputArguments output(nlhs, plhs, 1);
         StridedMatrix<const double, MemorySpace> train = MexToKokkos2d(prhs[0]);
         StridedMatrix<const double, MemorySpace> test = MexToKokkos2d(prhs[1]);
-        unsigned int dim = input.get<unsigned int>("dim",0)
+        unsigned int dim = input.get<unsigned int>("dim",0);
         std::shared_ptr<MapObjective<MemorySpace>> objective = ObjectiveFactory::CreateGaussianKLObjective(train, test, dim);
         output.set(0, Session<MapObjectiveMex>::create(new MapObjectiveMex(objective)));
     }

--- a/bindings/matlab/src/MapObjective_mex.cpp
+++ b/bindings/matlab/src/MapObjective_mex.cpp
@@ -19,10 +19,11 @@ namespace {
     MEX_DEFINE(GaussianKLObjective_newTrain) (int nlhs, mxArray* plhs[],
                                               int nrhs, const mxArray* prhs[]) {
 
-        InputArguments input(nrhs, prhs, 1);
+        InputArguments input(nrhs, prhs, 1, 1, "dim");
         OutputArguments output(nlhs, plhs, 1);
         StridedMatrix<const double, MemorySpace> train = MexToKokkos2d(prhs[0]);
-        std::shared_ptr<MapObjective<MemorySpace>> objective = ObjectiveFactory::CreateGaussianKLObjective(train);
+        unsigned int dim = input.get<unsigned int>("dim", 0)
+        std::shared_ptr<MapObjective<MemorySpace>> objective = ObjectiveFactory::CreateGaussianKLObjective(train, dim);
         output.set(0, Session<MapObjectiveMex>::create(new MapObjectiveMex(objective)));
     }
 
@@ -30,11 +31,12 @@ namespace {
     MEX_DEFINE(GaussianKLObjective_newTrainTest) (int nlhs, mxArray* plhs[],
                                               int nrhs, const mxArray* prhs[]) {
 
-        InputArguments input(nrhs, prhs, 2);
+        InputArguments input(nrhs, prhs, 2, 1, "dim");
         OutputArguments output(nlhs, plhs, 1);
         StridedMatrix<const double, MemorySpace> train = MexToKokkos2d(prhs[0]);
         StridedMatrix<const double, MemorySpace> test = MexToKokkos2d(prhs[1]);
-        std::shared_ptr<MapObjective<MemorySpace>> objective = ObjectiveFactory::CreateGaussianKLObjective(train, test);
+        unsigned int dim = input.get<unsigned int>("dim",0)
+        std::shared_ptr<MapObjective<MemorySpace>> objective = ObjectiveFactory::CreateGaussianKLObjective(train, test, dim);
         output.set(0, Session<MapObjectiveMex>::create(new MapObjectiveMex(objective)));
     }
 

--- a/bindings/matlab/src/MapObjective_mex.cpp
+++ b/bindings/matlab/src/MapObjective_mex.cpp
@@ -19,10 +19,10 @@ namespace {
     MEX_DEFINE(GaussianKLObjective_newTrain) (int nlhs, mxArray* plhs[],
                                               int nrhs, const mxArray* prhs[]) {
 
-        InputArguments input(nrhs, prhs, 1, 1, "dim");
+        InputArguments input(nrhs, prhs, 2);
         OutputArguments output(nlhs, plhs, 1);
         StridedMatrix<const double, MemorySpace> train = MexToKokkos2d(prhs[0]);
-        unsigned int dim = input.get<unsigned int>("dim", 0);
+        unsigned int dim = input.get<unsigned int>(1);
         std::shared_ptr<MapObjective<MemorySpace>> objective = ObjectiveFactory::CreateGaussianKLObjective(train, dim);
         output.set(0, Session<MapObjectiveMex>::create(new MapObjectiveMex(objective)));
     }
@@ -31,11 +31,11 @@ namespace {
     MEX_DEFINE(GaussianKLObjective_newTrainTest) (int nlhs, mxArray* plhs[],
                                               int nrhs, const mxArray* prhs[]) {
 
-        InputArguments input(nrhs, prhs, 2, 1, "dim");
+        InputArguments input(nrhs, prhs, 3);
         OutputArguments output(nlhs, plhs, 1);
         StridedMatrix<const double, MemorySpace> train = MexToKokkos2d(prhs[0]);
         StridedMatrix<const double, MemorySpace> test = MexToKokkos2d(prhs[1]);
-        unsigned int dim = input.get<unsigned int>("dim",0);
+        unsigned int dim = input.get<unsigned int>(2);
         std::shared_ptr<MapObjective<MemorySpace>> objective = ObjectiveFactory::CreateGaussianKLObjective(train, test, dim);
         output.set(0, Session<MapObjectiveMex>::create(new MapObjectiveMex(objective)));
     }
@@ -43,9 +43,9 @@ namespace {
     // Defines MEX API for delete.
     MEX_DEFINE(MapObjective_delete) (int nlhs, mxArray* plhs[],
                         int nrhs, const mxArray* prhs[]) {
-    InputArguments input(nrhs, prhs, 1);
-    OutputArguments output(nlhs, plhs, 0);
-    Session<MapObjectiveMex>::destroy(input.get(0));
+        InputArguments input(nrhs, prhs, 1);
+        OutputArguments output(nlhs, plhs, 0);
+        Session<MapObjectiveMex>::destroy(input.get(0));
     }
 
 }

--- a/bindings/matlab/src/MapObjective_mex.cpp
+++ b/bindings/matlab/src/MapObjective_mex.cpp
@@ -35,7 +35,7 @@ namespace {
         StridedMatrix<const double, MemorySpace> train = MexToKokkos2d(prhs[0]);
         StridedMatrix<const double, MemorySpace> test = MexToKokkos2d(prhs[1]);
         std::shared_ptr<MapObjective<MemorySpace>> objective = ObjectiveFactory::CreateGaussianKLObjective(train, test);
-        output.set(0, Session<MapObjectiveMex>::create(new MapObjectiveMex(objective));
+        output.set(0, Session<MapObjectiveMex>::create(new MapObjectiveMex(objective)));
     }
 
     // Defines MEX API for delete.

--- a/bindings/matlab/src/MexOptionsConversions.cpp
+++ b/bindings/matlab/src/MexOptionsConversions.cpp
@@ -100,7 +100,7 @@ TrainOptions mpart::binding::TrainOptionsFromMatlab(mexplus::InputArguments &inp
 }
 
 ATMOptions mpart::binding::ATMOptionsFromMatlab(mexplus::InputArguments &input, unsigned int start) {
-    MultiIndex& maxDegrees = *mexplus::Session<MultiIndex>::get(input.get(start+22));
+    MultiIndex& maxDegrees = *mexplus::Session<MultiIndex>::get(input.get(start+23));
     return ATMOptionsFromMatlab(input.get<std::string>(start + 0), input.get<std::string>(start + 1),
                                 input.get<std::string>(start + 2), input.get<double>(start + 3),
                                 input.get<double>(start + 4), input.get<unsigned int>(start + 5),
@@ -112,7 +112,7 @@ ATMOptions mpart::binding::ATMOptionsFromMatlab(mexplus::InputArguments &input, 
                                 input.get<double>(start + 16), input.get<double>(start + 17),
                                 input.get<int>(start + 18), input.get<double>(start + 19),
                                 input.get<int>(start + 20), input.get<unsigned int>(start + 21),
-                                input.get<unsigned int>(start + 21), maxDegrees);
+                                input.get<unsigned int>(start + 22), maxDegrees);
 }
 
 ATMOptions  mpart::binding::ATMOptionsFromMatlab(std::string basisType, std::string posFuncType,

--- a/bindings/matlab/src/MexOptionsConversions.cpp
+++ b/bindings/matlab/src/MexOptionsConversions.cpp
@@ -85,6 +85,14 @@ void mpart::binding::MapOptionsToMatlab(MapOptions opts, mexplus::OutputArgument
 
 #if defined(MPART_HAS_NLOPT)
 
+TrainOptions mpart::binding::TrainOptionsFromMatlab(InputArguments &input, unsigned int start) {
+    return TrainOptions(input.get<std::string>(start + 0), input.get<double>(start + 1),
+                        input.get<double>(start + 2), input.get<double>(start + 3),
+                        input.get<double>(start + 4), input.get<double>(start + 5),
+                        input.get<int>(start + 6), input.get<double>(start + 7),
+                        input.get<int>(start + 8));
+}
+
 ATMOptions mpart::binding::ATMOptionsFromMatlab(InputArguments &input, unsigned int start) {
     return ATMOptionsFromMatlab(input.get<std::string>(start + 0), input.get<std::string>(start + 1),
                                 input.get<std::string>(start + 2), input.get<double>(start + 3),

--- a/bindings/matlab/src/MexOptionsConversions.cpp
+++ b/bindings/matlab/src/MexOptionsConversions.cpp
@@ -84,6 +84,7 @@ void mpart::binding::MapOptionsToMatlab(MapOptions opts, mexplus::OutputArgument
 }
 
 #if defined(MPART_HAS_NLOPT)
+
 ATMOptions mpart::binding::ATMOptionsFromMatlab(InputArguments &input, unsigned int start) {
     return ATMOptionsFromMatlab(input.get<std::string>(start + 0), input.get<std::string>(start + 1),
                                 input.get<std::string>(start + 2), input.get<double>(start + 3),

--- a/bindings/matlab/src/MexOptionsConversions.cpp
+++ b/bindings/matlab/src/MexOptionsConversions.cpp
@@ -86,11 +86,11 @@ void mpart::binding::MapOptionsToMatlab(MapOptions opts, mexplus::OutputArgument
 #if defined(MPART_HAS_NLOPT)
 
 TrainOptions mpart::binding::TrainOptionsFromMatlab(mexplus::InputArguments &input, unsigned int start) {
-    return TrainOptions(input.get<std::string>(start + 0), input.get<double>(start + 1),
+    return TrainOptions {input.get<std::string>(start + 0), input.get<double>(start + 1),
                         input.get<double>(start + 2), input.get<double>(start + 3),
                         input.get<double>(start + 4), input.get<double>(start + 5),
                         input.get<int>(start + 6), input.get<double>(start + 7),
-                        input.get<int>(start + 8));
+                        input.get<int>(start + 8)};
 }
 
 ATMOptions mpart::binding::ATMOptionsFromMatlab(mexplus::InputArguments &input, unsigned int start) {

--- a/bindings/matlab/src/MexOptionsConversions.cpp
+++ b/bindings/matlab/src/MexOptionsConversions.cpp
@@ -94,7 +94,7 @@ TrainOptions mpart::binding::TrainOptionsFromMatlab(mexplus::InputArguments &inp
 }
 
 ATMOptions mpart::binding::ATMOptionsFromMatlab(mexplus::InputArguments &input, unsigned int start) {
-    MultiIndex& maxDegrees = *Session<MultiIndex>::get(input.get(start+22));
+    MultiIndex& maxDegrees = *mexplus::Session<MultiIndex>::get(input.get(start+22));
     return ATMOptionsFromMatlab(input.get<std::string>(start + 0), input.get<std::string>(start + 1),
                                 input.get<std::string>(start + 2), input.get<double>(start + 3),
                                 input.get<double>(start + 4), input.get<unsigned int>(start + 5),

--- a/bindings/matlab/src/MexOptionsConversions.cpp
+++ b/bindings/matlab/src/MexOptionsConversions.cpp
@@ -3,12 +3,12 @@
 
 using namespace mpart;
 
-MapOptions  mpart::binding::MapOptionsFromMatlab(std::string basisType, std::string posFuncType, 
+MapOptions  mpart::binding::MapOptionsFromMatlab(std::string basisType, std::string posFuncType,
                                         std::string quadType, double quadAbsTol,
-                                        double quadRelTol, unsigned int quadMaxSub, 
-                                        unsigned int quadMinSub,unsigned int quadPts, 
+                                        double quadRelTol, unsigned int quadMaxSub,
+                                        unsigned int quadMinSub,unsigned int quadPts,
                                         bool contDeriv, double basisLB, double basisUB, bool basisNorm)
-{   
+{
     MapOptions opts;
 
     if (basisType == "ProbabilistHermite") {
@@ -82,3 +82,86 @@ void mpart::binding::MapOptionsToMatlab(MapOptions opts, mexplus::OutputArgument
     output.set(i+10,opts.basisUB);
     output.set(i+11,opts.basisNorm);
 }
+
+#if defined(MPART_HAS_NLOPT)
+ATMOptions mpart::binding::ATMOptionsFromMatlab(InputArguments &input, unsigned int start) {
+    return ATMOptionsFromMatlab(input.get<std::string>(start + 0), input.get<std::string>(start + 1),
+                                input.get<std::string>(start + 2), input.get<double>(start + 3),
+                                input.get<double>(start + 4), input.get<unsigned int>(start + 5),
+                                input.get<unsigned int>(start + 6),input.get<unsigned int>(start + 7),
+                                input.get<bool>(start + 8), input.get<double>(start + 9),
+                                input.get<double>(start + 10), input.get<bool>(start + 11),
+                                input.get<std::string>(start + 12), input.get<double>(start + 13),
+                                input.get<double>(start + 14), input.get<double>(start + 15),
+                                input.get<double>(start + 16), input.get<double>(start + 17),
+                                input.get<int>(start + 18), input.get<double>(start + 19),
+                                input.get<int>(start + 20), input.get<unsigned int>(start + 21),
+                                input.get<unsigned int>(start + 21), input.get<MultiIndex>(start+22));
+}
+
+ATMOptions  mpart::binding::ATMOptionsFromMatlab(std::string basisType, std::string posFuncType,
+                                        std::string quadType, double quadAbsTol,
+                                        double quadRelTol, unsigned int quadMaxSub,
+                                        unsigned int quadMinSub,unsigned int quadPts,
+                                        bool contDeriv, double basisLB, double basisUB, bool basisNorm,
+                                        std::string opt_alg, double opt_stopval,
+                                        double opt_ftol_rel, double opt_ftol_abs,
+                                        double opt_xtol_rel, double opt_xtol_abs,
+                                        int opt_maxeval, double opt_maxtime, int verbose,
+                                        unsigned int maxPatience, unsigned int maxSize, MultiIndex maxDegrees)
+{
+    ATMOptions opts;
+
+    if (basisType == "ProbabilistHermite") {
+    opts.basisType    = BasisTypes::ProbabilistHermite;
+    } else if (basisType == "PhysicistHermite") {
+    opts.basisType    = BasisTypes::PhysicistHermite;
+    } else if (basisType == "HermiteFunctions") {
+    opts.basisType    = BasisTypes::HermiteFunctions;
+    } else {
+    std::cout << "Unknown basisType, value is set to default" <<std::endl;
+    }
+
+    if (posFuncType == "Exp") {
+    opts.posFuncType    = PosFuncTypes::Exp;
+    } else if (posFuncType == "SoftPlus") {
+    opts.posFuncType    = PosFuncTypes::SoftPlus;
+    } else {
+    std::cout << "Unknown posFuncType type, value is set to default" <<std::endl;
+    }
+
+    if (quadType == "ClenshawCurtis") {
+    opts.quadType    = QuadTypes::ClenshawCurtis;
+    } else if (quadType == "AdaptiveSimpson") {
+    opts.quadType    = QuadTypes::AdaptiveSimpson;
+    } else if (quadType == "AdaptiveClenshawCurtis") {
+    opts.quadType    = QuadTypes::AdaptiveClenshawCurtis;
+    } else {
+    std::cout << "Unknown quadType, value is set to default" <<std::endl;
+    }
+
+    opts.quadAbsTol = quadAbsTol;
+    opts.quadRelTol = quadRelTol;
+    opts.quadMaxSub = quadMaxSub;
+    opts.quadMinSub = quadMinSub;
+    opts.quadPts = quadPts;
+    opts.contDeriv = contDeriv;
+    opts.basisLB = basisLB;
+    opts.basisUB = basisUB;
+    opts.basisNorm = basisNorm;
+    opts.opt_alg = opt_alg;
+    opts.opt_stopval = opt_stopval;
+    opts.opt_ftol_rel = opt_ftol_rel;
+    opts.opt_ftol_abs = opt_ftol_abs;
+    opts.opt_xtol_rel = opt_xtol_rel;
+    opts.opt_xtol_abs = opt_xtol_abs;
+    opts.opt_maxeval = opt_maxeval;
+    opts.opt_maxtime = opt_maxtime;
+    opts.verbose = verbose;
+    opts.maxPatience = maxPatience;
+    opts.maxSize = maxSize;
+    opts.maxDegrees = maxDegrees;
+
+    return opts;
+}
+#endif // defined(MPART_HAS_NLOPT)

--- a/bindings/matlab/src/MexOptionsConversions.cpp
+++ b/bindings/matlab/src/MexOptionsConversions.cpp
@@ -86,11 +86,17 @@ void mpart::binding::MapOptionsToMatlab(MapOptions opts, mexplus::OutputArgument
 #if defined(MPART_HAS_NLOPT)
 
 TrainOptions mpart::binding::TrainOptionsFromMatlab(mexplus::InputArguments &input, unsigned int start) {
-    return TrainOptions {input.get<std::string>(start + 0), input.get<double>(start + 1),
-                        input.get<double>(start + 2), input.get<double>(start + 3),
-                        input.get<double>(start + 4), input.get<double>(start + 5),
-                        input.get<int>(start + 6), input.get<double>(start + 7),
-                        input.get<int>(start + 8)};
+    TrainOptions opts;
+    opts.opt_alg = input.get<std::string>(start + 0);
+    opts.opt_stopval = input.get<double>(start + 1);
+    opts.opt_ftol_rel = input.get<double>(start + 2);
+    opts.opt_ftol_abs = input.get<double>(start + 3);
+    opts.opt_xtol_rel = input.get<double>(start + 4);
+    opts.opt_xtol_abs = input.get<double>(start + 5);
+    opts.opt_maxeval = input.get<int>(start + 6);
+    opts.opt_maxtime = input.get<double>(start + 7);
+    opts.verbose = input.get<int>(start + 8);
+    return opts;
 }
 
 ATMOptions mpart::binding::ATMOptionsFromMatlab(mexplus::InputArguments &input, unsigned int start) {

--- a/bindings/matlab/src/MexOptionsConversions.cpp
+++ b/bindings/matlab/src/MexOptionsConversions.cpp
@@ -85,7 +85,7 @@ void mpart::binding::MapOptionsToMatlab(MapOptions opts, mexplus::OutputArgument
 
 #if defined(MPART_HAS_NLOPT)
 
-TrainOptions mpart::binding::TrainOptionsFromMatlab(InputArguments &input, unsigned int start) {
+TrainOptions mpart::binding::TrainOptionsFromMatlab(mexplus::InputArguments &input, unsigned int start) {
     return TrainOptions(input.get<std::string>(start + 0), input.get<double>(start + 1),
                         input.get<double>(start + 2), input.get<double>(start + 3),
                         input.get<double>(start + 4), input.get<double>(start + 5),
@@ -93,7 +93,7 @@ TrainOptions mpart::binding::TrainOptionsFromMatlab(InputArguments &input, unsig
                         input.get<int>(start + 8));
 }
 
-ATMOptions mpart::binding::ATMOptionsFromMatlab(InputArguments &input, unsigned int start) {
+ATMOptions mpart::binding::ATMOptionsFromMatlab(mexplus::InputArguments &input, unsigned int start) {
     return ATMOptionsFromMatlab(input.get<std::string>(start + 0), input.get<std::string>(start + 1),
                                 input.get<std::string>(start + 2), input.get<double>(start + 3),
                                 input.get<double>(start + 4), input.get<unsigned int>(start + 5),

--- a/bindings/matlab/src/MexOptionsConversions.cpp
+++ b/bindings/matlab/src/MexOptionsConversions.cpp
@@ -94,6 +94,7 @@ TrainOptions mpart::binding::TrainOptionsFromMatlab(mexplus::InputArguments &inp
 }
 
 ATMOptions mpart::binding::ATMOptionsFromMatlab(mexplus::InputArguments &input, unsigned int start) {
+    MultiIndex& maxDegrees = *Session<MultiIndex>::get(input.get(start+22));
     return ATMOptionsFromMatlab(input.get<std::string>(start + 0), input.get<std::string>(start + 1),
                                 input.get<std::string>(start + 2), input.get<double>(start + 3),
                                 input.get<double>(start + 4), input.get<unsigned int>(start + 5),
@@ -105,7 +106,7 @@ ATMOptions mpart::binding::ATMOptionsFromMatlab(mexplus::InputArguments &input, 
                                 input.get<double>(start + 16), input.get<double>(start + 17),
                                 input.get<int>(start + 18), input.get<double>(start + 19),
                                 input.get<int>(start + 20), input.get<unsigned int>(start + 21),
-                                input.get<unsigned int>(start + 21), input.get<MultiIndex>(start+22));
+                                input.get<unsigned int>(start + 21), maxDegrees);
 }
 
 ATMOptions  mpart::binding::ATMOptionsFromMatlab(std::string basisType, std::string posFuncType,
@@ -117,7 +118,7 @@ ATMOptions  mpart::binding::ATMOptionsFromMatlab(std::string basisType, std::str
                                         double opt_ftol_rel, double opt_ftol_abs,
                                         double opt_xtol_rel, double opt_xtol_abs,
                                         int opt_maxeval, double opt_maxtime, int verbose,
-                                        unsigned int maxPatience, unsigned int maxSize, MultiIndex maxDegrees)
+                                        unsigned int maxPatience, unsigned int maxSize, MultiIndex& maxDegrees)
 {
     ATMOptions opts;
 

--- a/bindings/matlab/tests/TrainMapTest.m
+++ b/bindings/matlab/tests/TrainMapTest.m
@@ -7,20 +7,23 @@ classdef TrainMapTest < matlab.unittest.TestCase
             dim = 2;
             N=20000;
             N_test = N/5;
-            data = randn(dim,N);
-            target = [data(1,:);data(2,:) + data(1,:).^2];
+            data = randn(dim+1,N);
+            target = [data(1,:);data(2,:);data(3,:) + data(2,:).^2];
             test = target(:,1:N_test);
             train = target(:,N_test+1:end);
 
             % Create objective and map
             obj1 = GaussianKLObjective(train, test, 1);
-            obj2 = GaussianKLObjective(train, test);
+            obj2 = GaussianKLObjective(train, test, 2);
+            obj3 = GaussianKLObjective(train, test);
             map_options = MapOptions();
             max_order = 2;
-            map1 = CreateComponent(FixedMultiIndex(dim,max_order),map_options);
-            map2 = CreateTriangular(dim,dim,max_order,map_options);
+            map1 = CreateComponent(FixedMultiIndexSet(dim+1,max_order),map_options);
+            map2 = CreateTriangular(dim+1,dim,max_order,map_options);
+            map3 = CreateTriangular(dim+1,dim+1,max_order,map_options);
             map1.SetCoeffs(zeros(map1.numCoeffs,1));
             map2.SetCoeffs(zeros(map2.numCoeffs,1));
+            map3.SetCoeffs(zeros(map3.numCoeffs,1));
 
             % Set Training Options
             train_options = TrainOptions;
@@ -28,10 +31,12 @@ classdef TrainMapTest < matlab.unittest.TestCase
             % Print test error before
             TrainMap(map1, obj1, train_options);
             TrainMap(map2, obj2, train_options);
+            TrainMap(map3, obj3, train_options);
 
             % Evaluate test samples after training
             KS_stat1 = KSStatistic(map1,test);
             KS_stat2 = KSStatistic(map2,test);
+            KS_stat3 = KSStatistic(map3,test);
             testCase.verifyTrue(KS_stat1 < 0.1);
             testCase.verifyTrue(KS_stat2 < 0.1);
         end
@@ -44,6 +49,6 @@ function KS_stat = KSStatistic(map,samples)
     pullback_evals = Evaluate(map,samples);
     sorted_samples = sort(pullback_evals(:));
     samps_cdf = (1 + erf(sorted_samples/sqrt(2)))/2;
-    samps_ecdf = (1:numel(samples))'/numel(samples);
+    samps_ecdf = (1:numel(sorted_samples))'/numel(sorted_samples);
     KS_stat = max(abs(samps_ecdf - samps_cdf));
 end

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -27,6 +27,7 @@ if(MPART_OPT)
   set(PYTHON_BINDING_SOURCES ${PYTHON_BINDING_SOURCES}
     src/MapObjective.cpp
     src/TrainMap.cpp
+    src/AdaptiveTransportMap.cpp
   )
 endif()
 

--- a/bindings/python/include/CommonPybindUtilities.h
+++ b/bindings/python/include/CommonPybindUtilities.h
@@ -57,6 +57,11 @@ void MapFactoryWrapper(pybind11::module &m);
 
 template<typename MemorySpace>
 void TrainMapWrapper(pybind11::module &m);
+
+void ATMOptionsWrapper(pybind11::module &m);
+
+template<typename MemorySpace>
+void AdaptiveTransportMapWrapper(pybind11::module &m);
 #endif
 
 

--- a/bindings/python/src/AdaptiveTransportMap.cpp
+++ b/bindings/python/src/AdaptiveTransportMap.cpp
@@ -32,7 +32,10 @@ void mpart::binding::AdaptiveTransportMapWrapper(py::module &m) {
     std::string tName = "AdaptiveTransportMap";
     if(!std::is_same<MemorySpace,Kokkos::HostSpace>::value) tName = "d" + tName;
 
-    m.def(tName.c_str(), &AdaptiveTransportMap<MemorySpace>)
+    m.def(tName.c_str(), [](std::vector<MultiIndexSet> &mset0, std::shared_ptr<MapObjective<MemorySpace>> obj, ATMOptions opts){
+        std::shared_ptr<ConditionalMapBase<MemorySpace>> map = AdaptiveTransportMap<MemorySpace>(mset0, obj, opts);
+        return py::make_tuple(mset0, map);
+    })
     ;
 }
 

--- a/bindings/python/src/AdaptiveTransportMap.cpp
+++ b/bindings/python/src/AdaptiveTransportMap.cpp
@@ -1,0 +1,42 @@
+#include "CommonPybindUtilities.h"
+#include "MParT/MapOptions.h"
+#include "MParT/MapObjective.h"
+#include "MParT/TrainMap.h"
+#include "MParT/AdaptiveTransportMap.h"
+#include <pybind11/stl.h>
+#include <pybind11/eigen.h>
+
+#include <Kokkos_Core.hpp>
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+using namespace mpart::binding;
+
+void mpart::binding::ATMOptionsWrapper(py::module &m)
+{
+    // ATMOptions
+    py::class_<ATMOptions, MapOptions, TrainOptions, std::shared_ptr<ATMOptions>>(m, "ATMOptions")
+    .def(py::init<>())
+    .def("__str__", &ATMOptions::String)
+    .def("__repr__", [](ATMOptions opts){return "<ATMOptions with fields\n" + opts.String() + ">";})
+    .def_readwrite("maxPatience", &ATMOptions::maxPatience)
+    .def_readwrite("maxSize", &ATMOptions::maxSize)
+    .def_readwrite("maxDegrees", &ATMOptions::maxDegrees)
+    ;
+
+}
+
+template<typename MemorySpace>
+void mpart::binding::AdaptiveTransportMapWrapper(py::module &m) {
+
+    std::string tName = "AdaptiveTransportMap";
+    if(!std::is_same<MemorySpace,Kokkos::HostSpace>::value) tName = "d" + tName;
+
+    m.def(tName.c_str(), &AdaptiveTransportMap<MemorySpace>)
+    ;
+}
+
+template void mpart::binding::AdaptiveTransportMapWrapper<Kokkos::HostSpace>(py::module&);
+#if defined(MPART_ENABLE_GPU)
+template void mpart::binding::AdaptiveTransportMapWrapper<mpart::DeviceSpace>(py::module&);
+#endif // MPART_ENABLE_GPU

--- a/bindings/python/src/MapObjective.cpp
+++ b/bindings/python/src/MapObjective.cpp
@@ -28,14 +28,14 @@ void mpart::binding::MapObjectiveWrapper(py::module &m) {
     ;
 
     py::class_<KLObjective<MemorySpace>, MapObjective<MemorySpace>, std::shared_ptr<KLObjective<MemorySpace>>>(m, t2Name.c_str());
-    m.def(mName.c_str(), [](Eigen::Ref<Eigen::MatrixXd> &train){
+    m.def(mName.c_str(), [](Eigen::Ref<Eigen::MatrixXd> &train, unsigned int dim = 0){
             StridedMatrix<const double, MemorySpace> trainView = MatToKokkos<double, MemorySpace>(train);
             Kokkos::View<double**,MemorySpace> storeTrain ("Training data store", trainView.extent(0), trainView.extent(1));
             Kokkos::deep_copy(storeTrain, trainView);
             trainView = storeTrain;
-            return ObjectiveFactory::CreateGaussianKLObjective(trainView);
+            return ObjectiveFactory::CreateGaussianKLObjective(trainView, dim);
         })
-        .def(mName.c_str(), [](Eigen::Ref<Eigen::MatrixXd> &trainEig, Eigen::Ref<Eigen::MatrixXd> &testEig){
+        .def(mName.c_str(), [](Eigen::Ref<Eigen::MatrixXd> &trainEig, Eigen::Ref<Eigen::MatrixXd> &testEig, unsigned int dim = 0){
             StridedMatrix<const double, MemorySpace> trainView = MatToKokkos<double, MemorySpace>(trainEig);
             StridedMatrix<const double, MemorySpace> testView = MatToKokkos<double, MemorySpace>(testEig);
             Kokkos::View<double**,MemorySpace> storeTrain ("Training data store", trainView.extent(0), trainView.extent(1));
@@ -44,7 +44,7 @@ void mpart::binding::MapObjectiveWrapper(py::module &m) {
             Kokkos::deep_copy(storeTest, testView);
             trainView = storeTrain;
             testView = storeTest;
-            return ObjectiveFactory::CreateGaussianKLObjective(trainView, testView);
+            return ObjectiveFactory::CreateGaussianKLObjective(trainView, testView, dim);
         })
     ;
 }

--- a/bindings/python/src/MapObjective.cpp
+++ b/bindings/python/src/MapObjective.cpp
@@ -8,6 +8,7 @@
 #include <pybind11/pybind11.h>
 
 namespace py = pybind11;
+using namespace py::literals;
 using namespace mpart;
 using namespace mpart::binding;
 
@@ -28,14 +29,14 @@ void mpart::binding::MapObjectiveWrapper(py::module &m) {
     ;
 
     py::class_<KLObjective<MemorySpace>, MapObjective<MemorySpace>, std::shared_ptr<KLObjective<MemorySpace>>>(m, t2Name.c_str());
-    m.def(mName.c_str(), [](Eigen::Ref<Eigen::MatrixXd> &train, unsigned int dim = 0){
+    m.def(mName.c_str(), [](Eigen::Ref<Eigen::MatrixXd> &train, unsigned int dim){
             StridedMatrix<const double, MemorySpace> trainView = MatToKokkos<double, MemorySpace>(train);
             Kokkos::View<double**,MemorySpace> storeTrain ("Training data store", trainView.extent(0), trainView.extent(1));
             Kokkos::deep_copy(storeTrain, trainView);
             trainView = storeTrain;
             return ObjectiveFactory::CreateGaussianKLObjective(trainView, dim);
-        })
-        .def(mName.c_str(), [](Eigen::Ref<Eigen::MatrixXd> &trainEig, Eigen::Ref<Eigen::MatrixXd> &testEig, unsigned int dim = 0){
+        }, "train"_a, "dim"_a = 0)
+        .def(mName.c_str(), [](Eigen::Ref<Eigen::MatrixXd> &trainEig, Eigen::Ref<Eigen::MatrixXd> &testEig, unsigned int dim){
             StridedMatrix<const double, MemorySpace> trainView = MatToKokkos<double, MemorySpace>(trainEig);
             StridedMatrix<const double, MemorySpace> testView = MatToKokkos<double, MemorySpace>(testEig);
             Kokkos::View<double**,MemorySpace> storeTrain ("Training data store", trainView.extent(0), trainView.extent(1));
@@ -45,7 +46,7 @@ void mpart::binding::MapObjectiveWrapper(py::module &m) {
             trainView = storeTrain;
             testView = storeTest;
             return ObjectiveFactory::CreateGaussianKLObjective(trainView, testView, dim);
-        })
+        }, "train"_a, "test"_a, "dim"_a = 0)
     ;
 }
 

--- a/bindings/python/src/TrainMap.cpp
+++ b/bindings/python/src/TrainMap.cpp
@@ -7,11 +7,6 @@
 #include <Kokkos_Core.hpp>
 #include <pybind11/pybind11.h>
 
-#if defined(MPART_HAS_CEREAL)
-#include "MParT/Utilities/Serialization.h"
-#include <fstream>
-#endif // MPART_HAS_CEREAL
-
 namespace py = pybind11;
 using namespace mpart::binding;
 
@@ -32,8 +27,6 @@ void mpart::binding::TrainOptionsWrapper(py::module &m)
     .def_readwrite("opt_maxtime", &TrainOptions::opt_maxtime)
     .def_readwrite("verbose", &TrainOptions::verbose)
     ;
-
-    
 }
 
 template<typename MemorySpace>

--- a/bindings/python/src/TrainMapAdaptive.cpp
+++ b/bindings/python/src/TrainMapAdaptive.cpp
@@ -11,6 +11,7 @@
 
 namespace py = pybind11;
 using namespace mpart::binding;
+using namespace mpart;
 
 void mpart::binding::ATMOptionsWrapper(py::module &m)
 {
@@ -27,16 +28,32 @@ void mpart::binding::ATMOptionsWrapper(py::module &m)
 }
 
 template<typename MemorySpace>
+std::shared_ptr<ConditionalMapBase<MemorySpace>> TrainMapAdaptiveSmartPointerPython(std::vector<std::shared_ptr<MultiIndexSet>> &mset0,
+                                                  std::shared_ptr<MapObjective<Kokkos::HostSpace>> objective,
+                                                  ATMOptions options) 
+{   
+    // Create a version of the mset vector with objects not pointers
+    std::vector<MultiIndexSet> newmset;
+    for(auto& ptr: mset0)
+        newmset.push_back(*ptr);
+
+    // Call AdaptiveTrainMap 
+    std::shared_ptr<ConditionalMapBase<MemorySpace>> map = TrainMapAdaptive<MemorySpace>(newmset, objective, options);
+
+    // Now update the pointers
+    for(int i=0; i<mset0.size(); ++i)
+        *mset0[i] = newmset[i];
+    
+    return map;
+}
+
+template<typename MemorySpace>
 void mpart::binding::TrainMapAdaptiveWrapper(py::module &m) {
 
     std::string tName = "TrainMapAdaptive";
     if(!std::is_same<MemorySpace,Kokkos::HostSpace>::value) tName = "d" + tName;
 
-    m.def(tName.c_str(), [](std::vector<MultiIndexSet> &mset0, std::shared_ptr<MapObjective<MemorySpace>> obj, ATMOptions opts){
-        std::shared_ptr<ConditionalMapBase<MemorySpace>> map = TrainMapAdaptive<MemorySpace>(mset0, obj, opts);
-        return py::make_tuple(mset0, map);
-    })
-    ;
+    m.def(tName.c_str(), &TrainMapAdaptiveSmartPointerPython<MemorySpace>);
 }
 
 template void mpart::binding::TrainMapAdaptiveWrapper<Kokkos::HostSpace>(py::module&);

--- a/bindings/python/src/Wrapper.cpp
+++ b/bindings/python/src/Wrapper.cpp
@@ -19,12 +19,14 @@ PYBIND11_MODULE(pympart, m) {
     SummarizedMapWrapper<Kokkos::HostSpace>(m);
     IdentityMapWrapper<Kokkos::HostSpace>(m);
     // DebugMapWrapper<Kokkos::HostSpace>(m);
+    MapFactoryWrapper<Kokkos::HostSpace>(m);
+    MapObjectiveWrapper<Kokkos::HostSpace>(m);
 
 #if defined(MPART_HAS_NLOPT)
-    MapObjectiveWrapper<Kokkos::HostSpace>(m);
     TrainOptionsWrapper(m);
+    ATMOptionsWrapper(m);
     TrainMapWrapper<Kokkos::HostSpace>(m);
-    MapFactoryWrapper<Kokkos::HostSpace>(m);
+    AdaptiveTransportMapWrapper<Kokkos::HostSpace>(m);
 #endif // MPART_HAS_NLOPT
 
 #if defined(MPART_HAS_CEREAL)

--- a/bindings/python/tests/test_TrainMap.py
+++ b/bindings/python/tests/test_TrainMap.py
@@ -3,6 +3,16 @@ import mpart
 import numpy as np
 import math
 
+def KS_statistic(map, test_samples):
+    pullback_samples = map.Evaluate(test_samples)
+    print(pullback_samples.shape)
+    sorted_samps = np.sort(pullback_samples.flatten())
+    erf = np.vectorize(math.erf)
+    samps_cdf = (1 + erf(sorted_samps/np.sqrt(2)))/2
+    samps_ecdf = (np.arange(pullback_samples.size) + 1)/pullback_samples.size
+    KS_stat = np.abs(samps_cdf - samps_ecdf).max()
+    return KS_stat
+
 # Create samples from banana
 dim=2
 seed = 43
@@ -17,24 +27,27 @@ test_samples = target_samples[:,:testPts]
 train_samples = target_samples[:,testPts:]
 
 # Create training objective
-obj = mpart.CreateGaussianKLObjective(np.asfortranarray(train_samples),np.asfortranarray(test_samples))
+obj2 = mpart.CreateGaussianKLObjective(np.asfortranarray(train_samples),np.asfortranarray(test_samples))
+obj1 = mpart.CreateGaussianKLObjective(np.asfortranarray(train_samples),np.asfortranarray(test_samples),1)
 
-# Create untrained map
+# Create untrained maps
 map_options = mpart.MapOptions()
-map = mpart.CreateTriangular(dim,dim,2,map_options)
+map2 = mpart.CreateTriangular(dim,dim,2,map_options) # Triangular map
+map1 = mpart.CreateComponent(mpart.FixedMultiIndexSet(2,2),map_options) # Singular Component
 
 # Train map
 train_options = mpart.TrainOptions()
-mpart.TrainMap(map, obj, train_options)
+mpart.TrainMap(map2, obj2, train_options)
+mpart.TrainMap(map1, obj1, train_options)
 
 def test_TestError():
-    assert obj.TestError(map) < 5.
+    assert obj1.TestError(map1) < 5.
+    assert obj2.TestError(map2) < 5.
 
 def test_Normality():
-    pullback_samples = map.Evaluate(test_samples)
-    sorted_samps = np.sort(pullback_samples.flatten())
-    erf = np.vectorize(math.erf)
-    samps_cdf = (1 + erf(sorted_samps/np.sqrt(2)))/2
-    samps_ecdf = (np.arange(dim*testPts) + 1)/(dim*testPts)
-    KS_stat = np.abs(samps_cdf - samps_ecdf).max()
-    assert KS_stat < 0.1
+    print("Testing map1...")
+    KS_stat1 = KS_statistic(map1, test_samples)
+    print("Testing map2...")
+    KS_stat2 = KS_statistic(map2, test_samples)
+    assert KS_stat1 < 0.1
+    assert KS_stat2 < 0.1

--- a/bindings/python/tests/test_TrainMap.py
+++ b/bindings/python/tests/test_TrainMap.py
@@ -17,7 +17,7 @@ test_samples = target_samples[:,:testPts]
 train_samples = target_samples[:,testPts:]
 
 # Create training objective
-obj = mpart.GaussianKLObjective(np.asfortranarray(train_samples),np.asfortranarray(test_samples))
+obj = mpart.CreateGaussianKLObjective(np.asfortranarray(train_samples),np.asfortranarray(test_samples))
 
 # Create untrained map
 map_options = mpart.MapOptions()

--- a/bindings/python/tests/test_TrainMapAdaptive.py
+++ b/bindings/python/tests/test_TrainMapAdaptive.py
@@ -1,0 +1,47 @@
+# Test methods of TriangularMap object
+import mpart
+import numpy as np
+import math
+
+def KS_statistic(map, test_samples):
+    pullback_samples = map.Evaluate(test_samples)
+    print(pullback_samples.shape)
+    sorted_samps = np.sort(pullback_samples.flatten())
+    erf = np.vectorize(math.erf)
+    samps_cdf = (1 + erf(sorted_samps/np.sqrt(2)))/2
+    samps_ecdf = (np.arange(pullback_samples.size) + 1)/pullback_samples.size
+    KS_stat = np.abs(samps_cdf - samps_ecdf).max()
+    return KS_stat
+
+# Create samples from banana
+dim=2
+seed = 43
+numPts = 5000
+testPts = numPts//5
+np.random.seed(seed)
+samples = np.random.randn(dim,numPts)
+target_samples = np.vstack([samples[0,:], samples[1,:] + samples[0,:]**2])
+
+# Separate into testing and training samples
+test_samples = target_samples[:,:testPts]
+train_samples = target_samples[:,testPts:]
+
+# Create training objective
+obj = mpart.CreateGaussianKLObjective(np.asfortranarray(train_samples),np.asfortranarray(test_samples))
+
+# Use ATM to build a map
+opts = mpart.ATMOptions()
+msets = [mpart.MultiIndexSet.CreateTotalOrder(d+1,1) for d in range(2)]
+map = mpart.TrainMapAdaptive(msets, obj, opts)
+
+def test_Msets():
+    # Make sure the multiindex set has changed
+    assert msets[1].Size()>3
+
+def test_TestError():
+    assert obj.TestError(map) < 5.
+
+def test_Normality():
+    print("Testing map1...")
+    KS_stat = KS_statistic(map, test_samples)
+    assert KS_stat < 0.1

--- a/src/AdaptiveTransportMap.cpp
+++ b/src/AdaptiveTransportMap.cpp
@@ -189,7 +189,7 @@ std::shared_ptr<ConditionalMapBase<Kokkos::HostSpace>> mpart::AdaptiveTransportM
         MultiIndex addedMulti = mset_tmp[maxIdxBlock][maxIdx];
         mset0[maxIdxBlock] += addedMulti;
         if(options.verbose) {
-            std::cerr << "Added multi = [" << addedMulti.String() << "]" <<std::endl;
+            std::cout << "Added multi = [" << addedMulti.String() << "]" <<std::endl;
         }
         currSz++;
         if(mset0[maxIdxBlock].Size() != mset_sizes[maxIdxBlock]+1) {

--- a/src/MapObjective.cpp
+++ b/src/MapObjective.cpp
@@ -36,14 +36,16 @@ StridedVector<double, MemorySpace> MapObjective<MemorySpace>::TrainCoeffGrad(std
 }
 
 template<typename MemorySpace>
-std::shared_ptr<MapObjective<MemorySpace>> ObjectiveFactory::CreateGaussianKLObjective(StridedMatrix<const double, MemorySpace> train) {
-    std::shared_ptr<GaussianSamplerDensity<MemorySpace>> density = std::make_shared<GaussianSamplerDensity<MemorySpace>>(train.extent(0));
+std::shared_ptr<MapObjective<MemorySpace>> ObjectiveFactory::CreateGaussianKLObjective(StridedMatrix<const double, MemorySpace> train, unsigned int dim) {
+    if(dim == 0) dim = train.extent(0);
+    std::shared_ptr<GaussianSamplerDensity<MemorySpace>> density = std::make_shared<GaussianSamplerDensity<MemorySpace>>(dim);
     return std::make_shared<KLObjective<MemorySpace>>(train, density);
 }
 
 template<typename MemorySpace>
-std::shared_ptr<MapObjective<MemorySpace>> ObjectiveFactory::CreateGaussianKLObjective(StridedMatrix<const double, MemorySpace> train, StridedMatrix<const double, MemorySpace> test) {
-    std::shared_ptr<GaussianSamplerDensity<MemorySpace>> density = std::make_shared<GaussianSamplerDensity<MemorySpace>>(train.extent(0));
+std::shared_ptr<MapObjective<MemorySpace>> ObjectiveFactory::CreateGaussianKLObjective(StridedMatrix<const double, MemorySpace> train, StridedMatrix<const double, MemorySpace> test, unsigned int dim) {
+    if(dim == 0) dim = train.extent(0);
+    std::shared_ptr<GaussianSamplerDensity<MemorySpace>> density = std::make_shared<GaussianSamplerDensity<MemorySpace>>(dim);
     return std::make_shared<KLObjective<MemorySpace>>(train, test, density);
 }
 
@@ -87,11 +89,11 @@ void KLObjective<MemorySpace>::CoeffGradImpl(StridedMatrix<const double, MemoryS
 // Explicit template instantiation
 template class mpart::MapObjective<Kokkos::HostSpace>;
 template class mpart::KLObjective<Kokkos::HostSpace>;
-template std::shared_ptr<MapObjective<Kokkos::HostSpace>> mpart::ObjectiveFactory::CreateGaussianKLObjective<Kokkos::HostSpace>(StridedMatrix<const double, Kokkos::HostSpace>);
-template std::shared_ptr<MapObjective<Kokkos::HostSpace>> mpart::ObjectiveFactory::CreateGaussianKLObjective<Kokkos::HostSpace>(StridedMatrix<const double, Kokkos::HostSpace>, StridedMatrix<const double, Kokkos::HostSpace>);
+template std::shared_ptr<MapObjective<Kokkos::HostSpace>> mpart::ObjectiveFactory::CreateGaussianKLObjective<Kokkos::HostSpace>(StridedMatrix<const double, Kokkos::HostSpace>, unsigned int);
+template std::shared_ptr<MapObjective<Kokkos::HostSpace>> mpart::ObjectiveFactory::CreateGaussianKLObjective<Kokkos::HostSpace>(StridedMatrix<const double, Kokkos::HostSpace>, StridedMatrix<const double, Kokkos::HostSpace>, unsigned int);
 #if defined(MPART_ENABLE_GPU)
     template class mpart::MapObjective<DeviceSpace>;
     template class mpart::KLObjective<DeviceSpace>;
-    template std::shared_ptr<MapObjective<DeviceSpace>> mpart::ObjectiveFactory::CreateGaussianKLObjective<DeviceSpace>(StridedMatrix<const double, DeviceSpace>);
-    template std::shared_ptr<MapObjective<DeviceSpace>> mpart::ObjectiveFactory::CreateGaussianKLObjective<DeviceSpace>(StridedMatrix<const double, DeviceSpace>, StridedMatrix<const double, DeviceSpace>);
+    template std::shared_ptr<MapObjective<DeviceSpace>> mpart::ObjectiveFactory::CreateGaussianKLObjective<DeviceSpace>(StridedMatrix<const double, DeviceSpace>, unsigned int);
+    template std::shared_ptr<MapObjective<DeviceSpace>> mpart::ObjectiveFactory::CreateGaussianKLObjective<DeviceSpace>(StridedMatrix<const double, DeviceSpace>, StridedMatrix<const double, DeviceSpace>, unsigned int);
 #endif

--- a/tests/Test_TrainMap.cpp
+++ b/tests/Test_TrainMap.cpp
@@ -16,25 +16,57 @@ TEST_CASE("Test_TrainMap", "[TrainMap]") {
     unsigned int dim = 2;
     unsigned int numPts = 20000;
     unsigned int testPts = numPts / 5;
-    auto sampler = std::make_shared<GaussianSamplerDensity<Kokkos::HostSpace>>(2);
+    auto sampler = std::make_shared<GaussianSamplerDensity<Kokkos::HostSpace>>(3);
     sampler->SetSeed(seed);
     auto samples = sampler->Sample(numPts);
-    Kokkos::View<double**, Kokkos::HostSpace> targetSamples("targetSamples", 2, numPts);
+    Kokkos::View<double**, Kokkos::HostSpace> targetSamples("targetSamples", 3, numPts);
     double max = 0;
     Kokkos::parallel_for("Banana", numPts, KOKKOS_LAMBDA(const unsigned int i) {
         targetSamples(0,i) = samples(0,i);
-        targetSamples(1,i) = samples(1,i) + samples(0,i)*samples(0,i);
+        targetSamples(1,i) = samples(1,i);
+        targetSamples(2,i) = samples(2,i) + samples(1,i)*samples(1,i);
     });
-    StridedMatrix<const double, Kokkos::HostSpace> testSamps = Kokkos::subview(targetSamples, Kokkos::ALL, Kokkos::pair<unsigned int, unsigned int>(0, testPts));
-    StridedMatrix<const double, Kokkos::HostSpace> trainSamps = Kokkos::subview(targetSamples, Kokkos::ALL, Kokkos::pair<unsigned int, unsigned int>(testPts, numPts));
-    auto obj = ObjectiveFactory::CreateGaussianKLObjective(trainSamps, testSamps);
+    unsigned int map_order = 2;
+    SECTION("SquareMap") {
+        StridedMatrix<const double, Kokkos::HostSpace> testSamps = Kokkos::subview(targetSamples, Kokkos::make_pair(1u,3u), Kokkos::make_pair(0u, testPts));
+        StridedMatrix<const double, Kokkos::HostSpace> trainSamps = Kokkos::subview(targetSamples, Kokkos::make_pair(1u,3u), Kokkos::make_pair(testPts, numPts));
+        auto obj = ObjectiveFactory::CreateGaussianKLObjective(trainSamps, testSamps);
 
-    MapOptions map_options;
-    auto map = MapFactory::CreateTriangular<Kokkos::HostSpace>(dim, dim, 2, map_options);
+        MapOptions map_options;
+        auto map = MapFactory::CreateTriangular<Kokkos::HostSpace>(dim, dim, map_order, map_options);
 
-    TrainOptions train_options;
-    train_options.verbose = 0;
-    TrainMap(map, obj, train_options);
-    auto pullback_samples = map->Evaluate(testSamps);
-    TestStandardNormalSamples(pullback_samples);
+        TrainOptions train_options;
+        train_options.verbose = 0;
+        TrainMap(map, obj, train_options);
+        auto pullback_samples = map->Evaluate(testSamps);
+        TestStandardNormalSamples(pullback_samples);
+    }
+    SECTION("ComponentMap") {
+        StridedMatrix<const double, Kokkos::HostSpace> testSamps = Kokkos::subview(targetSamples, Kokkos::make_pair(1u,3u), Kokkos::pair<unsigned int, unsigned int>(0, testPts));
+        StridedMatrix<const double, Kokkos::HostSpace> trainSamps = Kokkos::subview(targetSamples, Kokkos::make_pair(1u,3u), Kokkos::pair<unsigned int, unsigned int>(testPts, numPts));
+        auto obj = ObjectiveFactory::CreateGaussianKLObjective(trainSamps, testSamps, 1);
+
+        MapOptions map_options;
+        std::shared_ptr<ConditionalMapBase<Kokkos::HostSpace>> map = MapFactory::CreateComponent<Kokkos::HostSpace>(FixedMultiIndexSet<Kokkos::HostSpace>(dim,map_order), map_options);
+
+        TrainOptions train_options;
+        train_options.verbose = 0;
+        TrainMap(map, obj, train_options);
+        auto pullback_samples = map->Evaluate(testSamps);
+        TestStandardNormalSamples(pullback_samples);
+    }
+    SECTION("RectangleMap") {
+        StridedMatrix<const double, Kokkos::HostSpace> testSamps = Kokkos::subview(targetSamples, Kokkos::ALL(), Kokkos::pair<unsigned int, unsigned int>(0, testPts));
+        StridedMatrix<const double, Kokkos::HostSpace> trainSamps = Kokkos::subview(targetSamples, Kokkos::ALL(), Kokkos::pair<unsigned int, unsigned int>(testPts, numPts));
+        auto obj = ObjectiveFactory::CreateGaussianKLObjective(trainSamps, testSamps, 2);
+
+        MapOptions map_options;
+        std::shared_ptr<ConditionalMapBase<Kokkos::HostSpace>> map = MapFactory::CreateTriangular<Kokkos::HostSpace>(dim+1, dim, map_order, map_options);
+
+        TrainOptions train_options;
+        train_options.verbose = 0;
+        TrainMap(map, obj, train_options);
+        auto pullback_samples = map->Evaluate(testSamps);
+        TestStandardNormalSamples(pullback_samples);
+    }
 }


### PR DESCRIPTION
Bind necessary features to use ATM. Unfortunately, I could not _quite_ figure out a way to make everything exactly the same in all the languages, with two major dichotomies
- In C++, Julia, and Python, one uses `CreateGaussianKLObjective` to get a KLObjective with a gaussian "target" density (see below). For Matlab I sort-of had to make a `GaussianKLObjective` class unfortunately, so you instantiate it with `GaussianKLObjective` in those bindings.
- In C++, Julia, and Matlab, you pass in your initial `MultiIndexSet`s as a vector and the algorithm with change those sets in-place to be the optimal `MultiIndexSet`s (it returns a trained map using those msets). This is not easily doable in Python bindings that I found so, as a workaround, it just returns the msets as the first output and the trained map as the second output

However, this should work nicely, with a bonus feature of `ATMOptions::MaxDegrees` working in all the languages. I tidied some code up in the bindings as well, particularly regarding the Matlab bindings.