### PR TITLE
Fixing explicit instantiation must occur in namespace error.

### DIFF
--- a/src/Distributions/GaussianSamplerDensity.cpp
+++ b/src/Distributions/GaussianSamplerDensity.cpp
@@ -131,7 +131,7 @@ void GaussianSamplerDensity<MemorySpace>::SampleImpl(StridedMatrix<double, Memor
     }
 }
 
-template struct GaussianSamplerDensity<Kokkos::HostSpace>;
+template struct mpart::GaussianSamplerDensity<Kokkos::HostSpace>;
 #ifdef MPART_ENABLE_GPU
-template struct GaussianSamplerDensity<mpart::DeviceSpace>;
+template struct mpart::GaussianSamplerDensity<mpart::DeviceSpace>;
 #endif


### PR DESCRIPTION
When trying to build with pip, I ran into this error:
```
GaussianSamplerDensity.cpp:134:17: error: explicit instantiation of 'mpart::GaussianSamplerDensity' must occur in namespace 'mpart'
```

This pull request should fix that.