### PR TITLE
Mparno/issue327

### DIFF
--- a/MParT/AffineFunction.h
+++ b/MParT/AffineFunction.h
@@ -51,9 +51,9 @@ public:
 
 
 protected:
-
-    StridedMatrix<double,MemorySpace> A_;
-    StridedVector<double,MemorySpace> b_;
+    
+    Kokkos::View<double**, Kokkos::LayoutLeft, MemorySpace> A_;
+    Kokkos::View<double*, Kokkos::LayoutLeft, MemorySpace> b_;
 
     int ldA;
 

--- a/MParT/AffineMap.h
+++ b/MParT/AffineMap.h
@@ -13,6 +13,7 @@
 namespace mpart{
 
 /** @brief Defines transformations of the form \f$Ax+b\f$ for an invertible matrix \f$A\f$ and vector offset \f$b\f$.
+ * Makes a deep copy of any views passed to the constructor.
 */
 template<typename MemorySpace>
 class AffineMap : public ConditionalMapBase<MemorySpace>
@@ -64,8 +65,8 @@ public:
 
 protected:
 
-    StridedMatrix<double,MemorySpace> A_;
-    StridedVector<double,MemorySpace> b_;
+    Kokkos::View<double**, Kokkos::LayoutLeft, MemorySpace> A_;
+    Kokkos::View<double*, Kokkos::LayoutLeft, MemorySpace> b_;
 
     mpart::PartialPivLU<MemorySpace> luSolver_;
     double logDet_;

--- a/bindings/python/src/AffineMap.cpp
+++ b/bindings/python/src/AffineMap.cpp
@@ -13,15 +13,15 @@ using namespace mpart::binding;
 void mpart::binding::AffineMapWrapperHost(py::module &m)
 {
     py::class_<AffineMap<Kokkos::HostSpace>, ConditionalMapBase<Kokkos::HostSpace>, std::shared_ptr<AffineMap<Kokkos::HostSpace>>>(m, "AffineMap")
-        .def(py::init( [](Eigen::Ref<Eigen::VectorXd> const& b)
+        .def(py::init( [](py::EigenDRef<Eigen::VectorXd> const& b)
         {
             return new AffineMap<Kokkos::HostSpace>(VecToKokkos<double, Kokkos::HostSpace>(b));
         }))
-        .def(py::init( [](Eigen::Ref<Eigen::MatrixXd> const& A, Eigen::Ref<Eigen::VectorXd> const& b)
+        .def(py::init( [](py::EigenDRef<Eigen::MatrixXd> const& A, py::EigenDRef<Eigen::VectorXd> const& b)
         {
             return new AffineMap<Kokkos::HostSpace>(MatToKokkos<double, Kokkos::HostSpace>(A), VecToKokkos<double, Kokkos::HostSpace>(b));
         }))
-        .def(py::init( [](Eigen::Ref<Eigen::MatrixXd> const& A)
+        .def(py::init( [](py::EigenDRef<Eigen::MatrixXd> const& A)
         {
             return new AffineMap<Kokkos::HostSpace>(MatToKokkos<double, Kokkos::HostSpace>(A));
         }));
@@ -31,15 +31,15 @@ void mpart::binding::AffineMapWrapperHost(py::module &m)
 void mpart::binding::AffineFunctionWrapperHost(py::module &m)
 {
     py::class_<AffineFunction<Kokkos::HostSpace>, ParameterizedFunctionBase<Kokkos::HostSpace>, std::shared_ptr<AffineFunction<Kokkos::HostSpace>>>(m, "AffineFunction")
-        .def(py::init( [](Eigen::Ref<Eigen::VectorXd> const& b)
+        .def(py::init( [](py::EigenDRef<Eigen::VectorXd> const& b)
         {
             return new AffineFunction<Kokkos::HostSpace>(VecToKokkos<double, Kokkos::HostSpace>(b));
         }))
-        .def(py::init( [](Eigen::Ref<Eigen::MatrixXd> const& A, Eigen::Ref<Eigen::VectorXd> const& b)
+        .def(py::init( [](py::EigenDRef<Eigen::MatrixXd> const& A, py::EigenDRef<Eigen::VectorXd> const& b)
         {
             return new AffineFunction<Kokkos::HostSpace>(MatToKokkos<double, Kokkos::HostSpace>(A), VecToKokkos<double, Kokkos::HostSpace>(b));
         }))
-        .def(py::init( [](Eigen::Ref<Eigen::MatrixXd> const& A)
+        .def(py::init( [](py::EigenDRef<Eigen::MatrixXd> const& A)
         {
             return new AffineFunction<Kokkos::HostSpace>(MatToKokkos<double, Kokkos::HostSpace>(A));
         }));

--- a/src/AffineFunction.cpp
+++ b/src/AffineFunction.cpp
@@ -11,7 +11,7 @@ using namespace mpart;
 
 template<typename MemorySpace>
 AffineFunction<MemorySpace>::AffineFunction(StridedVector<double,MemorySpace> b) : ParameterizedFunctionBase<MemorySpace>(b.size(),b.size(),0), 
-                                                                  b_("b",b.layout()) 
+                                                                  b_("b",b.extent(0)) 
 {
 
     Kokkos::deep_copy(b_, b);
@@ -19,7 +19,7 @@ AffineFunction<MemorySpace>::AffineFunction(StridedVector<double,MemorySpace> b)
 
 template<typename MemorySpace>
 AffineFunction<MemorySpace>::AffineFunction(StridedMatrix<double,MemorySpace> A) : ParameterizedFunctionBase<MemorySpace>(A.extent(1),A.extent(0),0),
-                                                                               A_("A", A.layout())
+                                                                               A_("A", A.extent(0), A.extent(1))
 {
     Kokkos::deep_copy(A_, A);
     assert(A_.extent(0)<=A_.extent(1));
@@ -29,8 +29,8 @@ AffineFunction<MemorySpace>::AffineFunction(StridedMatrix<double,MemorySpace> A)
 template<typename MemorySpace>
 AffineFunction<MemorySpace>::AffineFunction(StridedMatrix<double,MemorySpace> A,
                                   StridedVector<double,MemorySpace> b) : ParameterizedFunctionBase<MemorySpace>(A.extent(1),A.extent(0),0),
-                                                                  A_("A", A.layout()),
-                                                                  b_("b",b.layout())
+                                                                  A_("A", A.extent(0), A.extent(1)),
+                                                                  b_("b", b.extent(0))
 {   
     Kokkos::deep_copy(A_, A);
     Kokkos::deep_copy(b_, b);

--- a/src/AffineMap.cpp
+++ b/src/AffineMap.cpp
@@ -17,7 +17,7 @@ AffineMap<MemorySpace>::AffineMap(StridedVector<double,MemorySpace> b) : Conditi
 
 template<typename MemorySpace>
 AffineMap<MemorySpace>::AffineMap(StridedMatrix<double,MemorySpace> A) : ConditionalMapBase<MemorySpace>(A.extent(1),A.extent(0),0),
-                                                                  A_("A", A.extent(0))
+                                                                  A_("A", A.extent(0), A.extent(1))
 {
     Kokkos::deep_copy(A_, A);
     assert(A_.extent(0)<=A_.extent(1));
@@ -150,7 +150,7 @@ void AffineMap<MemorySpace>::EvaluateImpl(StridedMatrix<const double, MemorySpac
         });
 
         dgemm<MemorySpace>(1.0, A_, pts, 0.0, output);
-        
+
     }else{
         Kokkos::deep_copy(output, pts);
     }


### PR DESCRIPTION
Closes #327 

The bug in #327 stemmed from not initializing the output matrix to 0.0, which allowed nans to trickle through.  I'm not entirely sure why this wasn't popping up anywhere other than the python bindings.

- Also added support for passing in numpy arrays with arbitrary storage orders to AffineMap and AffineFunction.  This means we won't need to use the `asfortranarray` function anymore.
- Since we were making deep copies of the arrays in AffineMap anyway, I forced them to be LayoutLeft, so no check or copy is needed during the factorization.