### PR TITLE
Fix striding for eigen conversion in Julia binding

### DIFF
--- a/bindings/julia/src/JlArrayConversions.cpp
+++ b/bindings/julia/src/JlArrayConversions.cpp
@@ -39,6 +39,7 @@ StridedMatrix<double, Kokkos::HostSpace> JuliaToKokkos(jlcxx::ArrayRef<double,2>
 Eigen::Map<const Eigen::Matrix<int,Eigen::Dynamic, Eigen::Dynamic>,0,Eigen::OuterStride<>> JuliaToEigenMat(jlcxx::ArrayRef<int,2> mat) {
     int* mptr = mat.data();
     unsigned int rows = size(mat,0);
+    unsigned int cols = size(mat,1);
     return Eigen::Map<const Eigen::Matrix<int,Eigen::Dynamic, Eigen::Dynamic>,0,Eigen::OuterStride<>>(mptr, rows, cols, Eigen::OuterStride<>(rows));
 }
 

--- a/bindings/julia/src/JlArrayConversions.cpp
+++ b/bindings/julia/src/JlArrayConversions.cpp
@@ -39,8 +39,7 @@ StridedMatrix<double, Kokkos::HostSpace> JuliaToKokkos(jlcxx::ArrayRef<double,2>
 Eigen::Map<const Eigen::Matrix<int,Eigen::Dynamic, Eigen::Dynamic>,0,Eigen::OuterStride<>> JuliaToEigenMat(jlcxx::ArrayRef<int,2> mat) {
     int* mptr = mat.data();
     unsigned int rows = size(mat,0);
-    unsigned int cols = size(mat,1);
-    return Eigen::Map<const Eigen::Matrix<int,Eigen::Dynamic, Eigen::Dynamic>,0,Eigen::OuterStride<>>(mptr, rows, cols, Eigen::OuterStride<>(std::max(rows,cols)));
+    return Eigen::Map<const Eigen::Matrix<int,Eigen::Dynamic, Eigen::Dynamic>,0,Eigen::OuterStride<>>(mptr, rows, cols, Eigen::OuterStride<>(rows));
 }
 
 /**

--- a/bindings/julia/src/MultiIndex.cpp
+++ b/bindings/julia/src/MultiIndex.cpp
@@ -83,7 +83,6 @@ void mpart::binding::MultiIndexWrapper(jlcxx::Module &mod) {
     mod.method("length", [](FixedMultiIndexSet<Kokkos::HostSpace> &mset){return mset.Length();});
     mod.method("size", [](FixedMultiIndexSet<Kokkos::HostSpace> &mset){return mset.Size();});
     mod.method("vec", [](MultiIndex const& idx){ return idx.Vector(); });
-    mod.method("copy", [](MultiIndexSet const& mset){ MultiIndexSet mset_copy = mset; return mset_copy;});
     mod.method("==", [](MultiIndex const& idx1, MultiIndex const& idx2){ return idx1 == idx2; });
     mod.method("!=", [](MultiIndex const& idx1, MultiIndex const& idx2){ return idx1 != idx2; });
     mod.method("<", [](MultiIndex const& idx1, MultiIndex const& idx2){ return idx1 < idx2; });

--- a/bindings/julia/src/MultiIndex.cpp
+++ b/bindings/julia/src/MultiIndex.cpp
@@ -63,6 +63,8 @@ void mpart::binding::MultiIndexWrapper(jlcxx::Module &mod) {
         .method("NumActiveForward", &MultiIndexSet::NumActiveForward)
         .method("NumForward", &MultiIndexSet::NumForward)
         .method("Size", &MultiIndexSet::Size)
+        .method("addto!", [](MultiIndexSet &mset, MultiIndex const& idx){ return mset += idx; })
+        .method("addto!", [](MultiIndexSet &mset, MultiIndexSet const& mset2){ return mset += mset2; })
     ;
 
     mod.method("MultiIndexSet", [](jlcxx::ArrayRef<int,2> idxs) {


### PR DESCRIPTION
Also fixed a small bug-- the previous binding for `copy` actually was unnecessary and caused problems with Julia. I added an `addto!` binding for MultiIndexSet to check whether the given `copy` works.