### PR TITLE
Streamline some unit/regression tests

### DIFF
--- a/tests/Test_ComposedMap.cpp
+++ b/tests/Test_ComposedMap.cpp
@@ -14,12 +14,12 @@ TEST_CASE( "Testing 2 layer composed map with moveCoeffs=false", "[ShallowCompos
     MapOptions options;
     options.basisType = BasisTypes::ProbabilistHermite;
     options.basisNorm = false;
-    
+
     unsigned int dim = 2;
     unsigned int numMaps = 2;
     unsigned int order = 2;
     unsigned int coeffSize = 0;
-    
+
 
     std::vector<std::shared_ptr<ConditionalMapBase<MemorySpace>>> maps(numMaps);
     for(unsigned int i=0;i<numMaps;++i){
@@ -38,9 +38,9 @@ TEST_CASE( "Testing 2 layer composed map with moveCoeffs=false", "[ShallowCompos
     Eigen::RowVectorXd coeffs(composedMap->numCoeffs);
     for(unsigned int i=0; i<composedMap->numCoeffs; ++i)
         coeffs(i) = 0.1*(i+1);
-    
+
     SECTION("Coefficients"){
-        
+
         // Set the coefficients of the triangular map
         composedMap->SetCoeffs(coeffs);
 
@@ -67,7 +67,7 @@ TEST_CASE( "Testing 2 layer composed map with moveCoeffs=false", "[ShallowCompos
 
     composedMap->SetCoeffs(coeffs);
     auto out = composedMap->Evaluate(in);
-    
+
     SECTION("Evaluate"){
         Kokkos::View<double**, Kokkos::HostSpace> trueOut("True output", dim, numSamps);
         Kokkos::deep_copy(trueOut, in);
@@ -113,7 +113,7 @@ TEST_CASE( "Testing 2 layer composed map with moveCoeffs=false", "[ShallowCompos
     SECTION("CoeffGrad"){
 
         Kokkos::View<double**,Kokkos::HostSpace> sens("Sensitivities", composedMap->outputDim, numSamps);
-        
+
         for(unsigned int j=0; j<numSamps; ++j){
             for(unsigned int i=0; i<composedMap->outputDim; ++i){
                 sens(i,j) = 1.0 + 0.1*i + j;
@@ -137,16 +137,16 @@ TEST_CASE( "Testing 2 layer composed map with moveCoeffs=false", "[ShallowCompos
             evals2 = composedMap->Evaluate(in);
 
             for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd){
-                
+
                 double fdDeriv = 0.0;
                 for(unsigned int j=0; j<composedMap->outputDim; ++j)
                     fdDeriv += sens(j,ptInd) * (evals2(j,ptInd)-evals(j,ptInd))/fdstep;
 
-                CHECK( coeffGrad(i,ptInd) == Approx(fdDeriv).margin(1e-3)); 
+                CHECK( coeffGrad(i,ptInd) == Approx(fdDeriv).margin(1e-3));
             }
             coeffs(i) -= fdstep;
         }
-        
+
     }
 
 
@@ -176,18 +176,18 @@ TEST_CASE( "Testing 2 layer composed map with moveCoeffs=false", "[ShallowCompos
             evals2 = composedMap->Evaluate(in);
 
             for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd){
-                
+
                 double fdDeriv = 0.0;
                 for(unsigned int j=0; j<composedMap->outputDim; ++j)
                     fdDeriv += sens(j,ptInd) * (evals2(j,ptInd)-evals(j,ptInd))/fdstep;
 
-                CHECK( inputGrad(i,ptInd) == Approx(fdDeriv).margin(1e-3)); 
+                CHECK( inputGrad(i,ptInd) == Approx(fdDeriv).margin(1e-3));
             }
 
             for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd)
                 in(i,ptInd) -= fdstep;
         }
-        
+
     }
 
     SECTION("LogDeterminantCoeffGrad"){
@@ -195,7 +195,7 @@ TEST_CASE( "Testing 2 layer composed map with moveCoeffs=false", "[ShallowCompos
         Kokkos::View<double**,Kokkos::HostSpace> detGrad = composedMap->LogDeterminantCoeffGrad(in);
         REQUIRE(detGrad.extent(0)==composedMap->numCoeffs);
         REQUIRE(detGrad.extent(1)==numSamps);
-        
+
         Kokkos::View<double*,Kokkos::HostSpace> logDet = composedMap->LogDeterminant(in);
         Kokkos::View<double*,Kokkos::HostSpace> logDet2;
 
@@ -208,8 +208,8 @@ TEST_CASE( "Testing 2 layer composed map with moveCoeffs=false", "[ShallowCompos
             logDet2 = composedMap->LogDeterminant(in);
 
             for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd){
-                CHECK( detGrad(i,ptInd) == Approx((logDet2(ptInd)-logDet(ptInd))/fdstep).margin(1e-3)); 
-                
+                CHECK( detGrad(i,ptInd) == Approx((logDet2(ptInd)-logDet(ptInd))/fdstep).margin(1e-3));
+
             }
             coeffs(i) -= fdstep;
         }
@@ -222,8 +222,8 @@ TEST_CASE( "Testing 2 layer composed map with moveCoeffs=false", "[ShallowCompos
         Kokkos::View<double**,Kokkos::HostSpace> detGrad = composedMap->LogDeterminantInputGrad(in);
         REQUIRE(detGrad.extent(0)==composedMap->inputDim);
         REQUIRE(detGrad.extent(1)==numSamps);
-        
-        
+
+
         Kokkos::View<double*,Kokkos::HostSpace> logDet = composedMap->LogDeterminant(in);
         Kokkos::View<double*,Kokkos::HostSpace> logDet2;
 
@@ -237,7 +237,7 @@ TEST_CASE( "Testing 2 layer composed map with moveCoeffs=false", "[ShallowCompos
             logDet2 = composedMap->LogDeterminant(in);
 
             for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd){
-                CHECK( detGrad(i,ptInd) == Approx((logDet2(ptInd)-logDet(ptInd))/fdstep).margin(1e-3)); 
+                CHECK( detGrad(i,ptInd) == Approx((logDet2(ptInd)-logDet(ptInd))/fdstep).margin(1e-3));
             }
 
             for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd)
@@ -253,12 +253,12 @@ TEST_CASE( "Testing 2 layer composed map with moveCoeffs=true", "[ShallowCompose
     MapOptions options;
     options.basisType = BasisTypes::ProbabilistHermite;
     options.basisNorm = false;
-    
+
     unsigned int dim = 2;
     unsigned int numMaps = 2;
     unsigned int order = 2;
     unsigned int coeffSize = 0;
-    
+
 
     std::vector<std::shared_ptr<ConditionalMapBase<MemorySpace>>> maps(numMaps);
     std::vector<Kokkos::View<double*,Kokkos::HostSpace>> coeffs_(numMaps);
@@ -271,7 +271,7 @@ TEST_CASE( "Testing 2 layer composed map with moveCoeffs=true", "[ShallowCompose
 
         for(unsigned int j=0; j<maps.at(i)->numCoeffs; ++j)
             coeffs_.at(i)(j) = 0.1*(j+1);
-        
+
         maps.at(i)->SetCoeffs(coeffs_.at(i));
     }
     bool moveCoeffs=true;
@@ -308,7 +308,7 @@ TEST_CASE( "Testing 2 layer composed map with moveCoeffs=true", "[ShallowCompose
     }
 
     auto out = composedMap->Evaluate(in);
-    
+
     SECTION("Evaluate"){
         Kokkos::View<double**, Kokkos::HostSpace> trueOut("True output", dim, numSamps);
         Kokkos::deep_copy(trueOut, in);
@@ -354,7 +354,7 @@ TEST_CASE( "Testing 2 layer composed map with moveCoeffs=true", "[ShallowCompose
     SECTION("CoeffGrad"){
 
         Kokkos::View<double**,Kokkos::HostSpace> sens("Sensitivities", composedMap->outputDim, numSamps);
-        
+
         for(unsigned int j=0; j<numSamps; ++j){
             for(unsigned int i=0; i<composedMap->outputDim; ++i){
                 sens(i,j) = 1.0 + 0.1*i + j;
@@ -378,16 +378,16 @@ TEST_CASE( "Testing 2 layer composed map with moveCoeffs=true", "[ShallowCompose
             evals2 = composedMap->Evaluate(in);
 
             for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd){
-                
+
                 double fdDeriv = 0.0;
                 for(unsigned int j=0; j<composedMap->outputDim; ++j)
                     fdDeriv += sens(j,ptInd) * (evals2(j,ptInd)-evals(j,ptInd))/fdstep;
 
-                CHECK( coeffGrad(i,ptInd) == Approx(fdDeriv).margin(1e-3)); 
+                CHECK( coeffGrad(i,ptInd) == Approx(fdDeriv).margin(1e-3));
             }
             coeffs(i) -= fdstep;
         }
-        
+
     }
 
 
@@ -417,18 +417,18 @@ TEST_CASE( "Testing 2 layer composed map with moveCoeffs=true", "[ShallowCompose
             evals2 = composedMap->Evaluate(in);
 
             for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd){
-                
+
                 double fdDeriv = 0.0;
                 for(unsigned int j=0; j<composedMap->outputDim; ++j)
                     fdDeriv += sens(j,ptInd) * (evals2(j,ptInd)-evals(j,ptInd))/fdstep;
 
-                CHECK( inputGrad(i,ptInd) == Approx(fdDeriv).margin(1e-3)); 
+                CHECK( inputGrad(i,ptInd) == Approx(fdDeriv).margin(1e-3));
             }
 
             for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd)
                 in(i,ptInd) -= fdstep;
         }
-        
+
     }
 
     SECTION("LogDeterminantCoeffGrad"){
@@ -436,7 +436,7 @@ TEST_CASE( "Testing 2 layer composed map with moveCoeffs=true", "[ShallowCompose
         Kokkos::View<double**,Kokkos::HostSpace> detGrad = composedMap->LogDeterminantCoeffGrad(in);
         REQUIRE(detGrad.extent(0)==composedMap->numCoeffs);
         REQUIRE(detGrad.extent(1)==numSamps);
-        
+
         Kokkos::View<double*,Kokkos::HostSpace> logDet = composedMap->LogDeterminant(in);
         Kokkos::View<double*,Kokkos::HostSpace> logDet2;
 
@@ -449,8 +449,8 @@ TEST_CASE( "Testing 2 layer composed map with moveCoeffs=true", "[ShallowCompose
             logDet2 = composedMap->LogDeterminant(in);
 
             for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd){
-                CHECK( detGrad(i,ptInd) == Approx((logDet2(ptInd)-logDet(ptInd))/fdstep).margin(1e-3)); 
-                
+                CHECK( detGrad(i,ptInd) == Approx((logDet2(ptInd)-logDet(ptInd))/fdstep).margin(1e-3));
+
             }
             coeffs(i) -= fdstep;
         }
@@ -463,8 +463,8 @@ TEST_CASE( "Testing 2 layer composed map with moveCoeffs=true", "[ShallowCompose
         Kokkos::View<double**,Kokkos::HostSpace> detGrad = composedMap->LogDeterminantInputGrad(in);
         REQUIRE(detGrad.extent(0)==composedMap->inputDim);
         REQUIRE(detGrad.extent(1)==numSamps);
-        
-        
+
+
         Kokkos::View<double*,Kokkos::HostSpace> logDet = composedMap->LogDeterminant(in);
         Kokkos::View<double*,Kokkos::HostSpace> logDet2;
 
@@ -478,7 +478,7 @@ TEST_CASE( "Testing 2 layer composed map with moveCoeffs=true", "[ShallowCompose
             logDet2 = composedMap->LogDeterminant(in);
 
             for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd){
-                CHECK( detGrad(i,ptInd) == Approx((logDet2(ptInd)-logDet(ptInd))/fdstep).margin(1e-3)); 
+                CHECK( detGrad(i,ptInd) == Approx((logDet2(ptInd)-logDet(ptInd))/fdstep).margin(1e-3));
             }
 
             for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd)
@@ -489,13 +489,13 @@ TEST_CASE( "Testing 2 layer composed map with moveCoeffs=true", "[ShallowCompose
 
 }
 
-TEST_CASE( "Testing 8 layer composed map with moveCoeffs=false", "[DeepComposedMap]" ) {
+TEST_CASE( "Testing 5 layer composed map with moveCoeffs=false", "[DeepComposedMap]" ) {
 
     MapOptions options;
     options.basisType = BasisTypes::ProbabilistHermite;
-    
+
     unsigned int dim = 2;
-    unsigned int numMaps = 8;
+    unsigned int numMaps = 5;
     unsigned int order = 1;
     unsigned int coeffSize = 0;
     int numChecks = 3; // number of checkpoints to use (including storing initial points)
@@ -512,7 +512,7 @@ TEST_CASE( "Testing 8 layer composed map with moveCoeffs=false", "[DeepComposedM
     Eigen::RowVectorXd coeffs(composedMap->numCoeffs);
     for(unsigned int i=0; i<composedMap->numCoeffs; ++i)
         coeffs(i) = 0.1*(i+1);
-    
+
 
     unsigned int numSamps = 10;
     Kokkos::View<double**, Kokkos::HostSpace> in("Map Input", dim, numSamps);
@@ -525,7 +525,7 @@ TEST_CASE( "Testing 8 layer composed map with moveCoeffs=false", "[DeepComposedM
 
     composedMap->SetCoeffs(coeffs);
     auto out = composedMap->Evaluate(in);
-    
+
     SECTION("Evaluate"){
         Kokkos::View<double**, Kokkos::HostSpace> trueOut("True output", dim, numSamps);
         Kokkos::deep_copy(trueOut, in);
@@ -561,7 +561,7 @@ TEST_CASE( "Testing 8 layer composed map with moveCoeffs=false", "[DeepComposedM
     SECTION("CoeffGrad"){
 
         Kokkos::View<double**,Kokkos::HostSpace> sens("Sensitivities", composedMap->outputDim, numSamps);
-        
+
         for(unsigned int j=0; j<numSamps; ++j){
             for(unsigned int i=0; i<composedMap->outputDim; ++i){
                 sens(i,j) = 1.0 + 0.1*i + j;
@@ -585,16 +585,16 @@ TEST_CASE( "Testing 8 layer composed map with moveCoeffs=false", "[DeepComposedM
             evals2 = composedMap->Evaluate(in);
 
             for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd){
-                
+
                 double fdDeriv = 0.0;
                 for(unsigned int j=0; j<composedMap->outputDim; ++j)
                     fdDeriv += sens(j,ptInd) * (evals2(j,ptInd)-evals(j,ptInd))/fdstep;
 
-                CHECK( coeffGrad(i,ptInd) == Approx(fdDeriv).margin(1e-3)); 
+                CHECK( coeffGrad(i,ptInd) == Approx(fdDeriv).margin(1e-3));
             }
             coeffs(i) -= fdstep;
         }
-        
+
     }
 
 
@@ -624,18 +624,18 @@ TEST_CASE( "Testing 8 layer composed map with moveCoeffs=false", "[DeepComposedM
             evals2 = composedMap->Evaluate(in);
 
             for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd){
-                
+
                 double fdDeriv = 0.0;
                 for(unsigned int j=0; j<composedMap->outputDim; ++j)
                     fdDeriv += sens(j,ptInd) * (evals2(j,ptInd)-evals(j,ptInd))/fdstep;
 
-                CHECK( inputGrad(i,ptInd) == Approx(fdDeriv).margin(1e-3)); 
+                CHECK( inputGrad(i,ptInd) == Approx(fdDeriv).margin(1e-3));
             }
 
             for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd)
                 in(i,ptInd) -= fdstep;
         }
-        
+
     }
 
     SECTION("LogDeterminantCoeffGrad"){
@@ -643,7 +643,7 @@ TEST_CASE( "Testing 8 layer composed map with moveCoeffs=false", "[DeepComposedM
         Kokkos::View<double**,Kokkos::HostSpace> detGrad = composedMap->LogDeterminantCoeffGrad(in);
         REQUIRE(detGrad.extent(0)==composedMap->numCoeffs);
         REQUIRE(detGrad.extent(1)==numSamps);
-        
+
         Kokkos::View<double*,Kokkos::HostSpace> logDet = composedMap->LogDeterminant(in);
         Kokkos::View<double*,Kokkos::HostSpace> logDet2;
 
@@ -656,8 +656,8 @@ TEST_CASE( "Testing 8 layer composed map with moveCoeffs=false", "[DeepComposedM
             logDet2 = composedMap->LogDeterminant(in);
 
             for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd){
-                CHECK( detGrad(i,ptInd) == Approx((logDet2(ptInd)-logDet(ptInd))/fdstep).margin(1e-3)); 
-                
+                CHECK( detGrad(i,ptInd) == Approx((logDet2(ptInd)-logDet(ptInd))/fdstep).margin(1e-3));
+
             }
             coeffs(i) -= fdstep;
         }
@@ -670,8 +670,8 @@ TEST_CASE( "Testing 8 layer composed map with moveCoeffs=false", "[DeepComposedM
         Kokkos::View<double**,Kokkos::HostSpace> detGrad = composedMap->LogDeterminantInputGrad(in);
         REQUIRE(detGrad.extent(0)==composedMap->inputDim);
         REQUIRE(detGrad.extent(1)==numSamps);
-        
-        
+
+
         Kokkos::View<double*,Kokkos::HostSpace> logDet = composedMap->LogDeterminant(in);
         Kokkos::View<double*,Kokkos::HostSpace> logDet2;
 
@@ -685,7 +685,7 @@ TEST_CASE( "Testing 8 layer composed map with moveCoeffs=false", "[DeepComposedM
             logDet2 = composedMap->LogDeterminant(in);
 
             for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd){
-                CHECK( detGrad(i,ptInd) == Approx((logDet2(ptInd)-logDet(ptInd))/fdstep).margin(1e-3)); 
+                CHECK( detGrad(i,ptInd) == Approx((logDet2(ptInd)-logDet(ptInd))/fdstep).margin(1e-3));
             }
 
             for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd)
@@ -700,7 +700,7 @@ TEST_CASE( "Testing 8 layer composed map with moveCoeffs=true", "[DeepComposedMa
 
     MapOptions options;
     options.basisType = BasisTypes::ProbabilistHermite;
-    
+
     unsigned int dim = 2;
     unsigned int numMaps = 8;
     unsigned int order = 1;
@@ -719,7 +719,7 @@ TEST_CASE( "Testing 8 layer composed map with moveCoeffs=true", "[DeepComposedMa
 
         for(unsigned int j=0; j<maps.at(i)->numCoeffs; ++j)
             coeffs_.at(i)(j) = 0.1*(j+1);
-        
+
         maps.at(i)->SetCoeffs(coeffs_.at(i));
     }
     bool moveCoeffs=true;
@@ -756,7 +756,7 @@ TEST_CASE( "Testing 8 layer composed map with moveCoeffs=true", "[DeepComposedMa
     }
 
     auto out = composedMap->Evaluate(in);
-    
+
     SECTION("Evaluate"){
         Kokkos::View<double**, Kokkos::HostSpace> trueOut("True output", dim, numSamps);
         Kokkos::deep_copy(trueOut, in);
@@ -792,7 +792,7 @@ TEST_CASE( "Testing 8 layer composed map with moveCoeffs=true", "[DeepComposedMa
     SECTION("CoeffGrad"){
 
         Kokkos::View<double**,Kokkos::HostSpace> sens("Sensitivities", composedMap->outputDim, numSamps);
-        
+
         for(unsigned int j=0; j<numSamps; ++j){
             for(unsigned int i=0; i<composedMap->outputDim; ++i){
                 sens(i,j) = 1.0 + 0.1*i + j;
@@ -816,16 +816,16 @@ TEST_CASE( "Testing 8 layer composed map with moveCoeffs=true", "[DeepComposedMa
             evals2 = composedMap->Evaluate(in);
 
             for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd){
-                
+
                 double fdDeriv = 0.0;
                 for(unsigned int j=0; j<composedMap->outputDim; ++j)
                     fdDeriv += sens(j,ptInd) * (evals2(j,ptInd)-evals(j,ptInd))/fdstep;
 
-                CHECK( coeffGrad(i,ptInd) == Approx(fdDeriv).margin(1e-3)); 
+                CHECK( coeffGrad(i,ptInd) == Approx(fdDeriv).margin(1e-3));
             }
             coeffs(i) -= fdstep;
         }
-        
+
     }
 
 
@@ -855,18 +855,18 @@ TEST_CASE( "Testing 8 layer composed map with moveCoeffs=true", "[DeepComposedMa
             evals2 = composedMap->Evaluate(in);
 
             for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd){
-                
+
                 double fdDeriv = 0.0;
                 for(unsigned int j=0; j<composedMap->outputDim; ++j)
                     fdDeriv += sens(j,ptInd) * (evals2(j,ptInd)-evals(j,ptInd))/fdstep;
 
-                CHECK( inputGrad(i,ptInd) == Approx(fdDeriv).margin(1e-3)); 
+                CHECK( inputGrad(i,ptInd) == Approx(fdDeriv).margin(1e-3));
             }
 
             for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd)
                 in(i,ptInd) -= fdstep;
         }
-        
+
     }
 
     SECTION("LogDeterminantCoeffGrad"){
@@ -874,7 +874,7 @@ TEST_CASE( "Testing 8 layer composed map with moveCoeffs=true", "[DeepComposedMa
         Kokkos::View<double**,Kokkos::HostSpace> detGrad = composedMap->LogDeterminantCoeffGrad(in);
         REQUIRE(detGrad.extent(0)==composedMap->numCoeffs);
         REQUIRE(detGrad.extent(1)==numSamps);
-        
+
         Kokkos::View<double*,Kokkos::HostSpace> logDet = composedMap->LogDeterminant(in);
         Kokkos::View<double*,Kokkos::HostSpace> logDet2;
 
@@ -887,8 +887,8 @@ TEST_CASE( "Testing 8 layer composed map with moveCoeffs=true", "[DeepComposedMa
             logDet2 = composedMap->LogDeterminant(in);
 
             for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd){
-                CHECK( detGrad(i,ptInd) == Approx((logDet2(ptInd)-logDet(ptInd))/fdstep).margin(1e-3)); 
-                
+                CHECK( detGrad(i,ptInd) == Approx((logDet2(ptInd)-logDet(ptInd))/fdstep).margin(1e-3));
+
             }
             coeffs(i) -= fdstep;
         }
@@ -901,8 +901,8 @@ TEST_CASE( "Testing 8 layer composed map with moveCoeffs=true", "[DeepComposedMa
         Kokkos::View<double**,Kokkos::HostSpace> detGrad = composedMap->LogDeterminantInputGrad(in);
         REQUIRE(detGrad.extent(0)==composedMap->inputDim);
         REQUIRE(detGrad.extent(1)==numSamps);
-        
-        
+
+
         Kokkos::View<double*,Kokkos::HostSpace> logDet = composedMap->LogDeterminant(in);
         Kokkos::View<double*,Kokkos::HostSpace> logDet2;
 
@@ -916,7 +916,7 @@ TEST_CASE( "Testing 8 layer composed map with moveCoeffs=true", "[DeepComposedMa
             logDet2 = composedMap->LogDeterminant(in);
 
             for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd){
-                CHECK( detGrad(i,ptInd) == Approx((logDet2(ptInd)-logDet(ptInd))/fdstep).margin(1e-3)); 
+                CHECK( detGrad(i,ptInd) == Approx((logDet2(ptInd)-logDet(ptInd))/fdstep).margin(1e-3));
             }
 
             for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd)

--- a/tests/Test_TrainMap.cpp
+++ b/tests/Test_TrainMap.cpp
@@ -14,7 +14,7 @@ using namespace Catch;
 TEST_CASE("Test_TrainMap", "[TrainMap]") {
     unsigned int seed = 42;
     unsigned int dim = 2;
-    unsigned int numPts = 20000;
+    unsigned int numPts = 5000;
     unsigned int testPts = numPts / 5;
     auto sampler = std::make_shared<GaussianSamplerDensity<Kokkos::HostSpace>>(3);
     sampler->SetSeed(seed);

--- a/tests/Test_TrainMapAdaptive.cpp
+++ b/tests/Test_TrainMapAdaptive.cpp
@@ -44,102 +44,102 @@ TEST_CASE("Adaptive Transport Map","[ATM]") {
     auto g_sampler = std::make_shared<GaussianSamplerDensity<Kokkos::HostSpace>>(dim);
     g_sampler->SetSeed(seed);
     StridedMatrix<double,Kokkos::HostSpace> samples = g_sampler->Sample(numPts);
-    SECTION("ModifiedBanana") {
-        Kokkos::View<double**, Kokkos::HostSpace> targetSamples("targetSamples", 2, numPts);
-        Kokkos::parallel_for("Intializing targetSamples", numPts, KOKKOS_LAMBDA(const unsigned int i){
-            targetSamples(0,i) = samples(0,i);
-            targetSamples(1,i) = samples(1,i) + samples(0,i) + samples(0,i)*samples(0,i);
-        });
-        NormalizeSamples(targetSamples);
+    // SECTION("ModifiedBanana") {
+    //     Kokkos::View<double**, Kokkos::HostSpace> targetSamples("targetSamples", 2, numPts);
+    //     Kokkos::parallel_for("Intializing targetSamples", numPts, KOKKOS_LAMBDA(const unsigned int i){
+    //         targetSamples(0,i) = samples(0,i);
+    //         targetSamples(1,i) = samples(1,i) + samples(0,i) + samples(0,i)*samples(0,i);
+    //     });
+    //     NormalizeSamples(targetSamples);
 
-        StridedMatrix<const double, Kokkos::HostSpace> testSamples = Kokkos::subview(targetSamples, Kokkos::ALL, Kokkos::pair<unsigned int, unsigned int>(0, testPts));
-        StridedMatrix<const double, Kokkos::HostSpace> trainSamples = Kokkos::subview(targetSamples, Kokkos::ALL, Kokkos::pair<unsigned int, unsigned int>(testPts, numPts));
-        auto objective = ObjectiveFactory::CreateGaussianKLObjective(trainSamples,testSamples);
+    //     StridedMatrix<const double, Kokkos::HostSpace> testSamples = Kokkos::subview(targetSamples, Kokkos::ALL, Kokkos::pair<unsigned int, unsigned int>(0, testPts));
+    //     StridedMatrix<const double, Kokkos::HostSpace> trainSamples = Kokkos::subview(targetSamples, Kokkos::ALL, Kokkos::pair<unsigned int, unsigned int>(testPts, numPts));
+    //     auto objective = ObjectiveFactory::CreateGaussianKLObjective(trainSamples,testSamples);
 
-        std::vector<MultiIndexSet> mset0 {MultiIndexSet::CreateTotalOrder(1,0), MultiIndexSet::CreateTotalOrder(2,0)};
-        MultiIndexSet correctMset1 = MultiIndexSet::CreateTotalOrder(1,1);
-        MultiIndexSet correctMset2 = MultiIndexSet::CreateTotalOrder(2,1) + MultiIndex{2,0};
+    //     std::vector<MultiIndexSet> mset0 {MultiIndexSet::CreateTotalOrder(1,0), MultiIndexSet::CreateTotalOrder(2,0)};
+    //     MultiIndexSet correctMset1 = MultiIndexSet::CreateTotalOrder(1,1);
+    //     MultiIndexSet correctMset2 = MultiIndexSet::CreateTotalOrder(2,1) + MultiIndex{2,0};
 
-        ATMOptions opts;
-        opts.maxSize = 8; // Algorithm must add 4 correct terms in 6 iterations
-        opts.basisLB = -3.;
-        opts.basisUB = 3.;
+    //     ATMOptions opts;
+    //     opts.maxSize = 8; // Algorithm must add 4 correct terms in 6 iterations
+    //     opts.basisLB = -3.;
+    //     opts.basisUB = 3.;
 
-        std::shared_ptr<ConditionalMapBase<Kokkos::HostSpace>> atm = TrainMapAdaptive<Kokkos::HostSpace>(mset0, objective, opts);
-        MultiIndexSet finalMset1 = mset0[0];
-        MultiIndexSet finalMset2 = mset0[1];
-        CHECK((finalMset1 + correctMset1).Size() == finalMset1.Size());
-        CHECK((finalMset2 + correctMset2).Size() == finalMset2.Size());
-        StridedMatrix<double, Kokkos::HostSpace> pullback_test = atm->Evaluate(testSamples);
-        TestStandardNormalSamples(pullback_test);
-    }
-    SECTION("GaussianMixture") {
-        double mean_1=-2,std_1=std::sqrt(0.5);
-        double mean_2= 2,std_2=std::sqrt(  2);
-        double prob_1 = 0.5;
-        auto u_sampler = std::make_shared<UniformSampler<Kokkos::HostSpace>>(1,1.);
-        StridedMatrix<double,Kokkos::HostSpace> u_samples = u_sampler->Sample(numPts);
-        StridedMatrix<double,Kokkos::HostSpace> targetSamples = Kokkos::View<double**,Kokkos::HostSpace>("targetSamples",2,numPts);
-        Kokkos::parallel_for("Create Gaussian mixture", numPts, KOKKOS_LAMBDA(const unsigned int i){
-            bool pick_1 = u_samples(0,i) < prob_1;
-            double scale = pick_1 ? std_1 : std_2;
-            double shift = pick_1 ? mean_1 : mean_2;
-            for(int j = 0; j < dim; j++) {
-                targetSamples(j,i) = samples(j,i)*scale;
-                samples(j,i) += shift;
-            }
-        });
-        NormalizeSamples(targetSamples);
-        StridedMatrix<const double, Kokkos::HostSpace> testSamples = Kokkos::subview(targetSamples, Kokkos::ALL, Kokkos::pair<unsigned int, unsigned int>(0, testPts));
-        StridedMatrix<const double, Kokkos::HostSpace> trainSamples = Kokkos::subview(targetSamples, Kokkos::ALL, Kokkos::pair<unsigned int, unsigned int>(testPts, numPts));
-        auto objective = ObjectiveFactory::CreateGaussianKLObjective(trainSamples,testSamples);
+    //     std::shared_ptr<ConditionalMapBase<Kokkos::HostSpace>> atm = TrainMapAdaptive<Kokkos::HostSpace>(mset0, objective, opts);
+    //     MultiIndexSet finalMset1 = mset0[0];
+    //     MultiIndexSet finalMset2 = mset0[1];
+    //     CHECK((finalMset1 + correctMset1).Size() == finalMset1.Size());
+    //     CHECK((finalMset2 + correctMset2).Size() == finalMset2.Size());
+    //     StridedMatrix<double, Kokkos::HostSpace> pullback_test = atm->Evaluate(testSamples);
+    //     TestStandardNormalSamples(pullback_test);
+    // }
+    // SECTION("GaussianMixture") {
+    //     double mean_1=-2,std_1=std::sqrt(0.5);
+    //     double mean_2= 2,std_2=std::sqrt(  2);
+    //     double prob_1 = 0.5;
+    //     auto u_sampler = std::make_shared<UniformSampler<Kokkos::HostSpace>>(1,1.);
+    //     StridedMatrix<double,Kokkos::HostSpace> u_samples = u_sampler->Sample(numPts);
+    //     StridedMatrix<double,Kokkos::HostSpace> targetSamples = Kokkos::View<double**,Kokkos::HostSpace>("targetSamples",2,numPts);
+    //     Kokkos::parallel_for("Create Gaussian mixture", numPts, KOKKOS_LAMBDA(const unsigned int i){
+    //         bool pick_1 = u_samples(0,i) < prob_1;
+    //         double scale = pick_1 ? std_1 : std_2;
+    //         double shift = pick_1 ? mean_1 : mean_2;
+    //         for(int j = 0; j < dim; j++) {
+    //             targetSamples(j,i) = samples(j,i)*scale;
+    //             samples(j,i) += shift;
+    //         }
+    //     });
+    //     NormalizeSamples(targetSamples);
+    //     StridedMatrix<const double, Kokkos::HostSpace> testSamples = Kokkos::subview(targetSamples, Kokkos::ALL, Kokkos::pair<unsigned int, unsigned int>(0, testPts));
+    //     StridedMatrix<const double, Kokkos::HostSpace> trainSamples = Kokkos::subview(targetSamples, Kokkos::ALL, Kokkos::pair<unsigned int, unsigned int>(testPts, numPts));
+    //     auto objective = ObjectiveFactory::CreateGaussianKLObjective(trainSamples,testSamples);
 
-        ATMOptions opts;
-        opts.maxSize = 5;
-        opts.basisLB = -3.;
-        opts.basisUB = 3.;
+    //     ATMOptions opts;
+    //     opts.maxSize = 5;
+    //     opts.basisLB = -3.;
+    //     opts.basisUB = 3.;
 
-        std::vector<MultiIndexSet> mset0 {MultiIndexSet::CreateTotalOrder(1,0), MultiIndexSet::CreateTotalOrder(2,0)};
-        std::shared_ptr<ConditionalMapBase<Kokkos::HostSpace>> atm = TrainMapAdaptive<Kokkos::HostSpace>(mset0, objective, opts);
-        StridedMatrix<double, Kokkos::HostSpace> pullback_test = atm->Evaluate(testSamples);
-        TestStandardNormalSamples(pullback_test);
-    }
-    SECTION("TraditionalBanana") {
-        Kokkos::View<double**, Kokkos::HostSpace> targetSamples("targetSamples", 2, numPts);
-        Kokkos::parallel_for("Intializing targetSamples", numPts, KOKKOS_LAMBDA(const unsigned int i){
-            targetSamples(0,i) = samples(0,i);
-            targetSamples(1,i) = samples(1,i) + samples(0,i)*samples(0,i);
-        });
-        NormalizeSamples(targetSamples);
+    //     std::vector<MultiIndexSet> mset0 {MultiIndexSet::CreateTotalOrder(1,0), MultiIndexSet::CreateTotalOrder(2,0)};
+    //     std::shared_ptr<ConditionalMapBase<Kokkos::HostSpace>> atm = TrainMapAdaptive<Kokkos::HostSpace>(mset0, objective, opts);
+    //     StridedMatrix<double, Kokkos::HostSpace> pullback_test = atm->Evaluate(testSamples);
+    //     TestStandardNormalSamples(pullback_test);
+    // }
+    // SECTION("TraditionalBanana") {
+    //     Kokkos::View<double**, Kokkos::HostSpace> targetSamples("targetSamples", 2, numPts);
+    //     Kokkos::parallel_for("Intializing targetSamples", numPts, KOKKOS_LAMBDA(const unsigned int i){
+    //         targetSamples(0,i) = samples(0,i);
+    //         targetSamples(1,i) = samples(1,i) + samples(0,i)*samples(0,i);
+    //     });
+    //     NormalizeSamples(targetSamples);
 
-        StridedMatrix<const double, Kokkos::HostSpace> testSamples = Kokkos::subview(targetSamples, Kokkos::ALL, Kokkos::pair<unsigned int, unsigned int>(0, testPts));
-        StridedMatrix<const double, Kokkos::HostSpace> trainSamples = Kokkos::subview(targetSamples, Kokkos::ALL, Kokkos::pair<unsigned int, unsigned int>(testPts, numPts));
-        auto objective = ObjectiveFactory::CreateGaussianKLObjective(trainSamples,testSamples);
+    //     StridedMatrix<const double, Kokkos::HostSpace> testSamples = Kokkos::subview(targetSamples, Kokkos::ALL, Kokkos::pair<unsigned int, unsigned int>(0, testPts));
+    //     StridedMatrix<const double, Kokkos::HostSpace> trainSamples = Kokkos::subview(targetSamples, Kokkos::ALL, Kokkos::pair<unsigned int, unsigned int>(testPts, numPts));
+    //     auto objective = ObjectiveFactory::CreateGaussianKLObjective(trainSamples,testSamples);
 
-        std::vector<MultiIndexSet> mset0 {MultiIndexSet::CreateTotalOrder(1,0), MultiIndexSet::CreateTotalOrder(2,0)};
-        MultiIndexSet correctMset1 = MultiIndexSet::CreateTotalOrder(1,1);
-        MultiIndexSet correctMset2 = (MultiIndexSet::CreateTotalOrder(2,0) + MultiIndex{0,1}) + MultiIndex{2,0};
+    //     std::vector<MultiIndexSet> mset0 {MultiIndexSet::CreateTotalOrder(1,0), MultiIndexSet::CreateTotalOrder(2,0)};
+    //     MultiIndexSet correctMset1 = MultiIndexSet::CreateTotalOrder(1,1);
+    //     MultiIndexSet correctMset2 = (MultiIndexSet::CreateTotalOrder(2,0) + MultiIndex{0,1}) + MultiIndex{2,0};
 
-        ATMOptions opts;
-        opts.maxSize = 15; // Algorithm must add 3 correct terms in 6 iterations
-        opts.basisLB = -3.;
-        opts.basisUB = 3.;
-        opts.maxDegrees = MultiIndex{1000,4}; // Limit the second input to have cubic complexity or less
+    //     ATMOptions opts;
+    //     opts.maxSize = 15; // Algorithm must add 3 correct terms in 6 iterations
+    //     opts.basisLB = -3.;
+    //     opts.basisUB = 3.;
+    //     opts.maxDegrees = MultiIndex{1000,4}; // Limit the second input to have cubic complexity or less
 
-        std::shared_ptr<ConditionalMapBase<Kokkos::HostSpace>> atm = TrainMapAdaptive<Kokkos::HostSpace>(mset0, objective, opts);
-        MultiIndexSet finalMset1 = mset0[0];
-        MultiIndexSet finalMset2 = mset0[1];
-        CHECK((finalMset1 + correctMset1).Size() == finalMset1.Size());
-        CHECK((finalMset2 + correctMset2).Size() == finalMset2.Size());
-        std::vector<bool> bounded1 = finalMset1.FilterBounded(opts.maxDegrees);
-        std::vector<bool> bounded2 = finalMset2.FilterBounded(opts.maxDegrees);
-        bool checkBound = false;
-        for(auto b1 : bounded1) checkBound |= b1;
-        for(auto b2 : bounded2) checkBound |= b2;
-        CHECK(!checkBound);
-        StridedMatrix<double, Kokkos::HostSpace> pullback_test = atm->Evaluate(testSamples);
-        TestStandardNormalSamples(pullback_test);
-    }
+    //     std::shared_ptr<ConditionalMapBase<Kokkos::HostSpace>> atm = TrainMapAdaptive<Kokkos::HostSpace>(mset0, objective, opts);
+    //     MultiIndexSet finalMset1 = mset0[0];
+    //     MultiIndexSet finalMset2 = mset0[1];
+    //     CHECK((finalMset1 + correctMset1).Size() == finalMset1.Size());
+    //     CHECK((finalMset2 + correctMset2).Size() == finalMset2.Size());
+    //     std::vector<bool> bounded1 = finalMset1.FilterBounded(opts.maxDegrees);
+    //     std::vector<bool> bounded2 = finalMset2.FilterBounded(opts.maxDegrees);
+    //     bool checkBound = false;
+    //     for(auto b1 : bounded1) checkBound |= b1;
+    //     for(auto b2 : bounded2) checkBound |= b2;
+    //     CHECK(!checkBound);
+    //     StridedMatrix<double, Kokkos::HostSpace> pullback_test = atm->Evaluate(testSamples);
+    //     TestStandardNormalSamples(pullback_test);
+    // }
     SECTION("TraditionalBananaOneComp") {
         Kokkos::View<double**, Kokkos::HostSpace> targetSamples("targetSamples", 2, numPts);
         Kokkos::parallel_for("Intializing targetSamples", numPts, KOKKOS_LAMBDA(const unsigned int i){

--- a/tests/Test_TriangularMap.cpp
+++ b/tests/Test_TriangularMap.cpp
@@ -12,7 +12,7 @@ TEST_CASE( "Testing 3d triangular map from MonotoneComponents with moveCoeffs=fa
     MapOptions options;
     options.basisType = BasisTypes::ProbabilistHermite;
     options.basisNorm = false;
-    
+
     unsigned int numBlocks = 3;
     unsigned int maxDegree = 2;
     unsigned int extraInputs = 1;
@@ -37,9 +37,9 @@ TEST_CASE( "Testing 3d triangular map from MonotoneComponents with moveCoeffs=fa
     Kokkos::View<double*,Kokkos::HostSpace> coeffs("Coefficients", triMap->numCoeffs);
     for(unsigned int i=0; i<triMap->numCoeffs; ++i)
         coeffs(i) = 0.1*(i+1);
-        
+
     SECTION("Coefficients"){
-        
+
         // Set the coefficients of the triangular map
         triMap->SetCoeffs(coeffs);
 
@@ -65,11 +65,11 @@ TEST_CASE( "Testing 3d triangular map from MonotoneComponents with moveCoeffs=fa
 
     triMap->SetCoeffs(coeffs);
     auto out = triMap->Evaluate(in);
-    
+
     SECTION("Evaluation"){
 
         for(unsigned int i=0; i<numBlocks; ++i){
-            
+
             auto outBlock = blocks.at(i)->Evaluate(Kokkos::subview(in, std::make_pair(0,int(i+1+extraInputs)), Kokkos::ALL()));
 
             REQUIRE(outBlock.extent(1)==numSamps);
@@ -134,16 +134,16 @@ TEST_CASE( "Testing 3d triangular map from MonotoneComponents with moveCoeffs=fa
             evals2 = triMap->Evaluate(in);
 
             for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd){
-                
+
                 double fdDeriv = 0.0;
                 for(unsigned int j=0; j<triMap->outputDim; ++j)
                     fdDeriv += sens(j,ptInd) * (evals2(j,ptInd)-evals(j,ptInd))/fdstep;
 
-                CHECK( coeffGrad(i,ptInd) == Approx(fdDeriv).margin(1e-3)); 
+                CHECK( coeffGrad(i,ptInd) == Approx(fdDeriv).margin(1e-3));
             }
             coeffs(i) -= fdstep;
         }
-        
+
     }
 
 
@@ -173,18 +173,18 @@ TEST_CASE( "Testing 3d triangular map from MonotoneComponents with moveCoeffs=fa
             evals2 = triMap->Evaluate(in);
 
             for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd){
-                
+
                 double fdDeriv = 0.0;
                 for(unsigned int j=0; j<triMap->outputDim; ++j)
                     fdDeriv += sens(j,ptInd) * (evals2(j,ptInd)-evals(j,ptInd))/fdstep;
 
-                CHECK( inputGrad(i,ptInd) == Approx(fdDeriv).margin(1e-3)); 
+                CHECK( inputGrad(i,ptInd) == Approx(fdDeriv).margin(1e-3));
             }
 
             for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd)
                 in(i,ptInd) -= fdstep;
         }
-        
+
     }
 
     SECTION("LogDeterminantCoeffGrad"){
@@ -199,7 +199,7 @@ TEST_CASE( "Testing 3d triangular map from MonotoneComponents with moveCoeffs=fa
         Kokkos::View<double**,Kokkos::HostSpace> detGrad = triMap->LogDeterminantCoeffGrad(in);
         REQUIRE(detGrad.extent(0)==triMap->numCoeffs);
         REQUIRE(detGrad.extent(1)==numSamps);
-        
+
         Kokkos::View<double*,Kokkos::HostSpace> logDet = triMap->LogDeterminant(in);
         Kokkos::View<double*,Kokkos::HostSpace> logDet2;
 
@@ -212,8 +212,8 @@ TEST_CASE( "Testing 3d triangular map from MonotoneComponents with moveCoeffs=fa
             logDet2 = triMap->LogDeterminant(in);
 
             for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd)
-                CHECK( detGrad(i,ptInd) == Approx((logDet2(ptInd)-logDet(ptInd))/fdstep).margin(1e-4)); 
-            
+                CHECK( detGrad(i,ptInd) == Approx((logDet2(ptInd)-logDet(ptInd))/fdstep).margin(1e-4));
+
             coeffs(i) -= fdstep;
         }
 
@@ -226,7 +226,7 @@ TEST_CASE( "Testing 3d triangular map from MonotoneComponents with moveCoeffs=tr
     MapOptions options;
     options.basisType = BasisTypes::ProbabilistHermite;
     options.basisNorm = false;
-    
+
     unsigned int numBlocks = 3;
     unsigned int maxDegree = 2;
     unsigned int extraInputs = 1;
@@ -238,7 +238,7 @@ TEST_CASE( "Testing 3d triangular map from MonotoneComponents with moveCoeffs=tr
     std::vector<std::shared_ptr<ConditionalMapBase<MemorySpace>>> blocks(numBlocks);
     std::vector<Kokkos::View<double*,Kokkos::HostSpace>> coeffs_(numBlocks);
     for(unsigned int i=0;i<numBlocks;++i){
-        
+
         FixedMultiIndexSet<MemorySpace> mset(i+extraInputs+1,maxDegree);
         coeffSize += mset.Size();
 
@@ -248,9 +248,9 @@ TEST_CASE( "Testing 3d triangular map from MonotoneComponents with moveCoeffs=tr
 
         for(unsigned int j=0; j<blocks.at(i)->numCoeffs; ++j)
             coeffs_.at(i)(j) = 0.1*(j+1);
-        
+
         blocks.at(i)->SetCoeffs(coeffs_.at(i));
-        
+
     }
     bool moveCoeffs=true;
     std::shared_ptr<ConditionalMapBase<MemorySpace>> triMap = std::make_shared<TriangularMap<MemorySpace>>(blocks, moveCoeffs);
@@ -269,177 +269,11 @@ TEST_CASE( "Testing 3d triangular map from MonotoneComponents with moveCoeffs=tr
         for(unsigned int i=0; i<numBlocks; ++i){
             for(unsigned int j=0; j<blocks.at(i)->numCoeffs; ++j){
                 CHECK(blocks.at(i)->Coeffs()(j) == coeffs(cumCoeffInd)); // Values of coefficients should be equal
-                CHECK(blocks.at(i)->Coeffs()(j) == coeffs_.at(i)(j)); 
+                CHECK(blocks.at(i)->Coeffs()(j) == coeffs_.at(i)(j));
                 CHECK(&blocks.at(i)->Coeffs()(j) == &coeffs(cumCoeffInd)); // Memory location should also be the same (no copy)
                 cumCoeffInd++;
             }
         }
-    }
-
-
-    unsigned int numSamps = 10;
-    Kokkos::View<double**, Kokkos::HostSpace> in("Map Input", numBlocks+extraInputs, numSamps);
-    for(unsigned int i=0; i<numBlocks+extraInputs; ++i){
-        for(unsigned int j=0; j<numSamps; ++j){
-            in(i,j) = double(i)/(numBlocks+extraInputs) + double(j)/numSamps;
-        }
-    }
-
-
-    
-    auto out = triMap->Evaluate(in);
-    
-    SECTION("Evaluation"){
-
-        for(unsigned int i=0; i<numBlocks; ++i){
-            
-            auto outBlock = blocks.at(i)->Evaluate(Kokkos::subview(in, std::make_pair(0,int(i+1+extraInputs)), Kokkos::ALL()));
-
-            REQUIRE(outBlock.extent(1)==numSamps);
-            REQUIRE(outBlock.extent(0)==1);
-            for(unsigned int j=0; j<numSamps; ++j)
-                CHECK( out(i,j) == Approx(outBlock(0,j)).margin(1e-6));
-        }
-    }
-
-
-    SECTION("Inverse"){
-
-        auto inv = triMap->Inverse(in,out);
-
-        for(unsigned int i=0; i<numBlocks; ++i){
-            for(unsigned int j=0; j<numSamps; ++j)
-                CHECK( inv(i,j) == Approx(in(i+extraInputs,j)).margin(1e-6));
-        }
-    }
-
-    SECTION("LogDeterminant"){
-        auto logDet = triMap->LogDeterminant(in);
-
-        REQUIRE(logDet.extent(0)==numSamps);
-        Kokkos::View<double*, Kokkos::HostSpace> truth("True Log Det", numSamps);
-
-        for(unsigned int i=0; i<numBlocks; ++i){
-            auto blockLogDet = blocks.at(i)->LogDeterminant(Kokkos::subview(in, std::make_pair(0,int(i+1+extraInputs)), Kokkos::ALL()));
-
-            for(unsigned int j=0; j<numSamps; ++j)
-                truth(j) += blockLogDet(j);
-        }
-
-        for(unsigned int j=0; j<numSamps; ++j)
-            CHECK(logDet(j) == Approx(truth(j)).margin(1e-10));
-
-    }
-
-    SECTION("CoeffGrad"){
-
-        Kokkos::View<double**,Kokkos::HostSpace> sens("Sensitivities", triMap->outputDim, numSamps);
-        for(unsigned int j=0; j<numSamps; ++j){
-            for(unsigned int i=0; i<triMap->outputDim; ++i){
-                sens(i,j) = 1.0 + 0.1*i + j;
-            }
-        }
-
-        Kokkos::View<double**,Kokkos::HostSpace> evals = triMap->Evaluate(in);
-        Kokkos::View<double**,Kokkos::HostSpace> evals2;
-
-        Kokkos::View<double**,Kokkos::HostSpace> coeffGrad = triMap->CoeffGrad(in, sens);
-
-        REQUIRE(coeffGrad.extent(0)==triMap->numCoeffs);
-        REQUIRE(coeffGrad.extent(1)==numSamps);
-
-        // Compare with finite differences
-        double fdstep = 1e-5;
-        for(unsigned int i=0; i<triMap->numCoeffs; ++i){
-            coeffs(i) += fdstep;
-
-            triMap->SetCoeffs(coeffs);
-            evals2 = triMap->Evaluate(in);
-
-            for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd){
-                
-                double fdDeriv = 0.0;
-                for(unsigned int j=0; j<triMap->outputDim; ++j)
-                    fdDeriv += sens(j,ptInd) * (evals2(j,ptInd)-evals(j,ptInd))/fdstep;
-
-                CHECK( coeffGrad(i,ptInd) == Approx(fdDeriv).margin(1e-3)); 
-            }
-            coeffs(i) -= fdstep;
-        }
-        
-    }
-
-
-    SECTION("Input Gradient"){
-
-        Kokkos::View<double**,Kokkos::HostSpace> sens("Sensitivities", triMap->outputDim, numSamps);
-        for(unsigned int j=0; j<numSamps; ++j){
-            for(unsigned int i=0; i<triMap->outputDim; ++i){
-                sens(i,j) = 1.0 + 0.1*i + j;
-            }
-        }
-
-        Kokkos::View<double**,Kokkos::HostSpace> evals = triMap->Evaluate(in);
-        Kokkos::View<double**,Kokkos::HostSpace> evals2;
-
-        Kokkos::View<double**,Kokkos::HostSpace> inputGrad = triMap->Gradient(in, sens);
-
-        REQUIRE(inputGrad.extent(0)==triMap->inputDim);
-        REQUIRE(inputGrad.extent(1)==numSamps);
-
-        // Compare with finite differences
-        double fdstep = 1e-5;
-        for(unsigned int i=0; i<triMap->inputDim; ++i){
-            for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd)
-                in(i,ptInd) += fdstep;
-
-            evals2 = triMap->Evaluate(in);
-
-            for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd){
-                
-                double fdDeriv = 0.0;
-                for(unsigned int j=0; j<triMap->outputDim; ++j)
-                    fdDeriv += sens(j,ptInd) * (evals2(j,ptInd)-evals(j,ptInd))/fdstep;
-
-                CHECK( inputGrad(i,ptInd) == Approx(fdDeriv).margin(1e-3)); 
-            }
-
-            for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd)
-                in(i,ptInd) -= fdstep;
-        }
-        
-    }
-
-    SECTION("LogDeterminantCoeffGrad"){
-
-        Kokkos::View<double**,Kokkos::HostSpace> sens("Sensitivities", triMap->outputDim, numSamps);
-        for(unsigned int j=0; j<numSamps; ++j){
-            for(unsigned int i=0; i<triMap->outputDim; ++i){
-                sens(i,j) = 1.0 + 0.1*i + j;
-            }
-        }
-
-        Kokkos::View<double**,Kokkos::HostSpace> detGrad = triMap->LogDeterminantCoeffGrad(in);
-        REQUIRE(detGrad.extent(0)==triMap->numCoeffs);
-        REQUIRE(detGrad.extent(1)==numSamps);
-        
-        Kokkos::View<double*,Kokkos::HostSpace> logDet = triMap->LogDeterminant(in);
-        Kokkos::View<double*,Kokkos::HostSpace> logDet2;
-
-        // Compare with finite differences
-        double fdstep = 1e-5;
-        for(unsigned int i=0; i<triMap->numCoeffs; ++i){
-            coeffs(i) += fdstep;
-
-            triMap->SetCoeffs(coeffs);
-            logDet2 = triMap->LogDeterminant(in);
-
-            for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd)
-                CHECK( detGrad(i,ptInd) == Approx((logDet2(ptInd)-logDet(ptInd))/fdstep).margin(1e-4)); 
-            
-            coeffs(i) -= fdstep;
-        }
-
     }
 
 }
@@ -454,9 +288,9 @@ TEST_CASE( "Testing TriangularMap made from smaller TriangularMaps with moveCoef
     unsigned int maxDegree = 2;
 
     unsigned int numBlocks = 3;
-    unsigned int dim1 = 2;
-    unsigned int dim2 = 4;
-    unsigned int dim3 = 3;
+    unsigned int dim1 = 1;
+    unsigned int dim2 = 3;
+    unsigned int dim3 = 2;
     unsigned int dim = dim1+dim2+dim3;
 
 
@@ -477,9 +311,9 @@ TEST_CASE( "Testing TriangularMap made from smaller TriangularMaps with moveCoef
     Kokkos::View<double*,Kokkos::HostSpace> coeffs("Coefficients", triMap->numCoeffs);
     for(unsigned int i=0; i<triMap->numCoeffs; ++i)
         coeffs(i) = 0.1*(i+1);
-        
+
     SECTION("Coefficients"){
-        
+
         // Set the coefficients of the triangular map
         triMap->SetCoeffs(coeffs);
 
@@ -505,18 +339,18 @@ TEST_CASE( "Testing TriangularMap made from smaller TriangularMaps with moveCoef
 
     triMap->SetCoeffs(coeffs);
     auto out = triMap->Evaluate(in);
-    
+
     SECTION("Evaluation"){
 
         unsigned int start = 0;
 
         for(unsigned int b=0; b<numBlocks; ++b){
-            
+
             auto subIn = Kokkos::subview(in, std::make_pair(0, int(blocks.at(b)->inputDim)), Kokkos::ALL());
             auto subOut = Kokkos::subview(out, std::make_pair(int(start), int(start + blocks.at(b)->outputDim)), Kokkos::ALL());
 
             auto outBlock = blocks.at(b)->Evaluate(subIn);
-            
+
             REQUIRE(outBlock.extent(1)==subOut.extent(1));
             REQUIRE(outBlock.extent(0)==subOut.extent(0));
 
@@ -584,16 +418,16 @@ TEST_CASE( "Testing TriangularMap made from smaller TriangularMaps with moveCoef
             evals2 = triMap->Evaluate(in);
 
             for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd){
-                
+
                 double fdDeriv = 0.0;
                 for(unsigned int j=0; j<triMap->outputDim; ++j)
                     fdDeriv += sens(j,ptInd) * (evals2(j,ptInd)-evals(j,ptInd))/fdstep;
 
-                CHECK( coeffGrad(i,ptInd) == Approx(fdDeriv).margin(1e-3)); 
+                CHECK( coeffGrad(i,ptInd) == Approx(fdDeriv).margin(1e-3));
             }
             coeffs(i) -= fdstep;
         }
-        
+
     }
 
 
@@ -623,18 +457,18 @@ TEST_CASE( "Testing TriangularMap made from smaller TriangularMaps with moveCoef
             evals2 = triMap->Evaluate(in);
 
             for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd){
-                
+
                 double fdDeriv = 0.0;
                 for(unsigned int j=0; j<triMap->outputDim; ++j)
                     fdDeriv += sens(j,ptInd) * (evals2(j,ptInd)-evals(j,ptInd))/fdstep;
 
-                CHECK( inputGrad(i,ptInd) == Approx(fdDeriv).epsilon(1e-3)); 
+                CHECK( inputGrad(i,ptInd) == Approx(fdDeriv).epsilon(1e-3));
             }
 
             for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd)
                 in(i,ptInd) -= fdstep;
         }
-        
+
     }
 
     SECTION("LogDeterminantCoeffGrad"){
@@ -649,7 +483,7 @@ TEST_CASE( "Testing TriangularMap made from smaller TriangularMaps with moveCoef
         Kokkos::View<double**,Kokkos::HostSpace> detGrad = triMap->LogDeterminantCoeffGrad(in);
         REQUIRE(detGrad.extent(0)==triMap->numCoeffs);
         REQUIRE(detGrad.extent(1)==numSamps);
-        
+
         Kokkos::View<double*,Kokkos::HostSpace> logDet = triMap->LogDeterminant(in);
         Kokkos::View<double*,Kokkos::HostSpace> logDet2;
 
@@ -662,8 +496,8 @@ TEST_CASE( "Testing TriangularMap made from smaller TriangularMaps with moveCoef
             logDet2 = triMap->LogDeterminant(in);
 
             for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd)
-                CHECK( detGrad(i,ptInd) == Approx((logDet2(ptInd)-logDet(ptInd))/fdstep).epsilon(1e-4)); 
-            
+                CHECK( detGrad(i,ptInd) == Approx((logDet2(ptInd)-logDet(ptInd))/fdstep).epsilon(1e-4));
+
             coeffs(i) -= fdstep;
         }
 
@@ -675,14 +509,12 @@ TEST_CASE( "Testing TriangularMap made from smaller TriangularMaps with moveCoef
 TEST_CASE( "Testing TriangularMap made from smaller TriangularMaps with moveCoeffs=true", "[TriangularMap_TriangularMaps]" ) {
 
     MapOptions options;
-    options.basisType = BasisTypes::ProbabilistHermite;
-    options.basisNorm = false;
     unsigned int maxDegree = 2;
 
     unsigned int numBlocks = 3;
-    unsigned int dim1 = 2;
-    unsigned int dim2 = 4;
-    unsigned int dim3 = 3;
+    unsigned int dim1 = 1;
+    unsigned int dim2 = 3;
+    unsigned int dim3 = 2;
     unsigned int dim = dim1+dim2+dim3;
 
 
@@ -691,17 +523,15 @@ TEST_CASE( "Testing TriangularMap made from smaller TriangularMaps with moveCoef
     blocks.at(0) = MapFactory::CreateTriangular<MemorySpace>(dim1, dim1, maxDegree, options);
     blocks.at(1) = MapFactory::CreateTriangular<MemorySpace>(dim1+dim2, dim2, maxDegree, options);
     blocks.at(2) = MapFactory::CreateTriangular<MemorySpace>(dim1+dim2+dim3, dim3, maxDegree, options);
-
+    unsigned int coeffSize = blocks.at(0)->numCoeffs + blocks.at(1)->numCoeffs + blocks.at(2)->numCoeffs;
 
     for(unsigned int i=0; i<3; ++i){
-
         coeffs_.at(i) = Kokkos::View<double*,Kokkos::HostSpace>("Coefficients", blocks.at(i)->numCoeffs);
         for(unsigned int j=0; j<blocks.at(i)->numCoeffs; ++j)
             coeffs_.at(i)(j) = 0.1*(j+1);
         blocks.at(i)->SetCoeffs(coeffs_.at(i));
-
     }
-    unsigned int coeffSize = blocks.at(0)->numCoeffs + blocks.at(1)->numCoeffs + blocks.at(2)->numCoeffs;
+
     bool moveCoeffs = true;
     std::shared_ptr<ConditionalMapBase<MemorySpace>> triMap = std::make_shared<TriangularMap<MemorySpace>>(blocks,moveCoeffs);
 
@@ -709,197 +539,19 @@ TEST_CASE( "Testing TriangularMap made from smaller TriangularMaps with moveCoef
     CHECK(triMap->inputDim == dim);
     CHECK(triMap->numCoeffs == coeffSize);
 
-
-        
     SECTION("Coefficients"){
-        
 
         // Now make sure that the coefficients of each block were set
         unsigned int cumCoeffInd = 0;
         for(unsigned int i=0; i<numBlocks; ++i){
             for(unsigned int j=0; j<blocks.at(i)->numCoeffs; ++j){
                 CHECK(blocks.at(i)->Coeffs()(j) == triMap->Coeffs()(cumCoeffInd)); // Values of coefficients should be equal
-                CHECK(blocks.at(i)->Coeffs()(j) == coeffs_.at(i)(j)); 
+                CHECK(blocks.at(i)->Coeffs()(j) == coeffs_.at(i)(j));
                 CHECK(&blocks.at(i)->Coeffs()(j) == &triMap->Coeffs()(cumCoeffInd)); // Memory location should also be the same (no copy)
                 cumCoeffInd++;
             }
         }
     }
-
-    Kokkos::View<double*,Kokkos::HostSpace> coeffs(triMap->Coeffs().data(), triMap->numCoeffs);
-    unsigned int numSamps = 10;
-    Kokkos::View<double**, Kokkos::HostSpace> in("Map Input", dim, numSamps);
-    for(unsigned int i=0; i<dim; ++i){
-        for(unsigned int j=0; j<numSamps; ++j){
-            in(i,j) = double(i)/dim + double(j)/numSamps;
-        }
-    }
-
-    auto out = triMap->Evaluate(in);
-    
-    SECTION("Evaluation"){
-
-        unsigned int start = 0;
-
-        for(unsigned int b=0; b<numBlocks; ++b){
-            
-            auto subIn = Kokkos::subview(in, std::make_pair(0, int(blocks.at(b)->inputDim)), Kokkos::ALL());
-            auto subOut = Kokkos::subview(out, std::make_pair(int(start), int(start + blocks.at(b)->outputDim)), Kokkos::ALL());
-
-            auto outBlock = blocks.at(b)->Evaluate(subIn);
-            
-            REQUIRE(outBlock.extent(1)==subOut.extent(1));
-            REQUIRE(outBlock.extent(0)==subOut.extent(0));
-
-            for(unsigned int i=0; i<outBlock.extent(0); ++i)
-                for(unsigned int j=0; j<outBlock.extent(1); ++j)
-                    CHECK( subOut(i,j) == Approx(outBlock(i,j)).epsilon(1e-6));
-
-
-            start += blocks.at(b)->outputDim;
-        }
-    }
-
-
-    SECTION("Inverse"){
-
-        auto inv = triMap->Inverse(in,out);
-
-        for(unsigned int i=0; i<dim; ++i){
-            for(unsigned int j=0; j<numSamps; ++j)
-                CHECK( inv(i,j) == Approx(in(i,j)).margin(1e-3));
-        }
-    }
-
-    SECTION("LogDeterminant"){
-        auto logDet = triMap->LogDeterminant(in);
-
-        REQUIRE(logDet.extent(0)==numSamps);
-        Kokkos::View<double*, Kokkos::HostSpace> truth("True Log Det", numSamps);
-
-        for(unsigned int i=0; i<numBlocks; ++i){
-            auto blockLogDet = blocks.at(i)->LogDeterminant(Kokkos::subview(in, std::make_pair(0,int(blocks.at(i)->inputDim)), Kokkos::ALL()));
-
-            for(unsigned int j=0; j<numSamps; ++j)
-                truth(j) += blockLogDet(j);
-        }
-
-        for(unsigned int j=0; j<numSamps; ++j)
-            CHECK(logDet(j) == Approx(truth(j)).margin(1e-5));
-
-    }
-
-    SECTION("CoeffGrad"){
-
-        Kokkos::View<double**,Kokkos::HostSpace> sens("Sensitivities", triMap->outputDim, numSamps);
-        for(unsigned int j=0; j<numSamps; ++j){
-            for(unsigned int i=0; i<triMap->outputDim; ++i){
-                sens(i,j) = 1.0 + 0.1*i + j;
-            }
-        }
-
-        Kokkos::View<double**,Kokkos::HostSpace> evals = triMap->Evaluate(in);
-        Kokkos::View<double**,Kokkos::HostSpace> evals2;
-
-        Kokkos::View<double**,Kokkos::HostSpace> coeffGrad = triMap->CoeffGrad(in, sens);
-
-        REQUIRE(coeffGrad.extent(0)==triMap->numCoeffs);
-        REQUIRE(coeffGrad.extent(1)==numSamps);
-
-        // Compare with finite differences
-        double fdstep = 1e-5;
-        for(unsigned int i=0; i<triMap->numCoeffs; ++i){
-            coeffs(i) += fdstep;
-
-            triMap->SetCoeffs(coeffs);
-            evals2 = triMap->Evaluate(in);
-
-            for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd){
-                
-                double fdDeriv = 0.0;
-                for(unsigned int j=0; j<triMap->outputDim; ++j)
-                    fdDeriv += sens(j,ptInd) * (evals2(j,ptInd)-evals(j,ptInd))/fdstep;
-
-                CHECK( coeffGrad(i,ptInd) == Approx(fdDeriv).margin(1e-3)); 
-            }
-            coeffs(i) -= fdstep;
-        }
-        
-    }
-
-
-    SECTION("Input Gradient"){
-
-        Kokkos::View<double**,Kokkos::HostSpace> sens("Sensitivities", triMap->outputDim, numSamps);
-        for(unsigned int j=0; j<numSamps; ++j){
-            for(unsigned int i=0; i<triMap->outputDim; ++i){
-                sens(i,j) = 1.0 + 0.1*i + j;
-            }
-        }
-
-        Kokkos::View<double**,Kokkos::HostSpace> evals = triMap->Evaluate(in);
-        Kokkos::View<double**,Kokkos::HostSpace> evals2;
-
-        Kokkos::View<double**,Kokkos::HostSpace> inputGrad = triMap->Gradient(in, sens);
-
-        REQUIRE(inputGrad.extent(0)==triMap->inputDim);
-        REQUIRE(inputGrad.extent(1)==numSamps);
-
-        // Compare with finite differences
-        double fdstep = 1e-5;
-        for(unsigned int i=0; i<triMap->inputDim; ++i){
-            for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd)
-                in(i,ptInd) += fdstep;
-
-            evals2 = triMap->Evaluate(in);
-
-            for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd){
-                
-                double fdDeriv = 0.0;
-                for(unsigned int j=0; j<triMap->outputDim; ++j)
-                    fdDeriv += sens(j,ptInd) * (evals2(j,ptInd)-evals(j,ptInd))/fdstep;
-
-                CHECK( inputGrad(i,ptInd) == Approx(fdDeriv).epsilon(1e-3)); 
-            }
-
-            for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd)
-                in(i,ptInd) -= fdstep;
-        }
-        
-    }
-
-    SECTION("LogDeterminantCoeffGrad"){
-
-        Kokkos::View<double**,Kokkos::HostSpace> sens("Sensitivities", triMap->outputDim, numSamps);
-        for(unsigned int j=0; j<numSamps; ++j){
-            for(unsigned int i=0; i<triMap->outputDim; ++i){
-                sens(i,j) = 1.0 + 0.1*i + j;
-            }
-        }
-
-        Kokkos::View<double**,Kokkos::HostSpace> detGrad = triMap->LogDeterminantCoeffGrad(in);
-        REQUIRE(detGrad.extent(0)==triMap->numCoeffs);
-        REQUIRE(detGrad.extent(1)==numSamps);
-        
-        Kokkos::View<double*,Kokkos::HostSpace> logDet = triMap->LogDeterminant(in);
-        Kokkos::View<double*,Kokkos::HostSpace> logDet2;
-
-        // Compare with finite differences
-        double fdstep = 1e-5;
-        for(unsigned int i=0; i<triMap->numCoeffs; ++i){
-            coeffs(i) += fdstep;
-
-            triMap->SetCoeffs(coeffs);
-            logDet2 = triMap->LogDeterminant(in);
-
-            for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd)
-                CHECK( detGrad(i,ptInd) == Approx((logDet2(ptInd)-logDet(ptInd))/fdstep).epsilon(1e-4)); 
-            
-            coeffs(i) -= fdstep;
-        }
-
-    }
-
 }
 
 
@@ -925,9 +577,9 @@ TEST_CASE( "Testing TriangularMap made using CreateSingleEntryMap", "[Triangular
     Kokkos::View<double*,Kokkos::HostSpace> coeffs("Coefficients", triMap->numCoeffs);
     for(unsigned int i=0; i<triMap->numCoeffs; ++i)
         coeffs(i) = 0.1*(i+1);
-        
+
     SECTION("Coefficients"){
-        
+
         // Set the coefficients of the triangular map
         triMap->SetCoeffs(coeffs);
 
@@ -937,7 +589,7 @@ TEST_CASE( "Testing TriangularMap made using CreateSingleEntryMap", "[Triangular
                 CHECK(comp->Coeffs()(i) == triMap->Coeffs()(i)); // Values of coefficients should be equal
                 CHECK(&comp->Coeffs()(i) == &triMap->Coeffs()(i)); // Memory location should also be the same (no copy)
         }
-        
+
     }
 
     unsigned int numSamps = 10;
@@ -950,7 +602,7 @@ TEST_CASE( "Testing TriangularMap made using CreateSingleEntryMap", "[Triangular
 
     triMap->SetCoeffs(coeffs);
     auto out = triMap->Evaluate(in);
-    
+
     SECTION("Evaluation"){
 
         unsigned int start = 0;
@@ -991,9 +643,9 @@ TEST_CASE( "Testing TriangularMap made using CreateSingleEntryMap", "[Triangular
     }
 
     SECTION("LogDeterminant"){
-        
+
         auto inTopAndMid = Kokkos::subview(in, std::make_pair(0, int(activeInd)), Kokkos::ALL());
-        
+
         auto logDet = triMap->LogDeterminant(in);
         auto logDet_ = comp->LogDeterminant(inTopAndMid);
 
@@ -1030,16 +682,16 @@ TEST_CASE( "Testing TriangularMap made using CreateSingleEntryMap", "[Triangular
             evals2 = triMap->Evaluate(in);
 
             for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd){
-                
+
                 double fdDeriv = 0.0;
                 for(unsigned int j=0; j<triMap->outputDim; ++j)
                     fdDeriv += sens(j,ptInd) * (evals2(j,ptInd)-evals(j,ptInd))/fdstep;
 
-                CHECK( coeffGrad(i,ptInd) == Approx(fdDeriv).margin(1e-3)); 
+                CHECK( coeffGrad(i,ptInd) == Approx(fdDeriv).margin(1e-3));
             }
             coeffs(i) -= fdstep;
         }
-        
+
     }
 
 
@@ -1069,18 +721,18 @@ TEST_CASE( "Testing TriangularMap made using CreateSingleEntryMap", "[Triangular
             evals2 = triMap->Evaluate(in);
 
             for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd){
-                
+
                 double fdDeriv = 0.0;
                 for(unsigned int j=0; j<triMap->outputDim; ++j)
                     fdDeriv += sens(j,ptInd) * (evals2(j,ptInd)-evals(j,ptInd))/fdstep;
 
-                CHECK( inputGrad(i,ptInd) == Approx(fdDeriv).margin(1e-3)); 
+                CHECK( inputGrad(i,ptInd) == Approx(fdDeriv).margin(1e-3));
             }
 
             for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd)
                 in(i,ptInd) -= fdstep;
         }
-        
+
     }
 
     SECTION("LogDeterminantCoeffGrad"){
@@ -1095,7 +747,7 @@ TEST_CASE( "Testing TriangularMap made using CreateSingleEntryMap", "[Triangular
         Kokkos::View<double**,Kokkos::HostSpace> detGrad = triMap->LogDeterminantCoeffGrad(in);
         REQUIRE(detGrad.extent(0)==triMap->numCoeffs);
         REQUIRE(detGrad.extent(1)==numSamps);
-        
+
         Kokkos::View<double*,Kokkos::HostSpace> logDet = triMap->LogDeterminant(in);
         Kokkos::View<double*,Kokkos::HostSpace> logDet2;
 
@@ -1108,8 +760,8 @@ TEST_CASE( "Testing TriangularMap made using CreateSingleEntryMap", "[Triangular
             logDet2 = triMap->LogDeterminant(in);
 
             for(unsigned int ptInd=0; ptInd<numSamps; ++ptInd)
-                CHECK( detGrad(i,ptInd) == Approx((logDet2(ptInd)-logDet(ptInd))/fdstep).margin(1e-4)); 
-            
+                CHECK( detGrad(i,ptInd) == Approx((logDet2(ptInd)-logDet(ptInd))/fdstep).margin(1e-4));
+
             coeffs(i) -= fdstep;
         }
 


### PR DESCRIPTION
RunTests was getting too lengthy for reasonable TDD, so I removed some redundant tests for when `moveCoeffs=true` from `Test_TriangularMap`, cranked down the complexity of some of those tests, and then cranked down the complexity of the ComposedMap depth (I think if it can handle 5, it can handle 8, but the time complexity goes up exponentially, which is unnecessary for tests). I commented out (🤮 ) some tests in TrainMapAdaptive which were somewhat redundant, because that algorithm is really expensive and we need to optimize it a little bit, so about 50% of the runtime of the tests is now from that one ATM call.