### PR TITLE
Add sigmoid, move root finding

### DIFF
--- a/MParT/MonotoneComponent.h
+++ b/MParT/MonotoneComponent.h
@@ -12,6 +12,7 @@
 #include "MParT/Utilities/Miscellaneous.h"
 #include "MParT/Utilities/KokkosSpaceMappings.h"
 #include "MParT/Utilities/KokkosHelpers.h"
+#include "MParT/Utilities/RootFinding.h"
 
 
 #include <Eigen/Core>
@@ -399,7 +400,13 @@ public:
 
                 // Compute the inverse
                 Kokkos::View<double*,MemorySpace> workspace(team_member.thread_scratch(1), workspaceSize);
-                output(ptInd) = InverseSingleBracket(workspace.data(), cache.data(), pt, ys(ptInd), coeffs, xtol, ytol, quad_, expansion_);
+                auto evaluate_lambda = KOKKOS_LAMBDA(double x){
+                    return EvaluateSingle(workspace.data(), cache.data(), pt, x, coeffs, quad_, expansion_);
+                };
+                // OLD
+                // output(ptInd) = InverseSingleBracket(workspace.data(), cache.data(), pt, ys(ptInd), coeffs, xtol, ytol, quad_, expansion_);
+                // NEW
+                output(ptInd) = RootFinding::InverseSingleBracket<MemorySpace>(ys(ptInd), evaluate_lambda, pt(pt.extent(0)-1), xtol, ytol);
             }
         };
 

--- a/MParT/MonotoneIntegrand.h
+++ b/MParT/MonotoneIntegrand.h
@@ -176,9 +176,11 @@ public:
 
         // Check for infs or nans
         if(std::isinf(gf)){
-            printf("\nERROR: In MonotoneIntegrand, value of g(df(...)) is inf.  The value of df(...) is %0.4f, and the value of f(df(...)) is %0.4f.\n\n", df, gf);
-        }else if(failOnNaN && std::isnan(gf)){
-            ProcAgnosticError<MemorySpace,std::runtime_error>::error("MonotoneIntegrand: nan was encountered in value of g(df(...)). Use MonotoneIntegrand::setFailOnNaN for enabling NaN propagation.");
+            if(failOnNaN) {
+                ProcAgnosticError<MemorySpace,std::runtime_error>::error("MonotoneIntegrand: nan was encountered in value of g(df(...)). Use MonotoneIntegrand::setFailOnNaN for enabling NaN propagation.");
+            } else {
+                printf("\nERROR: In MonotoneIntegrand, value of g(df(...)) is inf.  The value of df(...) is %0.4f, and the value of f(df(...)) is %0.4f.\n\n", df, gf);
+            }
         }
 
         // Compute the derivative with respect to x_d

--- a/MParT/Sigmoid.h
+++ b/MParT/Sigmoid.h
@@ -1,0 +1,60 @@
+#ifndef MPART_SIGMOID_H
+#define MPART_SIGMOID_H
+
+#include "MParT/Utilities/KokkosSpaceMappings.h"
+#include "MParT/Utilities/Miscellaneous.h"
+#include "MParT/ConditionalMapBase.h"
+
+#include <Kokkos_Core.hpp>
+
+namespace mpart{
+
+#if (KOKKOS_VERSION / 10000 == 3) && (KOKKOS_VERSION / 100 % 100 < 7)
+namespace MathSpace = Kokkos::Experimental;
+#else
+namespace MathSpace = Kokkos;
+#endif
+
+struct Logistic {
+    KOKKOS_INLINE_FUNCTION double static Evaluate(double x) {
+        return 0.5+0.5*MathSpace::tanh(x/2);
+    }
+    KOKKOS_INLINE_FUNCTION double static Inverse(double y) {
+        return y > 1 ? -MathSpace::log((1-y)/y) : MathSpace::log(y/(1-y));
+    }
+    KOKKOS_INLINE_FUNCTION double static Derivative(double x) {
+        double fx = Evaluate(x);
+        return fx*(1-fx); // Known expression for the derivative of this
+    }
+};
+
+template<typename MemorySpace, typename SigmoidType>
+class Sigmoid: public ParameterizedFunctionBase<MemorySpace>
+{
+    public:
+    Sigmoid(StridedVector<const double, MemorySpace> centers, StridedVector<const double, MemorySpace> widths): ParameterizedFunctionBase<MemorySpace>(1, 1, widths.extent(0))
+    {
+        if(centers.extent(0) != widths.extent(0)) {
+            std::stringstream ss;
+            ss << "Sigmoid: incompatible dims of centers and widths.";
+            ss << "centers: " << centers.extent(0) << ", ";
+            ss << "widths: " << widths.extent(0);
+            ProcAgnosticError<MemorySpace,std::invalid_argument>::error(ss.str().c_str());
+        }
+    }
+
+    void EvaluateImpl(StridedMatrix<const double, MemorySpace> const& pts, StridedMatrix<double, MemorySpace> out) override {
+        auto policy = Kokkos::RangePolicy<typename MemoryToExecution<MemorySpace>::Space>(0,pts.extent(1));
+        Kokkos::parallel_for(policy, KOKKOS_CLASS_LAMBDA (unsigned int pointInd) {
+            out(0,pointInd) = SigmoidType::Evaluate(pts(0,pointInd));
+        });
+    }
+    void GradientImpl(StridedMatrix<const double, MemorySpace> const& sens, StridedMatrix<const double, MemorySpace> const& pts, StridedMatrix<double, MemorySpace> out) override {}
+    void CoeffGradImpl(StridedMatrix<const double, MemorySpace> const& sens,StridedMatrix<const double, MemorySpace> const& pts, StridedMatrix<double, MemorySpace> out) override {}
+
+    private:
+
+};
+}
+
+#endif //MPART_SIGMOID_H

--- a/MParT/Utilities/RootFinding.h
+++ b/MParT/Utilities/RootFinding.h
@@ -1,0 +1,108 @@
+#ifndef MPART_ROOTFINDING_H
+#define MPART_ROOTFINDING_H
+#include "MParT/Utilities/Miscellaneous.h"
+#include <Kokkos_Core.hpp>
+
+namespace mpart {
+namespace RootFinding {
+template<typename T>
+KOKKOS_INLINE_FUNCTION void swapPair(T& x1, T& x2, T& y1, T& y2) {
+    simple_swap(x1, x2);
+    simple_swap(y1, y2);
+}
+
+template<typename MemorySpace, typename FunctorType>
+KOKKOS_INLINE_FUNCTION void FindBound(bool haveLowerBound, double yd, FunctorType f, double& x_unbound, double& y_unbound, double& x_prebounded, double& y_prebounded, const unsigned int maxIts) {
+    double boundSign = haveLowerBound ? 1.0 : -1.0;
+    double stepSize = 1.0;
+    unsigned int iter;
+    for(iter = 0; iter < maxIts; iter++) {
+        x_unbound += boundSign*stepSize;
+        y_unbound = f(x_unbound);
+        if(boundSign*(y_unbound - yd) > 0) return;
+        swapPair(x_prebounded, x_unbound, y_prebounded, y_unbound);
+        stepSize *= 2;
+    }
+    if(iter>maxIts)
+            ProcAgnosticError<MemorySpace,std::runtime_error>::error("InverseSingleBracket: bound calculation exceeds maxIts");
+}
+
+KOKKOS_INLINE_FUNCTION double Find_x_ITP(double xlb, double xub, double yd, double ylb, double yub,
+                           double k1, double k2, double nhalf, double n0, int it, double xtol) {
+
+        double xb = 0.5*(xub+xlb); // bisection point
+        double xf = xlb - (yd-ylb)*(xub-xlb) / (yub-ylb); // regula-falsi point
+
+        double sigma = ((xb-xf)>0)?1.0:-1.0; // sign(xb-xf)
+        double delta = fmin(k1*pow((xub-xlb), k2), fabs(xb-xf));
+
+        xf += delta*sigma;
+
+        double rho = fmin(xtol*pow(2.0, nhalf + n0 - it) - 0.5*(xub-xlb), fabs(xf - xb));
+        double xc = xb - sigma*rho;
+        return xc;
+}
+
+template<typename MemorySpace, typename FunctorType>
+KOKKOS_INLINE_FUNCTION double InverseSingleBracket(double yd, FunctorType f, double x0, const double xtol, const double ftol)
+{
+    double stepSize=1.0;
+    const unsigned int maxIts = 10000;
+
+    // First, we need to find two points that bound the solution.
+    double xlb, xub;
+    double ylb, yub;
+    double xc, yc;
+
+    xlb = x0;
+    ylb = f(xlb);
+
+    // We actually found an upper bound...
+    if(ylb>yd){
+        swapPair(xlb, xub, ylb, yub);
+        // Now find a lower bound...
+        FindBound<MemorySpace>(false, yd, f, xlb, ylb, xub, yub, maxIts);
+
+    // We have a lower bound...
+    }else{
+        // Now find an upper bound...
+        FindBound<MemorySpace>(true, yd, f, xub, yub, xlb, ylb, maxIts);
+    }
+
+    assert(ylb<yub);
+    assert(xlb<xub);
+
+    // Bracketed search
+    const double k1 = 0.1;
+    const double k2 = 2.0;
+    const double nhalf = ceil(log2(0.5*(xub-xlb)/xtol));
+    const double n0 = 1.0;
+
+    unsigned int it;
+    for(it=0; it<maxIts; ++it){
+        xc = Find_x_ITP(xlb, xub, yd, ylb, yub, k1, k2, nhalf, n0, it, xtol);
+
+        yc = f(xc);
+
+        if(abs(yc-yd)<ftol){
+            return xc;
+        }else if(yc>yd){
+            swapPair(xc, xub, yc, yub);
+        }else{
+            swapPair(xc, xlb, yc, ylb);
+        }
+
+        // Check for convergence
+        if(((xub-xlb)<xtol)||((yub-ylb)<ftol)) break;
+    };
+
+    if(it>maxIts)
+        ProcAgnosticError<MemorySpace,std::runtime_error>::error("InverseSingleBracket: Bracket search iterations exceeds maxIts");
+
+    return 0.5*(xub+xlb);
+}
+
+} // RootFinding
+
+} // mpart
+#endif // MPART_ROOTFINDING_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ set (TEST_SOURCES
      tests/Distributions/Test_TransportSampler.cpp
 
      tests/Test_OrthogonalPolynomials.cpp
+     tests/Test_RootFinding.cpp
      tests/Test_HermiteFunctions.cpp
      tests/Test_Sigmoid.cpp
      tests/Test_PositiveBijectors.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ set (TEST_SOURCES
 
      tests/Test_OrthogonalPolynomials.cpp
      tests/Test_HermiteFunctions.cpp
+     tests/Test_Sigmoid.cpp
      tests/Test_PositiveBijectors.cpp
      tests/Test_Quadrature.cpp
      tests/Test_MonotoneComponent.cpp

--- a/tests/Test_MonotoneComponent.cpp
+++ b/tests/Test_MonotoneComponent.cpp
@@ -11,6 +11,10 @@
 
 #include <Eigen/Dense>
 
+// TO REMOVE
+#include <iostream>
+#include <chrono>
+
 using namespace mpart;
 using namespace Catch;
 using HostSpace = Kokkos::HostSpace;
@@ -386,7 +390,12 @@ TEST_CASE( "Testing bracket-based inversion of monotone component", "[MonotoneBr
         comp.EvaluateImpl(evalPts, coeffs, ys);
 
         Kokkos::View<double*, HostSpace> testInverse("Test output", numPts);
-        comp.InverseImpl(evalPts, ys, coeffs, testInverse);
+        auto start = std::chrono::high_resolution_clock::now();
+        for(int i = 0; i < 100; i++)
+            comp.InverseImpl(evalPts, ys, coeffs, testInverse);
+        auto end = std::chrono::high_resolution_clock::now();
+        auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+        std::cout << "Inversion time taken: " << static_cast<double>(duration.count())*1e-9 << " microseconds" << std::endl;
 
         for(unsigned int i=0; i<numPts; ++i){
             CHECK(testInverse(i) == Approx(evalPts(0,i)).epsilon(testTol));

--- a/tests/Test_MonotoneComponent.cpp
+++ b/tests/Test_MonotoneComponent.cpp
@@ -353,7 +353,7 @@ TEST_CASE( "Testing monotone component evaluation in 1d", "[MonotoneComponent1d]
 
 TEST_CASE( "Testing bracket-based inversion of monotone component", "[MonotoneBracketInverse]" ) {
 
-    const double testTol = 1e-7;
+    const double testTol = 1e-6;
     unsigned int dim = 1;
 
     // Create points evently space on [lb,ub]
@@ -390,12 +390,8 @@ TEST_CASE( "Testing bracket-based inversion of monotone component", "[MonotoneBr
         comp.EvaluateImpl(evalPts, coeffs, ys);
 
         Kokkos::View<double*, HostSpace> testInverse("Test output", numPts);
-        auto start = std::chrono::high_resolution_clock::now();
         for(int i = 0; i < 100; i++)
             comp.InverseImpl(evalPts, ys, coeffs, testInverse);
-        auto end = std::chrono::high_resolution_clock::now();
-        auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
-        std::cout << "Inversion time taken: " << static_cast<double>(duration.count())*1e-9 << " microseconds" << std::endl;
 
         for(unsigned int i=0; i<numPts; ++i){
             CHECK(testInverse(i) == Approx(evalPts(0,i)).epsilon(testTol));

--- a/tests/Test_RootFinding.cpp
+++ b/tests/Test_RootFinding.cpp
@@ -1,0 +1,60 @@
+#include <catch2/catch_all.hpp>
+
+#include "MParT/Utilities/RootFinding.h"
+
+#include <Kokkos_Core.hpp>
+
+using namespace mpart::RootFinding;
+using namespace Catch;
+using HostSpace = Kokkos::HostSpace;
+
+void CheckFoundBounds(std::function<double(double)> f, double xlb, double xd, double xub, double ylb, double yd, double yub) {
+    REQUIRE((xlb < xd && xd < xub));
+    REQUIRE((ylb < yd && yd < yub));
+    REQUIRE((ylb == f(xlb) && yub == f(xub)));
+}
+
+TEST_CASE( "RootFindingUtils", "[RootFindingUtils]") {
+    SECTION("swapPair") {
+        double x1 = 1., x2 = 2., y1 = 3., y2 = 4.;
+        swapPair(x1, x2, y1, y2);
+        REQUIRE((x1 == 2. && x2 == 1. && y1 == 4. && y2 == 3.));
+    }
+    auto identity = [](double x){return x;};
+    auto sigmoid = [](double x){return 1./(std::exp(-x)+1);};
+    SECTION("FindBound lower linear") {
+        double xd = -1.;
+        double yd = identity(xd);
+        double xub = 2., yub = 2.;
+        double xlb = 0., ylb = 0.;
+        FindBound<HostSpace>(false, yd, identity, xlb, ylb, xub, yub, 10'000);
+        CheckFoundBounds(identity, xlb, xd, xub, ylb, yd, yub);
+    }
+    SECTION("FindBound upper linear") {
+        double xd = 1.;
+        double yd = identity(xd);
+        double xub = 0., yub = 0.;
+        double xlb = -2., ylb = -2.;
+        FindBound<HostSpace>(true, yd, identity, xub, yub, xlb, ylb, 10'000);
+        CheckFoundBounds(identity, xlb, xd, xub, ylb, yd, yub);
+    }
+    SECTION("FindBound lower sigmoid") {
+        double xd = -0.5;
+        double yd = sigmoid(xd);
+        double xub = 2., yub = 2.;
+        double xlb = 0., ylb = 0.;
+        FindBound<HostSpace>(false, yd, sigmoid, xlb, ylb, xub, yub, 10'000);
+        CheckFoundBounds(sigmoid, xlb, xd, xub, ylb, yd, yub);
+    }
+    SECTION("FindBound upper sigmoid") {
+        double xd = 0.5;
+        double yd = sigmoid(xd);
+        double xub = 0., yub = 0.;
+        double xlb = -2., ylb = -2.;
+        FindBound<HostSpace>(true, yd, sigmoid, xub, yub, xlb, ylb, 10'000);
+        std::cout << "ylb = " << ylb << ", f(xlb) = " << sigmoid(xlb) << std::endl;
+        CheckFoundBounds(sigmoid, xlb, xd, xub, ylb, yd, yub);
+    }
+
+
+}

--- a/tests/Test_RootFinding.cpp
+++ b/tests/Test_RootFinding.cpp
@@ -22,39 +22,74 @@ TEST_CASE( "RootFindingUtils", "[RootFindingUtils]") {
     }
     auto identity = [](double x){return x;};
     auto sigmoid = [](double x){return 1./(std::exp(-x)+1);};
+    auto sigmoid_combo = [sigmoid](double x){return sigmoid(2*(x-1)) + 3*sigmoid(x*0.5) + 0.5*sigmoid(1.5*(x+1));};
     SECTION("FindBound lower linear") {
-        double xd = -1.;
+        double xd = -1.1;
         double yd = identity(xd);
         double xub = 2., yub = 2.;
         double xlb = 0., ylb = 0.;
-        FindBound<HostSpace>(false, yd, identity, xlb, ylb, xub, yub, 10'000);
+        FindBound<HostSpace>(false, yd, identity, xub, yub, xlb, ylb, 10'000);
         CheckFoundBounds(identity, xlb, xd, xub, ylb, yd, yub);
     }
     SECTION("FindBound upper linear") {
-        double xd = 1.;
+        double xd = 1.1;
         double yd = identity(xd);
         double xub = 0., yub = 0.;
         double xlb = -2., ylb = -2.;
-        FindBound<HostSpace>(true, yd, identity, xub, yub, xlb, ylb, 10'000);
+        FindBound<HostSpace>(true, yd, identity, xlb, ylb, xub, yub, 10'000);
         CheckFoundBounds(identity, xlb, xd, xub, ylb, yd, yub);
     }
     SECTION("FindBound lower sigmoid") {
         double xd = -0.5;
         double yd = sigmoid(xd);
-        double xub = 2., yub = 2.;
-        double xlb = 0., ylb = 0.;
-        FindBound<HostSpace>(false, yd, sigmoid, xlb, ylb, xub, yub, 10'000);
+        double xub =  2., yub = sigmoid(xub);
+        double xlb =  0., ylb = sigmoid(xlb);
+        FindBound<HostSpace>(false, yd, sigmoid, xub, yub, xlb, ylb, 10'000);
         CheckFoundBounds(sigmoid, xlb, xd, xub, ylb, yd, yub);
     }
     SECTION("FindBound upper sigmoid") {
         double xd = 0.5;
         double yd = sigmoid(xd);
-        double xub = 0., yub = 0.;
-        double xlb = -2., ylb = -2.;
-        FindBound<HostSpace>(true, yd, sigmoid, xub, yub, xlb, ylb, 10'000);
-        std::cout << "ylb = " << ylb << ", f(xlb) = " << sigmoid(xlb) << std::endl;
+        double xub =  0., yub = sigmoid(xub);
+        double xlb = -2., ylb = sigmoid(xlb);
+        FindBound<HostSpace>(true, yd, sigmoid, xlb, ylb, xub, yub, 10'000);
         CheckFoundBounds(sigmoid, xlb, xd, xub, ylb, yd, yub);
     }
-
+    SECTION("Test Inverse Linear, low x0") {
+        double xd = 0.5, yd = identity(xd);
+        double x0 = 0.0, xtol = 1e-5, ftol = 1e-5;
+        double xd_found = InverseSingleBracket<HostSpace>(yd, identity, x0, xtol, ftol);
+        CHECK( xd_found == Approx(xd).epsilon(2*xtol));
+    }
+    SECTION("Test Inverse Linear, high x0") {
+        double xd = 0.5, yd = identity(xd);
+        double x0 = 1.0, xtol = 1e-5, ftol = 1e-5;
+        double xd_found = InverseSingleBracket<HostSpace>(yd, identity, x0, xtol, ftol);
+        CHECK( xd_found == Approx(xd).epsilon(2*xtol));
+    }
+    SECTION("Test Inverse Sigmoid, low x0") {
+        double xd = 0.5, yd = sigmoid(xd);
+        double x0 = 0.0, xtol = 1e-5, ftol = 1e-5;
+        double xd_found = InverseSingleBracket<HostSpace>(yd, sigmoid, x0, xtol, ftol);
+        CHECK( xd_found == Approx(xd).epsilon(2*xtol));
+    }
+    SECTION("Test Inverse Sigmoid, high x0") {
+        double xd = 0.5, yd = sigmoid(xd);
+        double x0 = 1.0, xtol = 1e-5, ftol = 1e-5;
+        double xd_found = InverseSingleBracket<HostSpace>(yd, sigmoid, x0, xtol, ftol);
+        CHECK( xd_found == Approx(xd).epsilon(2*xtol));
+    }
+    SECTION("Test Inverse Sigmoid Combo, low x0") {
+        double xd = 0.5, yd = sigmoid_combo(xd);
+        double x0 = -5.0, xtol = 1e-5, ftol = 1e-5;
+        double xd_found = InverseSingleBracket<HostSpace>(yd, sigmoid_combo, x0, xtol, ftol);
+        CHECK( xd_found == Approx(xd).epsilon(2*xtol));
+    }
+    SECTION("Test Inverse Sigmoid Combo, high x0") {
+        double xd = 0.5, yd = sigmoid_combo(xd);
+        double x0 = 5.0, xtol = 1e-5, ftol = 1e-5;
+        double xd_found = InverseSingleBracket<HostSpace>(yd, sigmoid_combo, x0, xtol, ftol);
+        CHECK( xd_found == Approx(xd).epsilon(2*xtol));
+    }
 
 }

--- a/tests/Test_Sigmoid.cpp
+++ b/tests/Test_Sigmoid.cpp
@@ -1,0 +1,40 @@
+#include <catch2/catch_all.hpp>
+#include "MParT/Sigmoid.h"
+
+using namespace mpart;
+using namespace Catch;
+using MemorySpace = Kokkos::HostSpace;
+
+
+TEMPLATE_TEST_CASE("Sigmoid","[sigmoid]", Logistic) {
+    SECTION("Initialization") {
+        Kokkos::View<double*, MemorySpace> centers("Sigmoid Centers", 2);
+        Kokkos::View<double*, MemorySpace> widths("Sigmoid Centers", 1);
+
+        CHECK_THROWS_AS((Sigmoid<MemorySpace,TestType>(centers, widths)), std::invalid_argument);
+    }
+    SECTION("Single Sigmoid") {
+        Kokkos::View<double*, MemorySpace> center("Sigmoid Centers", 1);
+        Kokkos::View<double*, MemorySpace> width("Sigmoid Centers", 1);
+        Kokkos::View<double*, MemorySpace> coeff("Sigmoid coeff", 1);
+        center(0) = 0; width(0) = 1; coeff(0) = 1.0;
+        Sigmoid<MemorySpace,TestType> Sigmoid (center, width);
+        Sigmoid.SetCoeffs(coeff);
+        Kokkos::View<double**, MemorySpace> evalPts("Input point", 1, 3);
+        evalPts(0,0) = -100; evalPts(0,1) = 0.0; evalPts(0,2) = 100;
+        StridedMatrix<double,MemorySpace> out = Sigmoid.Evaluate(evalPts);
+        double approxTol = 1e-5;
+        REQUIRE_THAT(out(0,0), Matchers::WithinAbs(0.0, approxTol));
+        REQUIRE_THAT(out(0,1), Matchers::WithinAbs(0.5, approxTol));
+        REQUIRE_THAT(out(0,2), Matchers::WithinAbs(1.0, approxTol));
+    }
+    SECTION("Multiple Sigmoids") {
+        int N_Sigmoid = 3;
+        Kokkos::View<double*, MemorySpace> centers("Sigmoid Centers", N_Sigmoid);
+        Kokkos::View<double*, MemorySpace> widths("Sigmoid Centers", N_Sigmoid);
+        Sigmoid<MemorySpace,TestType> Sigmoid (centers, widths);
+        Kokkos::View<double*, MemorySpace> coeffs("Sigmoid Coefficients", N_Sigmoid);
+        for(int j = 0; j < N_Sigmoid; j++) coeffs(j) = 0.5*(j+1);
+        Sigmoid.WrapCoeffs(coeffs);
+    }
+}

--- a/tests/Test_Sigmoid.cpp
+++ b/tests/Test_Sigmoid.cpp
@@ -6,33 +6,64 @@ using namespace Catch;
 using MemorySpace = Kokkos::HostSpace;
 
 
-TEMPLATE_TEST_CASE("Sigmoid","[sigmoid]", Logistic) {
+TEMPLATE_TEST_CASE("Sigmoid1d","[sigmoid1d]", Logistic) {
     SECTION("Initialization") {
         Kokkos::View<double*, MemorySpace> centers("Sigmoid Centers", 2);
         Kokkos::View<double*, MemorySpace> widths("Sigmoid Centers", 1);
 
-        CHECK_THROWS_AS((Sigmoid<MemorySpace,TestType>(centers, widths)), std::invalid_argument);
+        CHECK_THROWS_AS((Sigmoid1d<MemorySpace,TestType>(centers, widths)), std::invalid_argument);
     }
     SECTION("Single Sigmoid") {
         Kokkos::View<double*, MemorySpace> center("Sigmoid Centers", 1);
         Kokkos::View<double*, MemorySpace> width("Sigmoid Centers", 1);
         Kokkos::View<double*, MemorySpace> coeff("Sigmoid coeff", 1);
-        center(0) = 0; width(0) = 1; coeff(0) = 1.0;
-        Sigmoid<MemorySpace,TestType> Sigmoid (center, width);
-        Sigmoid.SetCoeffs(coeff);
-        Kokkos::View<double**, MemorySpace> evalPts("Input point", 1, 3);
-        evalPts(0,0) = -100; evalPts(0,1) = 0.0; evalPts(0,2) = 100;
-        StridedMatrix<double,MemorySpace> out = Sigmoid.Evaluate(evalPts);
-        double approxTol = 1e-5;
-        REQUIRE_THAT(out(0,0), Matchers::WithinAbs(0.0, approxTol));
-        REQUIRE_THAT(out(0,1), Matchers::WithinAbs(0.5, approxTol));
-        REQUIRE_THAT(out(0,2), Matchers::WithinAbs(1.0, approxTol));
+        center(0) = 0; width(0) = 1;
+        Sigmoid1d<MemorySpace,TestType> Sigmoid (center, width);
+        for(int coeff_int = 1; coeff_int <= 2; coeff_int++) {
+            coeff(0) = (double) coeff_int;
+            Sigmoid.WrapCoeffs(coeff);
+            Kokkos::View<double**, MemorySpace> evalPts("Input point", 1, 3);
+            evalPts(0,0) = -100; evalPts(0,1) = 0.0; evalPts(0,2) = 100;
+            StridedMatrix<double,MemorySpace> out = Sigmoid.Evaluate(evalPts);
+            double approxTol = 1e-5;
+            REQUIRE_THAT(out(0,0), Matchers::WithinAbs(coeff_int*0.0, approxTol));
+            REQUIRE_THAT(out(0,1), Matchers::WithinAbs(coeff_int*0.5, approxTol));
+            REQUIRE_THAT(out(0,2), Matchers::WithinAbs(coeff_int*1.0, approxTol));
+        }
+
+        unsigned int N_grad_points = 100;
+        double fd_delta = 1e-5;
+        Kokkos::View<double**, MemorySpace> gradPts("Gradient points", 1, N_grad_points);
+        Kokkos::View<double**, MemorySpace> gradPts_plus_delta("Gradient points plus delta", 1, N_grad_points);
+        Kokkos::View<double**, MemorySpace> sens("Sensitivities", 1, N_grad_points);
+        Kokkos::parallel_for(N_grad_points, KOKKOS_LAMBDA(unsigned int point_index) {
+            double gradPt = 3.0*(-1.0 + 2*((double) point_index)/((double) N_grad_points-1));
+            double sensPt = 2.0 + ((double) point_index)/((double) N_grad_points-1);
+            gradPts(0,point_index) = gradPt;
+            gradPts_plus_delta(0,point_index) = gradPt + fd_delta;
+            sens(0,point_index) = sensPt;
+        });
+        Kokkos::View<double**, MemorySpace> input_grad = Sigmoid.Gradient(sens, gradPts);
+        Kokkos::View<double**, MemorySpace> coeff_grad = Sigmoid.CoeffGrad(sens, gradPts);
+        Kokkos::View<double**, MemorySpace> gradPts_eval = Sigmoid.Evaluate(gradPts);
+        Kokkos::View<double**, MemorySpace> gradPts_plus_delta_eval = Sigmoid.Evaluate(gradPts_plus_delta);
+        coeff(0) += fd_delta;
+        Kokkos::View<double**, MemorySpace> gradPts_plus_coeff_delta_eval = Sigmoid.Evaluate(gradPts);
+        double input_grad_error_accumulator = 0., coeff_grad_error_accumulator = 0.;
+        for(int i = 0; i < N_grad_points; i++) {
+            double input_grad_i_fd = (gradPts_plus_delta_eval(0,i) - gradPts_eval(0,i))/fd_delta;
+            double coeff_grad_i_fd = (gradPts_plus_coeff_delta_eval(0,i) - gradPts_eval(0,i))/fd_delta;
+            input_grad_error_accumulator += fabs(input_grad_i_fd*sens(0,i) - input_grad(0,i));
+            coeff_grad_error_accumulator += fabs(coeff_grad_i_fd*sens(0,i) - coeff_grad(0,i));
+        }
+        CHECK(input_grad_error_accumulator < N_grad_points*2*fd_delta);
+        CHECK(coeff_grad_error_accumulator < N_grad_points*2*fd_delta);
     }
     SECTION("Multiple Sigmoids") {
         int N_Sigmoid = 3;
         Kokkos::View<double*, MemorySpace> centers("Sigmoid Centers", N_Sigmoid);
         Kokkos::View<double*, MemorySpace> widths("Sigmoid Centers", N_Sigmoid);
-        Sigmoid<MemorySpace,TestType> Sigmoid (centers, widths);
+        Sigmoid1d<MemorySpace,TestType> Sigmoid (centers, widths);
         Kokkos::View<double*, MemorySpace> coeffs("Sigmoid Coefficients", N_Sigmoid);
         for(int j = 0; j < N_Sigmoid; j++) coeffs(j) = 0.5*(j+1);
         Sigmoid.WrapCoeffs(coeffs);

--- a/tests/Test_Sigmoid.cpp
+++ b/tests/Test_Sigmoid.cpp
@@ -5,34 +5,8 @@ using namespace mpart;
 using namespace Catch;
 using MemorySpace = Kokkos::HostSpace;
 
-
-TEMPLATE_TEST_CASE("Sigmoid1d","[sigmoid1d]", Logistic) {
-    SECTION("Initialization") {
-        Kokkos::View<double*, MemorySpace> centers("Sigmoid Centers", 2);
-        Kokkos::View<double*, MemorySpace> widths("Sigmoid Centers", 1);
-
-        CHECK_THROWS_AS((Sigmoid1d<MemorySpace,TestType>(centers, widths)), std::invalid_argument);
-    }
-    SECTION("Single Sigmoid") {
-        Kokkos::View<double*, MemorySpace> center("Sigmoid Centers", 1);
-        Kokkos::View<double*, MemorySpace> width("Sigmoid Centers", 1);
-        Kokkos::View<double*, MemorySpace> coeff("Sigmoid coeff", 1);
-        center(0) = 0; width(0) = 1;
-        Sigmoid1d<MemorySpace,TestType> Sigmoid (center, width);
-        for(int coeff_int = 1; coeff_int <= 2; coeff_int++) {
-            coeff(0) = (double) coeff_int;
-            Sigmoid.WrapCoeffs(coeff);
-            Kokkos::View<double**, MemorySpace> evalPts("Input point", 1, 3);
-            evalPts(0,0) = -100; evalPts(0,1) = 0.0; evalPts(0,2) = 100;
-            StridedMatrix<double,MemorySpace> out = Sigmoid.Evaluate(evalPts);
-            double approxTol = 1e-5;
-            REQUIRE_THAT(out(0,0), Matchers::WithinAbs(coeff_int*0.0, approxTol));
-            REQUIRE_THAT(out(0,1), Matchers::WithinAbs(coeff_int*0.5, approxTol));
-            REQUIRE_THAT(out(0,2), Matchers::WithinAbs(coeff_int*1.0, approxTol));
-        }
-
-        unsigned int N_grad_points = 100;
-        double fd_delta = 1e-5;
+template<typename Function>
+void TestSigmoidGradients(Function Sigmoid, unsigned int N_grad_points, double fd_delta, Kokkos::View<double*, MemorySpace> coeff) {
         Kokkos::View<double**, MemorySpace> gradPts("Gradient points", 1, N_grad_points);
         Kokkos::View<double**, MemorySpace> gradPts_plus_delta("Gradient points plus delta", 1, N_grad_points);
         Kokkos::View<double**, MemorySpace> sens("Sensitivities", 1, N_grad_points);
@@ -47,25 +21,97 @@ TEMPLATE_TEST_CASE("Sigmoid1d","[sigmoid1d]", Logistic) {
         Kokkos::View<double**, MemorySpace> coeff_grad = Sigmoid.CoeffGrad(sens, gradPts);
         Kokkos::View<double**, MemorySpace> gradPts_eval = Sigmoid.Evaluate(gradPts);
         Kokkos::View<double**, MemorySpace> gradPts_plus_delta_eval = Sigmoid.Evaluate(gradPts_plus_delta);
-        coeff(0) += fd_delta;
-        Kokkos::View<double**, MemorySpace> gradPts_plus_coeff_delta_eval = Sigmoid.Evaluate(gradPts);
+        Kokkos::View<double**, MemorySpace> gradPts_coeff_plus_delta_eval ("Evals for each directional add", coeff.extent(0), N_grad_points);
+        for(int j = 0; j < coeff.extent(0); j++) {
+            coeff(j) += fd_delta;
+            Kokkos::View<double**, MemorySpace> coeff_eval_perturb_j = Sigmoid.Evaluate(gradPts);
+            Kokkos::parallel_for(N_grad_points, KOKKOS_LAMBDA(unsigned int i){
+                gradPts_coeff_plus_delta_eval(j,i) = coeff_eval_perturb_j(0,i);
+            });
+            coeff(j) -= fd_delta;
+        }
         double input_grad_error_accumulator = 0., coeff_grad_error_accumulator = 0.;
         for(int i = 0; i < N_grad_points; i++) {
             double input_grad_i_fd = (gradPts_plus_delta_eval(0,i) - gradPts_eval(0,i))/fd_delta;
-            double coeff_grad_i_fd = (gradPts_plus_coeff_delta_eval(0,i) - gradPts_eval(0,i))/fd_delta;
             input_grad_error_accumulator += fabs(input_grad_i_fd*sens(0,i) - input_grad(0,i));
-            coeff_grad_error_accumulator += fabs(coeff_grad_i_fd*sens(0,i) - coeff_grad(0,i));
+            for(int j = 0; j < coeff.extent(0); j++) {
+                double coeff_grad_ij_fd = (gradPts_coeff_plus_delta_eval(j,i) - gradPts_eval(0,i))/fd_delta;
+                coeff_grad_error_accumulator += fabs(coeff_grad_ij_fd*sens(0,i) - coeff_grad(j,i));
+            }
         }
-        CHECK(input_grad_error_accumulator < N_grad_points*2*fd_delta);
-        CHECK(coeff_grad_error_accumulator < N_grad_points*2*fd_delta);
+        CHECK(input_grad_error_accumulator < 3*N_grad_points*fd_delta);
+        CHECK(coeff_grad_error_accumulator < 3*N_grad_points*coeff.extent(0)*fd_delta);
+}
+
+TEMPLATE_TEST_CASE("Sigmoid1d","[sigmoid1d]", Logistic) {
+    SECTION("Initialization") {
+        Kokkos::View<double*, MemorySpace> centers("Sigmoid Centers", 2);
+        Kokkos::View<double*, MemorySpace> widths("Sigmoid Centers", 1);
+
+        CHECK_THROWS_AS((Sigmoid1d<MemorySpace,TestType>(centers, widths)), std::invalid_argument);
+    }
+
+    unsigned int N_grad_points = 100;
+    double fd_delta = 1e-6;
+    const double support_bound = 100.;
+
+    SECTION("Single Sigmoid") {
+        Kokkos::View<double*, MemorySpace> center("Sigmoid Centers", 1);
+        Kokkos::View<double*, MemorySpace> width("Sigmoid Centers", 1);
+        Kokkos::View<double*, MemorySpace> coeff("Sigmoid coeff", 1);
+        center(0) = 0; width(0) = 1;
+        Sigmoid1d<MemorySpace,TestType> Sigmoid (center, width);
+        for(int coeff_int = 1; coeff_int <= 2; coeff_int++) {
+            coeff(0) = (double) coeff_int;
+            Sigmoid.WrapCoeffs(coeff);
+            Kokkos::View<double**, MemorySpace> evalPts("Input point", 1, 3);
+            evalPts(0,0) = -support_bound; evalPts(0,1) = 0.0; evalPts(0,2) = support_bound;
+            StridedMatrix<double,MemorySpace> out = Sigmoid.Evaluate(evalPts);
+            double approxTol = 1e-5;
+            REQUIRE_THAT(out(0,0), Matchers::WithinAbs(coeff_int*0.0, approxTol));
+            REQUIRE_THAT(out(0,1), Matchers::WithinAbs(coeff_int*0.5, approxTol));
+            REQUIRE_THAT(out(0,2), Matchers::WithinAbs(coeff_int*1.0, approxTol));
+        }
+        TestSigmoidGradients(Sigmoid, N_grad_points, fd_delta, coeff);
     }
     SECTION("Multiple Sigmoids") {
-        int N_Sigmoid = 3;
-        Kokkos::View<double*, MemorySpace> centers("Sigmoid Centers", N_Sigmoid);
-        Kokkos::View<double*, MemorySpace> widths("Sigmoid Centers", N_Sigmoid);
+        int N_sigmoid = 3;
+        Kokkos::View<double*, MemorySpace> centers("Sigmoid Centers", N_sigmoid);
+        Kokkos::View<double*, MemorySpace> widths("Sigmoid Centers", N_sigmoid);
         Sigmoid1d<MemorySpace,TestType> Sigmoid (centers, widths);
-        Kokkos::View<double*, MemorySpace> coeffs("Sigmoid Coefficients", N_Sigmoid);
-        for(int j = 0; j < N_Sigmoid; j++) coeffs(j) = 0.5*(j+1);
+        Kokkos::View<double*, MemorySpace> coeffs("Sigmoid Coefficients", N_sigmoid);
+        for(int j = 0; j < N_sigmoid; j++) {
+            centers(j) = 1-0.75*j;
+            widths(j) = 2*(j+1);
+        }
         Sigmoid.WrapCoeffs(coeffs);
+        for(int coeff_int = 1; coeff_int <= 2; coeff_int++) {
+            double coeff_sum = 0.;
+            for(int j = 1; j < N_sigmoid; j++) {
+                double coeff_j = 0.5*((double) N_sigmoid*(j+1));
+                coeffs(j) = coeff_j;
+                coeff_sum += coeff_j;
+            }
+            Kokkos::View<double**, MemorySpace> evalPts("Input point", 1, N_sigmoid+2);
+            evalPts(0,0) = -support_bound; evalPts(0,1) = support_bound;
+            Kokkos::View<double*, MemorySpace> expectedEval("Expected output", N_sigmoid);
+            for(int j = 0; j < N_sigmoid; j++) {
+                double pt_j = centers(j);
+                evalPts(0,j+2) = pt_j;
+                double exp_eval_j = 0.;
+                for(int k = 0; k < N_sigmoid; k++) {
+                    exp_eval_j += coeffs(k)*TestType::Evaluate(widths(k)*(pt_j - centers(k)));
+                }
+                expectedEval(j) = exp_eval_j;
+            }
+            StridedMatrix<double,MemorySpace> out = Sigmoid.Evaluate(evalPts);
+            double approxTol = 1e-5;
+            REQUIRE_THAT(out(0,0), Matchers::WithinAbs(0.0      , approxTol));
+            REQUIRE_THAT(out(0,1), Matchers::WithinAbs(coeff_sum, approxTol));
+            for(int j = 0; j < N_sigmoid; j++) {
+                REQUIRE_THAT(out(0,j+2), Matchers::WithinAbs(expectedEval(j), approxTol));
+            }
+        }
+        TestSigmoidGradients(Sigmoid, N_grad_points, fd_delta, coeffs);
     }
 }


### PR DESCRIPTION
- Creates linear sigmoid 1d basis (often called "RBFs", we actually care about using the integral of the RBF, which is a sigmoid function in most literature)
- Allows for centers and widths to allow for more expressible functions
- Moves the 1d root finding to external file, which will be needed for multiple different function representations (and also cleans up the file)