### PR TITLE
Fixed bug in `FixedMultiindexSet` python bindings

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,20 +5,20 @@ cff-version: 1.2.0
 title: Monotone Parameterization Toolkit (MParT)
 message: 'If you use MParT, please cite it as below.'
 type: software
-version: 1.4.0
+version: 2.0.3
 authors:
   - given-names: Matthew
     family-names: Parno
     email: parnomd@gmail.com
     orcid: https://orcid.org/0000-0002-9419-2693
-  - given-names: Paul-Baptiste
-    family-names: Rubio
-    email: rubiop@mit.edu
-    orcid: https://orcid.org/0000-0002-9765-1162
   - given-names: Daniel
     family-names: Sharp
     email: dannys4@vt.edu
     orcid: https://orcid.org/0000-0002-0439-5084
+  - given-names: Paul-Baptiste
+    family-names: Rubio
+    email: rubiop@mit.edu
+    orcid: https://orcid.org/0000-0002-9765-1162
   - given-names: Michael
     family-names: Brennan
     email: mcbrenn@mit.edu

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ cff-version: 1.2.0
 title: Monotone Parameterization Toolkit (MParT)
 message: 'If you use MParT, please cite it as below.'
 type: software
-version: 2.0.3
+version: 2.1.1
 authors:
   - given-names: Matthew
     family-names: Parno

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.13)
-project(MParT VERSION 2.0.3)
+project(MParT VERSION 2.1.1)
 
 message(STATUS "Will install MParT to ${CMAKE_INSTALL_PREFIX}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.13)
-project(MParT VERSION 2.0.2)
+project(MParT VERSION 2.0.3)
 
 message(STATUS "Will install MParT to ${CMAKE_INSTALL_PREFIX}")
 

--- a/MParT/TrainMapAdaptive.h
+++ b/MParT/TrainMapAdaptive.h
@@ -20,7 +20,7 @@ struct ATMOptions: public MapOptions, public TrainOptions {
     /** Maximum number of iterations that do not improve error */
     unsigned int maxPatience = 10;
     /** Maximum number of coefficients in final expansion (including ALL dimensions of map) */
-    unsigned int maxSize = std::numeric_limits<unsigned int>::infinity();
+    unsigned int maxSize = std::numeric_limits<int>::max(); // <- use this instead of infinity because python doesn't have infinite ints
     /** Multiindex representing the maximum degree in each input dimension */
     MultiIndex maxDegrees;
 

--- a/MParT/Utilities/ArrayConversions.h
+++ b/MParT/Utilities/ArrayConversions.h
@@ -145,7 +145,7 @@ namespace mpart{
     template<typename ScalarType, class MemorySpace>
     StridedVector<ScalarType, MemorySpace> ConstVecToKokkos(const std::vector<ScalarType> &vec)
     {
-        double* ptr = const_cast<double*>(vec.data());
+        ScalarType* ptr = const_cast<ScalarType*>(vec.data());
         return Kokkos::View<ScalarType*, MemorySpace>(ptr, vec.size());
     }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ license={file="LICENSE.txt"}
 readme="README.md"
 requires-python = ">=3.7"
 description="A Monotone Parameterization Toolkit"
-version="2.0.3"
+version="2.1.1"
 keywords=["Measure Transport", "Monotone", "Transport Map", "Isotonic Regression", "Triangular", "Knothe-Rosenblatt"]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ license={file="LICENSE.txt"}
 readme="README.md"
 requires-python = ">=3.7"
 description="A Monotone Parameterization Toolkit"
-version="2.0.2"
+version="2.0.3"
 keywords=["Measure Transport", "Monotone", "Transport Map", "Isotonic Regression", "Triangular", "Knothe-Rosenblatt"]
 
 [project.urls]

--- a/setup.py
+++ b/setup.py
@@ -37,5 +37,5 @@ setup(
     package_dir={'mpart': 'bindings/python/package'},
     package_data={'mpart':['**/*pympart*']},
     include_package_data=True,
-    cmake_args=['-DKokkos_ENABLE_THREADS:BOOL=ON', f'-DSKBUILD_LIB_RPATH={lib_folder}', f'-DSKBUILD_SITE_PATH={site_folder}', '-DPYTHON_INSTALL_SUFFIX=bindings/python/package/', '-DMPART_JULIA:BOOL=OFF', '-DMPART_MATLAB:BOOL=OFF', '-DMPART_BUILD_TESTS:BOOL=OFF', '-DMPART_PYTHON:BOOL=ON', '-DPYTHON_INSTALL_PREFIX=']
+    cmake_args=['-DKokkos_ENABLE_THREADS:BOOL=ON', '-DKokkos_ENABLE_THREADS=ON', f'-DSKBUILD_LIB_RPATH={lib_folder}', f'-DSKBUILD_SITE_PATH={site_folder}', '-DPYTHON_INSTALL_SUFFIX=bindings/python/package/', '-DMPART_JULIA:BOOL=OFF', '-DMPART_MATLAB:BOOL=OFF', '-DMPART_BUILD_TESTS:BOOL=OFF', '-DMPART_PYTHON:BOOL=ON', '-DPYTHON_INSTALL_PREFIX=']
 )


### PR DESCRIPTION
Segfaults were occurring when manually creating a `FixedMultiIndexSet` in python because of a shallow copy of a temporary vector in the python bindings for the `FixedMultiIndexSet` constructor.  This PR fixes the issue with deep copies.

Also fixes a bug in the `ConstVecToKokkos` function that showed up when exploring fixes to the python bindings.