### PR TITLE
Fix silent hang in map inversion.

### DIFF
--- a/MParT/MonotoneComponent.h
+++ b/MParT/MonotoneComponent.h
@@ -400,7 +400,7 @@ public:
 
                 // Compute the inverse
                 Kokkos::View<double*,MemorySpace> workspace(team_member.thread_scratch(1), workspaceSize);
-                auto eval = SingleEvaluator(workspace.data(), cache.data(), pt, coeffs, quad_, expansion_);
+                auto eval = SingleEvaluator<decltype(pt),decltype(coeffs)>(workspace.data(), cache.data(), pt, coeffs, quad_, expansion_);
                 output(ptInd) = RootFinding::InverseSingleBracket<MemorySpace>(ys(ptInd), eval, pt(pt.extent(0)-1), xtol, ytol);
             }
         };

--- a/MParT/Utilities/Miscellaneous.h
+++ b/MParT/Utilities/Miscellaneous.h
@@ -22,7 +22,7 @@ namespace mpart{
     template<typename MemorySpace, typename ErrorType>
     struct ProcAgnosticError {
         static void error(const char*) {
-            assert(0);
+            assert(false);
         }
     };
 

--- a/MParT/Utilities/Miscellaneous.h
+++ b/MParT/Utilities/Miscellaneous.h
@@ -19,6 +19,9 @@ namespace mpart{
                           std::string                                 const& key,
                           std::string                                 const& defaultValue);
 
+    /** Provides a mechanism for raising exceptions in CPU code where recovery is possible 
+        and assertions in GPU code where exceptions aren't alllowed.
+     */
     template<typename MemorySpace, typename ErrorType>
     struct ProcAgnosticError {
         static void error(const char*) {

--- a/MParT/Utilities/RootFinding.h
+++ b/MParT/Utilities/RootFinding.h
@@ -43,9 +43,9 @@ KOKKOS_INLINE_FUNCTION void FindBracket(FunctorType f,
             xlb = xub-stepSize;
             ylb = f(xlb);
             
-            if(abs((yub-ylb)/(xub-xlb))<1e-12){
+            if((fabs((yub-ylb)/(xub-xlb))<1e-12)&&((xub-xlb)>10)){
                 info = -1;
-                break;
+                return;
             }
 
             if(ylb>yd){
@@ -67,11 +67,11 @@ KOKKOS_INLINE_FUNCTION void FindBracket(FunctorType f,
         for(i=0; i<maxIts; ++i){ // Could just be while(true), but want to avoid infinite loop
             xub = xlb+stepSize;
             yub = f(xub);
-          
-            // Check to see if function is perfectly flat
-            if(abs((yub-ylb)/(xub-xlb))<1e-12){
+
+            // Check to see if function is perfectly flat over a wide region
+            if((fabs((yub-ylb)/(xub-xlb))<1e-12)&&((xub-xlb)>10)){
                 info = -1;
-                break;
+                return;
             }
 
             if(yub<yd){
@@ -128,6 +128,7 @@ KOKKOS_INLINE_FUNCTION double InverseSingleBracket(double yd, FunctorType f, dou
     // Compute initial bracket containing the root
     int bracket_info = 0;
     FindBracket<MemorySpace>(f, xlb, ylb, xub, yub, yd, bracket_info);
+    
     if((bracket_info<0)||(((ylb>yd)||(yub<yd)))){
         info = -2;
         return std::numeric_limits<double>::quiet_NaN();
@@ -142,7 +143,6 @@ KOKKOS_INLINE_FUNCTION double InverseSingleBracket(double yd, FunctorType f, dou
     unsigned int it;
     for(it=0; it<maxIts; ++it){
         
-        //std::cout << "Iteration " << it << std::endl;
         xc = Find_x_ITP(xlb, xub, yd, ylb, yub, k1, k2, nhalf, n0, it, xtol);
 
         yc = f(xc);

--- a/MParT/Utilities/RootFinding.h
+++ b/MParT/Utilities/RootFinding.h
@@ -18,16 +18,15 @@ KOKKOS_INLINE_FUNCTION void FindBracket(FunctorType f,
                                         double& xub, double& yub,
                                         const double yd)
 {
-    double xb, xf; // Bisection point and regula falsi point
-    double xc, yc;
     const unsigned int maxIts = 1000;
     double stepSize = 1.0;
-
-    ylb = f(xb);
-
+    
+    ylb = f(xlb);
+    yub = f(xub);
+    
     // We actually found an upper bound...
     if(ylb>yd){
-
+    
         mpart::simple_swap(ylb,yub);
         mpart::simple_swap(xlb,xub);
 
@@ -67,7 +66,7 @@ KOKKOS_INLINE_FUNCTION void FindBracket(FunctorType f,
         if(i>=maxIts)
             ProcAgnosticError<MemorySpace,std::runtime_error>::error("FindBracket: Could not find initial bracket such that f(xlb)<yd and f(xub)>yd.");
     }
-}
+ }
 
 KOKKOS_INLINE_FUNCTION double Find_x_ITP(double xlb, double xub, double yd, double ylb, double yub,
                            double k1, double k2, double nhalf, double n0, int it, double xtol) {
@@ -88,7 +87,6 @@ KOKKOS_INLINE_FUNCTION double Find_x_ITP(double xlb, double xub, double yd, doub
 template<typename MemorySpace, typename FunctorType>
 KOKKOS_INLINE_FUNCTION double InverseSingleBracket(double yd, FunctorType f, double x0, const double xtol, const double ftol)
 {   
-    std::cout << "Hereherehere" << std::endl;
     double stepSize=1.0;
     const unsigned int maxIts = 10000;
 
@@ -101,9 +99,7 @@ KOKKOS_INLINE_FUNCTION double InverseSingleBracket(double yd, FunctorType f, dou
     ylb = yub = f(xlb);
 
     // Compute bounds
-    std::cout << "About to call find bracket..." << std::endl;
     FindBracket<MemorySpace>(f, xlb, ylb, xub, yub, yd);
-    std::cout << "done " << xlb << ", " << xub << ", " << ylb << ", " << yub << std::endl;
     assert(ylb<yub);
     assert(xlb<xub);
 
@@ -115,9 +111,7 @@ KOKKOS_INLINE_FUNCTION double InverseSingleBracket(double yd, FunctorType f, dou
 
     unsigned int it;
     for(it=0; it<maxIts; ++it){
-        std::cout << " about to call Find_x_ITP" << std::endl;
         xc = Find_x_ITP(xlb, xub, yd, ylb, yub, k1, k2, nhalf, n0, it, xtol);
-        std::cout << " done" << std::endl;
 
         yc = f(xc);
 

--- a/tests/Test_RootFinding.cpp
+++ b/tests/Test_RootFinding.cpp
@@ -30,7 +30,7 @@ TEST_CASE( "RootFindingUtils", "[RootFindingUtils]") {
         double yd = identity(xd);
         double xub = 2., yub = 2.;
         double xlb = 0., ylb = 0.;
-        FindBracket<HostSpace>(identity, xlb, ylb, xub, ylb, 10'000);
+        FindBracket<HostSpace>(identity, xlb, ylb, xub, yub, yd);
         CheckFoundBounds(identity, xlb, xd, xub, ylb, yd, yub);
     }
     SECTION("FindBracker sigmoid") {
@@ -38,7 +38,7 @@ TEST_CASE( "RootFindingUtils", "[RootFindingUtils]") {
         double yd = sigmoid(xd);
         double xub =  2., yub = sigmoid(xub);
         double xlb =  0., ylb = sigmoid(xlb);
-        FindBracket<HostSpace>(sigmoid, xlb, ylb, xub, ylb, 10'000);
+        FindBracket<HostSpace>(sigmoid, xlb, ylb, xub, yub, yd);
         CheckFoundBounds(sigmoid, xlb, xd, xub, ylb, yd, yub);
     }
     SECTION("Test Inverse Linear, low x0") {

--- a/tests/Test_RootFinding.cpp
+++ b/tests/Test_RootFinding.cpp
@@ -23,36 +23,22 @@ TEST_CASE( "RootFindingUtils", "[RootFindingUtils]") {
     auto identity = [](double x){return x;};
     auto sigmoid = [](double x){return 1./(std::exp(-x)+1);};
     auto sigmoid_combo = [sigmoid](double x){return sigmoid(2*(x-1)) + 3*sigmoid(x*0.5) + 0.5*sigmoid(1.5*(x+1));};
-    SECTION("FindBound lower linear") {
+    
+    
+    SECTION("FindBracket linear") {
         double xd = -1.1;
         double yd = identity(xd);
         double xub = 2., yub = 2.;
         double xlb = 0., ylb = 0.;
-        FindBound<HostSpace>(false, yd, identity, xub, yub, xlb, ylb, 10'000);
+        FindBracket<HostSpace>(identity, xlb, ylb, xub, ylb, 10'000);
         CheckFoundBounds(identity, xlb, xd, xub, ylb, yd, yub);
     }
-    SECTION("FindBound upper linear") {
-        double xd = 1.1;
-        double yd = identity(xd);
-        double xub = 0., yub = 0.;
-        double xlb = -2., ylb = -2.;
-        FindBound<HostSpace>(true, yd, identity, xlb, ylb, xub, yub, 10'000);
-        CheckFoundBounds(identity, xlb, xd, xub, ylb, yd, yub);
-    }
-    SECTION("FindBound lower sigmoid") {
+    SECTION("FindBracker sigmoid") {
         double xd = -0.5;
         double yd = sigmoid(xd);
         double xub =  2., yub = sigmoid(xub);
         double xlb =  0., ylb = sigmoid(xlb);
-        FindBound<HostSpace>(false, yd, sigmoid, xub, yub, xlb, ylb, 10'000);
-        CheckFoundBounds(sigmoid, xlb, xd, xub, ylb, yd, yub);
-    }
-    SECTION("FindBound upper sigmoid") {
-        double xd = 0.5;
-        double yd = sigmoid(xd);
-        double xub =  0., yub = sigmoid(xub);
-        double xlb = -2., ylb = sigmoid(xlb);
-        FindBound<HostSpace>(true, yd, sigmoid, xlb, ylb, xub, yub, 10'000);
+        FindBracket<HostSpace>(sigmoid, xlb, ylb, xub, ylb, 10'000);
         CheckFoundBounds(sigmoid, xlb, xd, xub, ylb, yd, yub);
     }
     SECTION("Test Inverse Linear, low x0") {

--- a/tests/Test_RootFinding.cpp
+++ b/tests/Test_RootFinding.cpp
@@ -30,52 +30,87 @@ TEST_CASE( "RootFindingUtils", "[RootFindingUtils]") {
         double yd = identity(xd);
         double xub = 2., yub = 2.;
         double xlb = 0., ylb = 0.;
-        FindBracket<HostSpace>(identity, xlb, ylb, xub, yub, yd);
+        int info = 0;
+        FindBracket<HostSpace>(identity, xlb, ylb, xub, yub, yd, info);
         CheckFoundBounds(identity, xlb, xd, xub, ylb, yd, yub);
+        CHECK(info==0);
     }
     SECTION("FindBracker sigmoid") {
         double xd = -0.5;
         double yd = sigmoid(xd);
         double xub =  2., yub = sigmoid(xub);
         double xlb =  0., ylb = sigmoid(xlb);
-        FindBracket<HostSpace>(sigmoid, xlb, ylb, xub, yub, yd);
+        int info = 0;
+        FindBracket<HostSpace>(sigmoid, xlb, ylb, xub, yub, yd, info);
         CheckFoundBounds(sigmoid, xlb, xd, xub, ylb, yd, yub);
+        CHECK(info==0);
+    }
+    SECTION("FindBracket flat") {
+        double xd = -1.1;
+        double yd = 0.0;
+        double xub = 2., yub = -1.0;
+        double xlb = 0., ylb = -1.0;
+        int info = 0;
+        auto f = [](double x){return -1.0;};
+        FindBracket<HostSpace>(f, xlb, ylb, xub, yub, yd, info);
+        CHECK(info==-1);
     }
     SECTION("Test Inverse Linear, low x0") {
         double xd = 0.5, yd = identity(xd);
         double x0 = 0.0, xtol = 1e-5, ftol = 1e-5;
-        double xd_found = InverseSingleBracket<HostSpace>(yd, identity, x0, xtol, ftol);
+        int info = 0;
+        double xd_found = InverseSingleBracket<HostSpace>(yd, identity, x0, xtol, ftol, info);
         CHECK( xd_found == Approx(xd).epsilon(2*xtol));
+        CHECK(info==0);
     }
     SECTION("Test Inverse Linear, high x0") {
         double xd = 0.5, yd = identity(xd);
         double x0 = 1.0, xtol = 1e-5, ftol = 1e-5;
-        double xd_found = InverseSingleBracket<HostSpace>(yd, identity, x0, xtol, ftol);
+        int info = 0;
+        double xd_found = InverseSingleBracket<HostSpace>(yd, identity, x0, xtol, ftol, info);
         CHECK( xd_found == Approx(xd).epsilon(2*xtol));
+        CHECK(info==0);
+    }
+    SECTION("Test Inverse Flat") {
+        double xd = 0.5, yd = -1.0;
+        double x0 = 0.0, xtol = 1e-5, ftol = 1e-5;
+        auto f = [](double x){return -1.0;};
+        int info = 0;
+        double xd_found = InverseSingleBracket<HostSpace>(yd, f, x0, xtol, ftol, info);
+        CHECK( std::isnan(xd_found));
+        CHECK(info==-2);
     }
     SECTION("Test Inverse Sigmoid, low x0") {
         double xd = 0.5, yd = sigmoid(xd);
         double x0 = 0.0, xtol = 1e-5, ftol = 1e-5;
-        double xd_found = InverseSingleBracket<HostSpace>(yd, sigmoid, x0, xtol, ftol);
+        int info = 0;
+        double xd_found = InverseSingleBracket<HostSpace>(yd, sigmoid, x0, xtol, ftol, info);
         CHECK( xd_found == Approx(xd).epsilon(2*xtol));
+        CHECK(info==0);
     }
     SECTION("Test Inverse Sigmoid, high x0") {
         double xd = 0.5, yd = sigmoid(xd);
         double x0 = 1.0, xtol = 1e-5, ftol = 1e-5;
-        double xd_found = InverseSingleBracket<HostSpace>(yd, sigmoid, x0, xtol, ftol);
+        int info;
+        double xd_found = InverseSingleBracket<HostSpace>(yd, sigmoid, x0, xtol, ftol, info);
         CHECK( xd_found == Approx(xd).epsilon(2*xtol));
+        CHECK(info==0);
     }
     SECTION("Test Inverse Sigmoid Combo, low x0") {
         double xd = 0.5, yd = sigmoid_combo(xd);
         double x0 = -5.0, xtol = 1e-5, ftol = 1e-5;
-        double xd_found = InverseSingleBracket<HostSpace>(yd, sigmoid_combo, x0, xtol, ftol);
+        int info;
+        double xd_found = InverseSingleBracket<HostSpace>(yd, sigmoid_combo, x0, xtol, ftol, info);
         CHECK( xd_found == Approx(xd).epsilon(2*xtol));
+        CHECK(info==0);
     }
     SECTION("Test Inverse Sigmoid Combo, high x0") {
         double xd = 0.5, yd = sigmoid_combo(xd);
         double x0 = 5.0, xtol = 1e-5, ftol = 1e-5;
-        double xd_found = InverseSingleBracket<HostSpace>(yd, sigmoid_combo, x0, xtol, ftol);
+        int info;
+        double xd_found = InverseSingleBracket<HostSpace>(yd, sigmoid_combo, x0, xtol, ftol, info);
         CHECK( xd_found == Approx(xd).epsilon(2*xtol));
+        CHECK(info==0);
     }
 
 }

--- a/tests/Test_RootFinding.cpp
+++ b/tests/Test_RootFinding.cpp
@@ -24,7 +24,6 @@ TEST_CASE( "RootFindingUtils", "[RootFindingUtils]") {
     auto sigmoid = [](double x){return 1./(std::exp(-x)+1);};
     auto sigmoid_combo = [sigmoid](double x){return sigmoid(2*(x-1)) + 3*sigmoid(x*0.5) + 0.5*sigmoid(1.5*(x+1));};
     
-    
     SECTION("FindBracket linear") {
         double xd = -1.1;
         double yd = identity(xd);
@@ -46,7 +45,6 @@ TEST_CASE( "RootFindingUtils", "[RootFindingUtils]") {
         CHECK(info==0);
     }
     SECTION("FindBracket flat") {
-        double xd = -1.1;
         double yd = 0.0;
         double xub = 2., yub = -1.0;
         double xlb = 0., ylb = -1.0;
@@ -72,7 +70,7 @@ TEST_CASE( "RootFindingUtils", "[RootFindingUtils]") {
         CHECK(info==0);
     }
     SECTION("Test Inverse Flat") {
-        double xd = 0.5, yd = -1.0;
+        double xd = 0.5, yd = 0.0;
         double x0 = 0.0, xtol = 1e-5, ftol = 1e-5;
         auto f = [](double x){return -1.0;};
         int info = 0;


### PR DESCRIPTION
We were running into issues where an initial bracket could not be found during the map inversion because the map was essentially flat.  In this situation, the inverse would just hang.  This PR changes the way error handling is done inside the bracketed inverse to avoid this silent hang.  It also adds a basic check to determine of the function we're tracking to bracket is essentially flat.