### PR TITLE
Integration Nugget

### DIFF
--- a/MParT/MapFactory.h
+++ b/MParT/MapFactory.h
@@ -28,6 +28,7 @@ namespace mpart{
     options.quadRelTol = 1e-6;                          // Optional. Default = 1e-6
     options.quadMaxSub = 10;                            // Optional. Default = 30
     options.contDeriv = true;                           // Optional. Default = true
+    options.nugget = 1e-4;                              // Optional. Default = 0.0
 
     // Create a triangular map with these options
     unsigned int inDim = 4;

--- a/MParT/MapOptions.h
+++ b/MParT/MapOptions.h
@@ -96,11 +96,14 @@ namespace mpart{
         /** If orthogonal polynomial basis functions should be normalized. */
         bool basisNorm = true;
 
+        /** The minimum slope of the monotone component.  This nugget is added to the g(df) integrand. Must be non-negative. */
+        double nugget = 0.0;
+
         #if defined(MPART_HAS_CEREAL)
         template<class Archive>
         void serialize(Archive &archive)
         {
-            archive( basisType, basisLB, basisUB, posFuncType, quadType, quadAbsTol, quadRelTol, quadMaxSub, quadMinSub, quadPts, contDeriv, basisNorm );
+            archive( basisType, basisLB, basisUB, posFuncType, quadType, quadAbsTol, quadRelTol, quadMaxSub, quadMinSub, quadPts, contDeriv, basisNorm, nugget);
         }
         #endif // MPART_HAS_CEREAL
 
@@ -118,6 +121,7 @@ namespace mpart{
             ret &= (quadPts     == opts2.quadPts);
             ret &= (contDeriv   == opts2.contDeriv);
             ret &= (basisNorm   == opts2.basisNorm);
+            ret &= (nugget      == opts2.nugget);
             return ret;
         }
 
@@ -137,7 +141,8 @@ namespace mpart{
             ss << "quadMaxSub = " << quadMaxSub << "\n";
             ss << "quadMinSub = " << quadMinSub << "\n";
             ss << "quadPts = " << quadPts << "\n";
-            ss << "contDeriv = " << (contDeriv ? "true" : "false");
+            ss << "contDeriv = " << (contDeriv ? "true" : "false") << "\n";
+            ss << "nugget = " << nugget << "\n";
             return ss.str();
         }
     };

--- a/bindings/julia/src/MapOptions.cpp
+++ b/bindings/julia/src/MapOptions.cpp
@@ -42,6 +42,7 @@ void mpart::binding::MapOptionsWrapper(jlcxx::Module &mod) {
         .method("__quadMinSub!", [](MapOptions &opts, unsigned int sub){ opts.quadMinSub = sub; })
         .method("__quadPts!", [](MapOptions &opts, unsigned int pts){ opts.quadPts = pts; })
         .method("__contDeriv!", [](MapOptions &opts, bool deriv){ opts.contDeriv = deriv; })
+        .method("__nugget!", [](MapOptions &opts, double nugget){ opts.nugget = nugget; })
         .method("Serialize", [](MapOptions &opts, std::string &filename){
 #if defined(MPART_HAS_CEREAL)
             std::ofstream os (filename);

--- a/bindings/matlab/include/MexOptionsConversions.h
+++ b/bindings/matlab/include/MexOptionsConversions.h
@@ -15,7 +15,8 @@ namespace binding{
                                      std::string quadType, double quadAbsTol,
                                      double quadRelTol, unsigned int quadMaxSub,
                                      unsigned int quadMinSub,unsigned int quadPts,
-                                     bool contDeriv, double basisLB, double basisUB, bool basisNorm);
+                                     bool contDeriv, double basisLB, double basisUB, 
+                                     bool basisNorm, double nugget);
 
     void MapOptionsToMatlab(MapOptions opts, mexplus::OutputArguments &output, int start = 0);
 #if defined(MPART_HAS_NLOPT)

--- a/bindings/matlab/mat/MapOptions/MapOptions.m
+++ b/bindings/matlab/mat/MapOptions/MapOptions.m
@@ -12,6 +12,7 @@ classdef MapOptions
         basisLB = log(0);
         basisUB = 1.0/0.0;
         basisNorm = true;
+        nugget = 0.0;
     end
 
     methods
@@ -51,6 +52,9 @@ classdef MapOptions
         function obj = set.contDeriv(obj,value)
             obj.contDeriv = value;
         end
+        function obj = set.nugget(obj,value)
+            obj.nugget = value;
+        end
         function optionsArray = getMexOptions(obj)
             optionsArray{1} = char(obj.basisType);
             optionsArray{2} = char(obj.posFuncType);
@@ -64,6 +68,7 @@ classdef MapOptions
             optionsArray{10} = obj.basisLB;
             optionsArray{11} = obj.basisUB;
             optionsArray{12} = obj.basisNorm;
+            optionsArray{13} = obj.nugget;
         end
 
         function res = eq(obj1, obj2)
@@ -80,17 +85,18 @@ classdef MapOptions
             res = res && isequal(obj1.quadMinSub,  obj2.quadMinSub);
             res = res && isequal(obj1.quadPts,     obj2.quadPts);
             res = res && isequal(obj1.contDeriv,   obj2.contDeriv);
+            res = res && isequal(obj1.nugget,      obj2.nugget);
         end
 
         function Serialize(obj,filename)
             MParT_('MapOptions_Serialize',filename, char(obj.basisType),  ...
              char(obj.posFuncType), char(obj.quadType), obj.quadAbsTol,   ...
              obj.quadRelTol, obj.quadMaxSub, obj.quadMinSub, obj.quadPts, ...
-             obj.contDeriv, obj.basisLB, obj.basisUB, obj.basisNorm)
+             obj.contDeriv, obj.basisLB, obj.basisUB, obj.basisNorm, obj.nugget)
         end
 
         function obj = Deserialize(obj,filename)
-            options_len = 12;
+            options_len = 13;
             optionsArray = cell(options_len,1);
             input_str = [']=MParT_(',char(39),'MapOptions_Deserialize',char(39),',filename);'];
             for i=options_len:-1:1
@@ -114,6 +120,7 @@ classdef MapOptions
             obj.basisLB = optionsArray{10};
             obj.basisUB = optionsArray{11};
             obj.basisNorm = optionsArray{12};
+            obj.nugget = optionsArray{13};
         end
     end
 

--- a/bindings/matlab/src/ConditionalMap_mex.cpp
+++ b/bindings/matlab/src/ConditionalMap_mex.cpp
@@ -126,7 +126,7 @@ MEX_DEFINE(ConditionalMap_newTotalTriMap) (int nlhs, mxArray* plhs[],
                                          input.get<std::string>(5),input.get<double>(6),
                                          input.get<double>(7),input.get<unsigned int>(8),
                                          input.get<unsigned int>(9),input.get<unsigned int>(10),
-                                         input.get<bool>(11),input.get<double>(12),input.get<double>(13),input.get<bool>(14));
+                                         input.get<bool>(11),input.get<double>(12),input.get<double>(13),input.get<bool>(14), input.get<double>(15));
 
   output.set(0, Session<ConditionalMapMex>::create(new ConditionalMapMex(inputDim,outputDim,totalOrder,opts)));
 }
@@ -141,7 +141,7 @@ MEX_DEFINE(ConditionalMap_newMap) (int nlhs, mxArray* plhs[],
                                          input.get<std::string>(3),input.get<double>(4),
                                          input.get<double>(5),input.get<unsigned int>(6),
                                          input.get<unsigned int>(7),input.get<unsigned int>(8),
-                                         input.get<bool>(9),input.get<double>(10),input.get<double>(11),input.get<bool>(12));
+                                         input.get<bool>(9),input.get<double>(10),input.get<double>(11),input.get<bool>(12), input.get<double>(13));
 
   output.set(0, Session<ConditionalMapMex>::create(new ConditionalMapMex(mset.Fix(),opts)));
 }
@@ -156,7 +156,7 @@ MEX_DEFINE(ConditionalMap_newMapFixed) (int nlhs, mxArray* plhs[],
                                          input.get<std::string>(3),input.get<double>(4),
                                          input.get<double>(5),input.get<unsigned int>(6),
                                          input.get<unsigned int>(7),input.get<unsigned int>(8),
-                                         input.get<bool>(9),input.get<double>(10),input.get<double>(11),input.get<bool>(12));
+                                         input.get<bool>(9),input.get<double>(10),input.get<double>(11),input.get<bool>(12), input.get<double>(13));
 
   output.set(0, Session<ConditionalMapMex>::create(new ConditionalMapMex(mset,opts)));
 }

--- a/bindings/matlab/src/MexOptionsConversions.cpp
+++ b/bindings/matlab/src/MexOptionsConversions.cpp
@@ -7,7 +7,7 @@ MapOptions  mpart::binding::MapOptionsFromMatlab(std::string basisType, std::str
                                         std::string quadType, double quadAbsTol,
                                         double quadRelTol, unsigned int quadMaxSub,
                                         unsigned int quadMinSub,unsigned int quadPts,
-                                        bool contDeriv, double basisLB, double basisUB, bool basisNorm)
+                                        bool contDeriv, double basisLB, double basisUB, bool basisNorm, double nugget)
 {
     MapOptions opts;
 
@@ -48,6 +48,7 @@ MapOptions  mpart::binding::MapOptionsFromMatlab(std::string basisType, std::str
     opts.basisLB = basisLB;
     opts.basisUB = basisUB;
     opts.basisNorm = basisNorm;
+    opts.nugget = nugget;
     return opts;
 }
 

--- a/bindings/matlab/src/MexOptionsConversions.cpp
+++ b/bindings/matlab/src/MexOptionsConversions.cpp
@@ -82,6 +82,7 @@ void mpart::binding::MapOptionsToMatlab(MapOptions opts, mexplus::OutputArgument
     output.set(i+9,opts.basisLB);
     output.set(i+10,opts.basisUB);
     output.set(i+11,opts.basisNorm);
+    output.set(i+12,opts.nugget);
 }
 
 #if defined(MPART_HAS_NLOPT)

--- a/bindings/matlab/src/ParameterizedFunctionBase_mex.cpp
+++ b/bindings/matlab/src/ParameterizedFunctionBase_mex.cpp
@@ -47,7 +47,7 @@ MEX_DEFINE(ParameterizedFunction_newMap) (int nlhs, mxArray* plhs[],
                                          input.get<std::string>(4),input.get<double>(5),
                                          input.get<double>(6),input.get<unsigned int>(7),
                                          input.get<unsigned int>(8),input.get<unsigned int>(9),
-                                         input.get<bool>(10),input.get<double>(11),input.get<double>(12),input.get<bool>(13));
+                                         input.get<bool>(10),input.get<double>(11),input.get<double>(12),input.get<bool>(13),input.get<double>(14));
 
   output.set(0, Session<ParameterizedFunctionMex>::create(new ParameterizedFunctionMex(outputDim,mset.Fix(),opts)));
 }
@@ -213,7 +213,7 @@ MEX_DEFINE(MapOptions_Serialize) (int nlhs, mxArray* plhs[],
                                          input.get<std::string>(3),input.get<double>(4),
                                          input.get<double>(5),input.get<unsigned int>(6),
                                          input.get<unsigned int>(7),input.get<unsigned int>(8),
-                                         input.get<bool>(9),input.get<double>(10),input.get<double>(11),input.get<bool>(12));
+                                         input.get<bool>(9),input.get<double>(10),input.get<double>(11),input.get<bool>(12),input.get<double>(13));
   std::ofstream os (filename);
   cereal::BinaryOutputArchive oarchive(os);
   oarchive(opts);

--- a/bindings/python/src/MapOptions.cpp
+++ b/bindings/python/src/MapOptions.cpp
@@ -52,6 +52,7 @@ void mpart::binding::MapOptionsWrapper(py::module &m)
     .def_readwrite("quadMinSub", &MapOptions::quadMinSub)
     .def_readwrite("quadPts", &MapOptions::quadPts)
     .def_readwrite("contDeriv", &MapOptions::contDeriv)
+    .def_readwrite("nugget", &MapOptions::nugget)
     #if defined(MPART_HAS_CEREAL)
     .def("Serialize", [](MapOptions const &opts, std::string const &filename){
         std::ofstream os (filename);

--- a/docs/source/mathematics.rst
+++ b/docs/source/mathematics.rst
@@ -17,14 +17,14 @@ While there are infinitely many transformations that couple densities, if :math:
 Monotone Parameterizations
 --------------------------
 
-We represent monotone functions as the smooth transformation of an unconstrained function :math:`f\colon\mathbb{R}^{d} \rightarrow \mathbb{R}`. Let :math:`g\colon\mathbb{R}\rightarrow \mathbb{R}_{>0}` be a strictly positive function, such as the softplus :math:`g(x) = \log(1 + \exp(x))`. Then, the d-th map component :math:`T_{d}` is given by
+We represent monotone functions as the smooth transformation of an unconstrained function :math:`f\colon\mathbb{R}^{d} \rightarrow \mathbb{R}`. Let :math:`g\colon\mathbb{R}\rightarrow \mathbb{R}_{>0}` be a strictly positive function, such as the softplus :math:`g(x) = \log(1 + \exp(x))`, and let :math:`\epsilon \geq 0` be a non-negative constant. Then, the d-th map component :math:`T_{d}` is given by
 
 .. math::
     :label: cont_map 
 
-    T_d(\mathbf{x}_{1:d}; \mathbf{w}) = f(x_1,\ldots, x_{d-1},0; \mathbf{w}) + \int_0^{x_d} g( \partial_d f(x_1,\ldots, x_{d-1},t; \mathbf{w}) ) dt.
+    T_d(\mathbf{x}_{1:d}; \mathbf{w}) = f(x_1,\ldots, x_{d-1},0; \mathbf{w}) + \int_0^{x_d} g( \partial_d f(x_1,\ldots, x_{d-1},t; \mathbf{w}) ) + \epsilon dt.
 
-Other choices for the :math:`g` include the squared and exponential functions. These choices, however, have implications for the identifiability of the coefficients. If :math:`g` is bijective, then we can recover :math:`f` from :math:`T_d` as 
+Notice that the additive "nugget" :math:`\epsilon` is the lower bound on the diagonal derivative :math:`\partial T_d / \partial x_d`.  Other choices for the :math:`g` include the squared and exponential functions. These choices, however, have implications for the identifiability of the coefficients. If :math:`g` is bijective and :math:`\epsilon=0`, then we can recover :math:`f` from :math:`T_d` as 
 
 .. math::
     f(\mathbf{x}_{1:d}; \mathbf{w}) = T_d(x_1,\ldots, x_{d-1},0; \mathbf{w}) + \int_0^{x_d} g^{-1}( \partial_d T_d(x_1,\ldots, x_{d-1},t; \mathbf{w}) ) dt.
@@ -59,7 +59,7 @@ Computationally, we approximate the integral in the definition of :math:`T_d(\ma
 .. math::
     :label: discr_map 
 
-    \tilde{T}_d(\mathbf{x}_{1:d}; \mathbf{w}) = f(x_1,\ldots, x_{d-1},0; \mathbf{w}) + x_d \sum_{i=1}^N c^{(i)} g( \partial_d f(x_1,\ldots, x_{d-1},x_d t^{(i)}; \mathbf{w}) ),
+    \tilde{T}_d(\mathbf{x}_{1:d}; \mathbf{w}) = f(x_1,\ldots, x_{d-1},0; \mathbf{w}) + x_d \sum_{i=1}^N c^{(i)} \left[g( \partial_d f(x_1,\ldots, x_{d-1},x_d t^{(i)}; \mathbf{w}) ) + \epsilon \right],
 
 where the :math:`x_d` term outside the summation comes from a change of integration domains from :math:`[0,1]` to :math:`[0,x_d]`. 
 
@@ -75,15 +75,15 @@ The derivative :math:`\partial T_d / \partial x_d` is particularly important whe
 .. math::
     :label: cont_deriv 
 
-    \frac{\partial T_d}{\partial x_d}(\mathbf{x}_{1:d}; \mathbf{w}) = g(\, \partial_d f(\mathbf{x}_{1:d}; \mathbf{w})\, ).
+    \frac{\partial T_d}{\partial x_d}(\mathbf{x}_{1:d}; \mathbf{w}) = g(\, \partial_d f(\mathbf{x}_{1:d}; \mathbf{w})\, ) + \epsilon.
 
 The discrete derivative on the other hand is more complicated: 
 
 .. math::
     :label: discr_deriv 
 
-    \frac{\partial \tilde{T}_d}{\partial x_d}(\mathbf{x}_{1:d}; \mathbf{w}) &= \frac{\partial}{\partial x_d} \left[x_d \sum_{i=1}^N c^{(i)} g( \partial_d f(x_1,\ldots, x_{d-1},x_d t^{(i)}; \mathbf{w}) )\right]\\
-    & = \sum_{i=1}^N c^{(i)} g( \partial_d f(x_1,\ldots, x_{d-1},x_d t^{(i)}; \mathbf{w}) ) \\
+    \frac{\partial \tilde{T}_d}{\partial x_d}(\mathbf{x}_{1:d}; \mathbf{w}) &= \frac{\partial}{\partial x_d} \left[x_d \sum_{i=1}^N c^{(i)} \left(g( \partial_d f(x_1,\ldots, x_{d-1},x_d t^{(i)}; \mathbf{w}) ) + \epsilon\right)\right]\\
+    & = \sum_{i=1}^N c^{(i)} \left(g( \partial_d f(x_1,\ldots, x_{d-1},x_d t^{(i)}; \mathbf{w}) )+\epsilon\right) \\
     &+ x_d \sum_{i=1}^N c^{(i)} t^{(i)} \partial g( \partial_d f(x_1,\ldots, x_{d-1},x_d t^{(i)}; \mathbf{w}) ) \partial^2_{dd}f(x_1,\ldots, x_{d-1},x_d t^{(i)}; \mathbf{w}) .
 
 
@@ -104,7 +104,7 @@ If is also possible to compute the gradient of the diagonal derivative :math:`\n
 
 .. math::
 
-    \nabla_{\mathbf{w}}\left[ \frac{\partial T_d}{\partial d}\right] & = \nabla_{\mathbf{w}}\left[ g(\, \partial_d f(\mathbf{x}_{1:d}; \mathbf{w})\, ) \right] \\
+    \nabla_{\mathbf{w}}\left[ \frac{\partial T_d}{\partial d}\right] & = \nabla_{\mathbf{w}}\left[ g(\, \partial_d f(\mathbf{x}_{1:d}; \mathbf{w})\, ) + \epsilon \right] \\
     & = \partial g(\, \partial_d f(\mathbf{x}_{1:d}; \mathbf{w})\, )  \nabla_{\mathbf{w}}\left[\partial_d f(\mathbf{x}_{1:d}; \mathbf{w})\right].
 
 

--- a/src/MapFactoryImpl1.cpp
+++ b/src/MapFactoryImpl1.cpp
@@ -24,7 +24,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_Phys_ACC(Fi
     MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
     std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
-    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv);
+    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv, opts.nugget);
 
     output->SetCoeffs(Kokkos::View<double*,MemorySpace>("Component Coefficients", mset.Size()));
     return output;

--- a/src/MapFactoryImpl10.cpp
+++ b/src/MapFactoryImpl10.cpp
@@ -24,7 +24,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_LinPhys_ACC
     MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
     std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
-    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv);
+    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv, opts.nugget);
 
     output->SetCoeffs(Kokkos::View<double*,MemorySpace>("Component Coefficients", mset.Size()));
     return output;

--- a/src/MapFactoryImpl11.cpp
+++ b/src/MapFactoryImpl11.cpp
@@ -22,7 +22,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_LinPhys_CC(
     MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
     std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
-    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv);
+    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv, opts.nugget);
 
     output->SetCoeffs(Kokkos::View<double*,MemorySpace>("Component Coefficients", mset.Size()));
     return output;

--- a/src/MapFactoryImpl12.cpp
+++ b/src/MapFactoryImpl12.cpp
@@ -21,7 +21,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_LinPhys_AS(
     MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
     std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
-    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv);
+    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv, opts.nugget);
 
     output->SetCoeffs(Kokkos::View<double*,MemorySpace>("Component Coefficients", mset.Size()));
     return output;

--- a/src/MapFactoryImpl13.cpp
+++ b/src/MapFactoryImpl13.cpp
@@ -23,7 +23,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_LinProb_ACC
     MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
     std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
-    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv);
+    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv, opts.nugget);
 
     output->SetCoeffs(Kokkos::View<double*,MemorySpace>("Component Coefficients", mset.Size()));
     return output;

--- a/src/MapFactoryImpl14.cpp
+++ b/src/MapFactoryImpl14.cpp
@@ -21,7 +21,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_LinProb_CC(
     MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
     std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
-    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv);
+    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv, opts.nugget);
 
     output->SetCoeffs(Kokkos::View<double*,MemorySpace>("Component Coefficients", mset.Size()));
     return output;

--- a/src/MapFactoryImpl15.cpp
+++ b/src/MapFactoryImpl15.cpp
@@ -21,7 +21,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_LinProb_AS(
     MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
     std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
-    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv);
+    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv, opts.nugget);
 
     output->SetCoeffs(Kokkos::View<double*,MemorySpace>("Component Coefficients", mset.Size()));
     return output;

--- a/src/MapFactoryImpl16.cpp
+++ b/src/MapFactoryImpl16.cpp
@@ -21,7 +21,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_LinHF_AS(Fi
     MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
     std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
-    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv);
+    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv, opts.nugget);
 
     output->SetCoeffs(Kokkos::View<double*,MemorySpace>("Component Coefficients", mset.Size()));
     return output;

--- a/src/MapFactoryImpl17.cpp
+++ b/src/MapFactoryImpl17.cpp
@@ -21,7 +21,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_LinHF_CC(Fi
     MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
     std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
-    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv);
+    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv, opts.nugget);
 
     output->SetCoeffs(Kokkos::View<double*,MemorySpace>("Component Coefficients", mset.Size()));
     return output;

--- a/src/MapFactoryImpl18.cpp
+++ b/src/MapFactoryImpl18.cpp
@@ -22,7 +22,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_LinHF_ACC(F
     MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
     std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
-    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv);
+    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv, opts.nugget);
 
     output->SetCoeffs(Kokkos::View<double*,MemorySpace>("Component Coefficients", mset.Size()));
     return output;

--- a/src/MapFactoryImpl2.cpp
+++ b/src/MapFactoryImpl2.cpp
@@ -20,7 +20,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_Phys_CC(Fix
     MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
     std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
-    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv);
+    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv, opts.nugget);
 
     output->SetCoeffs(Kokkos::View<double*,MemorySpace>("Component Coefficients", mset.Size()));
     return output;

--- a/src/MapFactoryImpl3.cpp
+++ b/src/MapFactoryImpl3.cpp
@@ -19,7 +19,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_Phys_AS(Fix
     MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
     std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
-    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv);
+    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv, opts.nugget);
 
     output->SetCoeffs(Kokkos::View<double*,MemorySpace>("Component Coefficients", mset.Size()));
     return output;

--- a/src/MapFactoryImpl4.cpp
+++ b/src/MapFactoryImpl4.cpp
@@ -21,7 +21,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_Prob_ACC(Fi
     MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
     std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
-    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv);
+    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv, opts.nugget);
 
     output->SetCoeffs(Kokkos::View<double*,MemorySpace>("Component Coefficients", mset.Size()));
     return output;

--- a/src/MapFactoryImpl5.cpp
+++ b/src/MapFactoryImpl5.cpp
@@ -19,7 +19,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_Prob_CC(Fix
     MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
     std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
-    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv);
+    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv, opts.nugget);
 
     output->SetCoeffs(Kokkos::View<double*,MemorySpace>("Component Coefficients", mset.Size()));
     return output;

--- a/src/MapFactoryImpl6.cpp
+++ b/src/MapFactoryImpl6.cpp
@@ -19,7 +19,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_Prob_AS(Fix
     MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
     std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
-    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv);
+    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv, opts.nugget);
 
     output->SetCoeffs(Kokkos::View<double*,MemorySpace>("Component Coefficients", mset.Size()));
     return output;

--- a/src/MapFactoryImpl7.cpp
+++ b/src/MapFactoryImpl7.cpp
@@ -21,7 +21,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_HF_ACC(Fixe
     MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
     std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
-    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv);
+    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv, opts.nugget);
 
     output->SetCoeffs(Kokkos::View<double*,MemorySpace>("Component Coefficients", mset.Size()));
     return output;

--- a/src/MapFactoryImpl8.cpp
+++ b/src/MapFactoryImpl8.cpp
@@ -19,7 +19,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_HF_CC(Fixed
     MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
     std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
-    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv);
+    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv, opts.nugget);
 
     output->SetCoeffs(Kokkos::View<double*,MemorySpace>("Component Coefficients", mset.Size()));
     return output;

--- a/src/MapFactoryImpl9.cpp
+++ b/src/MapFactoryImpl9.cpp
@@ -19,7 +19,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_HF_AS(Fixed
     MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
     std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
-    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv);
+    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv, opts.nugget);
 
     output->SetCoeffs(Kokkos::View<double*,MemorySpace>("Component Coefficients", mset.Size()));
     return output;

--- a/tests/Test_MonotoneComponent.cpp
+++ b/tests/Test_MonotoneComponent.cpp
@@ -41,7 +41,7 @@ TEST_CASE( "MonotoneIntegrand1d", "[MonotoneIntegrand1d]") {
     pt(0) = 1.0;
 
     SECTION("Integrand Only") {
-        MonotoneIntegrand<MultivariateExpansionWorker<ProbabilistHermite>, Exp, Kokkos::View<double*, HostSpace>, Kokkos::View<double*, HostSpace>> integrand(&cache[0], expansion, pt, coeffs, DerivativeFlags::None);
+        MonotoneIntegrand<MultivariateExpansionWorker<ProbabilistHermite>, Exp, Kokkos::View<double*, HostSpace>, Kokkos::View<double*, HostSpace>> integrand(&cache[0], expansion, pt, coeffs, DerivativeFlags::None, 0.0);
 
         double val;
         integrand(0.0, &val);
@@ -53,7 +53,7 @@ TEST_CASE( "MonotoneIntegrand1d", "[MonotoneIntegrand1d]") {
     }
 
     SECTION("Integrand Derivative") {
-        MonotoneIntegrand<MultivariateExpansionWorker<ProbabilistHermite>, Exp, Kokkos::View<double*,HostSpace>, Kokkos::View<double*,HostSpace>> integrand(&cache[0], expansion, pt, coeffs, DerivativeFlags::Diagonal);
+        MonotoneIntegrand<MultivariateExpansionWorker<ProbabilistHermite>, Exp, Kokkos::View<double*,HostSpace>, Kokkos::View<double*,HostSpace>> integrand(&cache[0], expansion, pt, coeffs, DerivativeFlags::Diagonal, 0.0);
 
         Kokkos::View<double*,HostSpace> test("Integrand",2);
 
@@ -68,8 +68,8 @@ TEST_CASE( "MonotoneIntegrand1d", "[MonotoneIntegrand1d]") {
     }
 
     SECTION("Integrand Parameters Gradient") {
-        MonotoneIntegrand<MultivariateExpansionWorker<ProbabilistHermite>, Exp, Kokkos::View<double*,HostSpace>,Kokkos::View<double*,HostSpace>> integrand(&cache[0], expansion, pt, coeffs, DerivativeFlags::Parameters);
-        MonotoneIntegrand<MultivariateExpansionWorker<ProbabilistHermite>, Exp, Kokkos::View<double*,HostSpace>,Kokkos::View<double*,HostSpace>> integrand2(&cache[0], expansion, pt, coeffs, DerivativeFlags::None);
+        MonotoneIntegrand<MultivariateExpansionWorker<ProbabilistHermite>, Exp, Kokkos::View<double*,HostSpace>,Kokkos::View<double*,HostSpace>> integrand(&cache[0], expansion, pt, coeffs, DerivativeFlags::Parameters, 0.0);
+        MonotoneIntegrand<MultivariateExpansionWorker<ProbabilistHermite>, Exp, Kokkos::View<double*,HostSpace>,Kokkos::View<double*,HostSpace>> integrand2(&cache[0], expansion, pt, coeffs, DerivativeFlags::None, 0.0);
 
         Kokkos::View<double*, HostSpace> testVal("Integrand", 1+mset.Size());
         integrand(0.5, testVal.data());
@@ -90,8 +90,8 @@ TEST_CASE( "MonotoneIntegrand1d", "[MonotoneIntegrand1d]") {
 
     SECTION("Integrand Mixed Gradient") {
         Kokkos::View<double*,HostSpace> work("Integrand workspace", mset.Size());
-        MonotoneIntegrand<MultivariateExpansionWorker<ProbabilistHermite>, Exp, Kokkos::View<double*,HostSpace>,Kokkos::View<double*,HostSpace>> integrand(&cache[0], expansion, pt, coeffs, DerivativeFlags::Mixed, work);
-        MonotoneIntegrand<MultivariateExpansionWorker<ProbabilistHermite>, Exp, Kokkos::View<double*,HostSpace>,Kokkos::View<double*,HostSpace>> integrand2(&cache[0], expansion, pt, coeffs, DerivativeFlags::Diagonal);
+        MonotoneIntegrand<MultivariateExpansionWorker<ProbabilistHermite>, Exp, Kokkos::View<double*,HostSpace>,Kokkos::View<double*,HostSpace>> integrand(&cache[0], expansion, pt, coeffs, DerivativeFlags::Mixed, 0.0, work);
+        MonotoneIntegrand<MultivariateExpansionWorker<ProbabilistHermite>, Exp, Kokkos::View<double*,HostSpace>,Kokkos::View<double*,HostSpace>> integrand2(&cache[0], expansion, pt, coeffs, DerivativeFlags::Diagonal, 0.0);
 
         Kokkos::View<double*, HostSpace> testVal("Integrand", 1+mset.Size());
         integrand(0.5, testVal.data());
@@ -108,6 +108,96 @@ TEST_CASE( "MonotoneIntegrand1d", "[MonotoneIntegrand1d]") {
     }
 }
 
+
+
+TEST_CASE( "MonotoneIntegrand1d With Nugget", "[MonotoneIntegrand1d]") {
+
+    const double testTol = 1e-7;
+    const double nugget = 1.0; // Choose a large nugget just for testing purposes.  Typically this will be quite small
+    unsigned int dim = 1;
+    unsigned int maxDegree = 1;
+    FixedMultiIndexSet<HostSpace> mset(dim, maxDegree); // Create a total order limited fixed multindex set
+
+    MultivariateExpansionWorker<ProbabilistHermite, HostSpace> expansion(mset);
+
+    // Make room for the cache
+    std::vector<double> cache(expansion.CacheSize());
+    REQUIRE(cache.size() == 6);
+
+    Kokkos::View<double*, HostSpace> coeffs("Expansion coefficients", mset.Size());
+    coeffs(0) = 1.0; // Constant term
+    coeffs(1) = 1.0; // Linear term
+
+    Kokkos::View<double*, HostSpace> pt("evaluation point", dim);
+    pt(0) = 1.0;
+
+    SECTION("Integrand Only") {
+        MonotoneIntegrand<MultivariateExpansionWorker<ProbabilistHermite>, Exp, Kokkos::View<double*, HostSpace>, Kokkos::View<double*, HostSpace>> integrand(&cache[0], expansion, pt, coeffs, DerivativeFlags::None, nugget);
+
+        double val;
+        integrand(0.0, &val);
+        CHECK(val == Approx(exp(1)+nugget).epsilon(testTol));
+        integrand(0.5, &val);
+        CHECK(val == Approx(exp(1)+nugget).epsilon(testTol));
+        integrand(-0.5, &val);
+        CHECK(val == Approx(exp(1)+nugget).epsilon(testTol));
+    }
+
+    SECTION("Integrand Derivative") {
+        MonotoneIntegrand<MultivariateExpansionWorker<ProbabilistHermite>, Exp, Kokkos::View<double*,HostSpace>, Kokkos::View<double*,HostSpace>> integrand(&cache[0], expansion, pt, coeffs, DerivativeFlags::Diagonal, nugget);
+
+        Kokkos::View<double*,HostSpace> test("Integrand",2);
+
+        integrand(0.0, test.data());
+        CHECK(test(0) == Approx(exp(1)+nugget).epsilon(testTol));
+
+        integrand(0.5, test.data());
+        CHECK(test(0) == Approx(exp(1)+nugget).epsilon(testTol));
+
+        integrand(-0.5, test.data());
+        CHECK(test(0) == Approx(exp(1)+nugget).epsilon(testTol));
+    }
+
+    SECTION("Integrand Parameters Gradient") {
+        MonotoneIntegrand<MultivariateExpansionWorker<ProbabilistHermite>, Exp, Kokkos::View<double*,HostSpace>,Kokkos::View<double*,HostSpace>> integrand(&cache[0], expansion, pt, coeffs, DerivativeFlags::Parameters, nugget);
+        MonotoneIntegrand<MultivariateExpansionWorker<ProbabilistHermite>, Exp, Kokkos::View<double*,HostSpace>,Kokkos::View<double*,HostSpace>> integrand2(&cache[0], expansion, pt, coeffs, DerivativeFlags::None, nugget);
+
+        Kokkos::View<double*, HostSpace> testVal("Integrand", 1+mset.Size());
+        integrand(0.5, testVal.data());
+
+        const double fdStep = 1e-4;
+        double testVal2;
+        for(unsigned int termInd=0; termInd<mset.Size(); ++termInd){
+            coeffs(termInd) += fdStep;
+            integrand2(0.5, &testVal2);
+            double fdDeriv = (testVal2 - testVal(0))/fdStep;
+            CHECK(testVal(termInd+1) == Approx(fdDeriv).epsilon(1e-4));
+
+            coeffs(termInd) -= fdStep;
+        }
+
+    }
+
+
+    SECTION("Integrand Mixed Gradient") {
+        Kokkos::View<double*,HostSpace> work("Integrand workspace", mset.Size());
+        MonotoneIntegrand<MultivariateExpansionWorker<ProbabilistHermite>, Exp, Kokkos::View<double*,HostSpace>,Kokkos::View<double*,HostSpace>> integrand(&cache[0], expansion, pt, coeffs, DerivativeFlags::Mixed, nugget, work);
+        MonotoneIntegrand<MultivariateExpansionWorker<ProbabilistHermite>, Exp, Kokkos::View<double*,HostSpace>,Kokkos::View<double*,HostSpace>> integrand2(&cache[0], expansion, pt, coeffs, DerivativeFlags::Diagonal, nugget);
+
+        Kokkos::View<double*, HostSpace> testVal("Integrand", 1+mset.Size());
+        integrand(0.5, testVal.data());
+
+        const double fdStep = 1e-4;
+        double testVal2;
+        for(unsigned int termInd=0; termInd<mset.Size(); ++termInd){
+            coeffs(termInd) += fdStep;
+            integrand2(0.5, &testVal2);
+            double fdDeriv = (testVal2 - testVal(0))/fdStep;
+            CHECK(testVal(termInd+1) == Approx(fdDeriv).epsilon(1e-4));
+            coeffs(termInd) -= fdStep;
+        }
+    }
+}
 
 TEST_CASE( "MonotoneIntegrand2d", "[MonotoneIntegrand2d]") {
 
@@ -138,7 +228,7 @@ TEST_CASE( "MonotoneIntegrand2d", "[MonotoneIntegrand2d]") {
     SECTION("Integrand Only") {
 
         // Construct the integrand
-        MonotoneIntegrand<MultivariateExpansionWorker<ProbabilistHermite>, Exp, Kokkos::View<double*,HostSpace>,Kokkos::View<double*,HostSpace>> integrand(&cache[0], expansion, pt, coeffs, DerivativeFlags::None);
+        MonotoneIntegrand<MultivariateExpansionWorker<ProbabilistHermite>, Exp, Kokkos::View<double*,HostSpace>,Kokkos::View<double*,HostSpace>> integrand(&cache[0], expansion, pt, coeffs, DerivativeFlags::None, 0.0);
 
         // Evaluate the expansion
         double df;
@@ -154,7 +244,7 @@ TEST_CASE( "MonotoneIntegrand2d", "[MonotoneIntegrand2d]") {
     }
 
     SECTION("Integrand Derivative") {
-        MonotoneIntegrand<MultivariateExpansionWorker<ProbabilistHermite>, Exp, Kokkos::View<double*,HostSpace>,Kokkos::View<double*,HostSpace>> integrand(&cache[0], expansion, pt, coeffs, DerivativeFlags::Diagonal);
+        MonotoneIntegrand<MultivariateExpansionWorker<ProbabilistHermite>, Exp, Kokkos::View<double*,HostSpace>,Kokkos::View<double*,HostSpace>> integrand(&cache[0], expansion, pt, coeffs, DerivativeFlags::Diagonal, 0.0);
 
         // Evaluate the expansion
         double df, d2f;
@@ -175,7 +265,7 @@ TEST_CASE( "MonotoneIntegrand2d", "[MonotoneIntegrand2d]") {
     SECTION("Integrand Input Gradient") {
         double fdStep = 1e-5;
 
-        MonotoneIntegrand<MultivariateExpansionWorker<ProbabilistHermite>, Exp, Kokkos::View<double*,HostSpace>,Kokkos::View<double*,HostSpace>> integrand(&cache[0], expansion, pt, coeffs, DerivativeFlags::Input);
+        MonotoneIntegrand<MultivariateExpansionWorker<ProbabilistHermite>, Exp, Kokkos::View<double*,HostSpace>,Kokkos::View<double*,HostSpace>> integrand(&cache[0], expansion, pt, coeffs, DerivativeFlags::Input, 0.0);
 
         // Evaluate the expansion
         double df, d2f;
@@ -203,7 +293,7 @@ TEST_CASE( "MonotoneIntegrand2d", "[MonotoneIntegrand2d]") {
 
     SECTION("Integrand Parameters Gradient") {
 
-        MonotoneIntegrand<MultivariateExpansionWorker<ProbabilistHermite>, Exp, Kokkos::View<double*,HostSpace>,Kokkos::View<double*,HostSpace>> integrand(&cache[0], expansion, pt, coeffs, DerivativeFlags::Parameters);
+        MonotoneIntegrand<MultivariateExpansionWorker<ProbabilistHermite>, Exp, Kokkos::View<double*,HostSpace>,Kokkos::View<double*,HostSpace>> integrand(&cache[0], expansion, pt, coeffs, DerivativeFlags::Parameters, 0.0);
 
         // Evaluate the expansion
         double df;
@@ -230,7 +320,7 @@ TEST_CASE( "MonotoneIntegrand2d", "[MonotoneIntegrand2d]") {
     SECTION("Integrand Mixed Gradient") {
 
         Kokkos::View<double*, HostSpace> workspace("Integrand Workspace", numTerms);
-        MonotoneIntegrand<MultivariateExpansionWorker<ProbabilistHermite>, Exp, Kokkos::View<double*,HostSpace>,Kokkos::View<double*,HostSpace>> integrand(&cache[0], expansion, pt, coeffs, DerivativeFlags::Mixed, workspace);
+        MonotoneIntegrand<MultivariateExpansionWorker<ProbabilistHermite>, Exp, Kokkos::View<double*,HostSpace>,Kokkos::View<double*,HostSpace>> integrand(&cache[0], expansion, pt, coeffs, DerivativeFlags::Mixed, 0.0, workspace);
 
         // Evaluate the expansion
         double df, d2f;
@@ -816,7 +906,7 @@ TEST_CASE( "MonotoneIntegrand1d on device", "[MonotoneIntegrandDevice]") {
         Kokkos::View<double*, DeviceSpace> dres("result", 1);
 
         Kokkos::parallel_for(1, KOKKOS_LAMBDA(const int i){
-            MonotoneIntegrand<decltype(expansion), Exp, decltype(dpt), decltype(dcoeffs), DeviceSpace> integrand(dcache.data(), expansion, dpt, dcoeffs, DerivativeFlags::None);
+            MonotoneIntegrand<decltype(expansion), Exp, decltype(dpt), decltype(dcoeffs), DeviceSpace> integrand(dcache.data(), expansion, dpt, dcoeffs, DerivativeFlags::None, 0.0);
             integrand(0.5, &dres(0));
         });
 
@@ -829,7 +919,7 @@ TEST_CASE( "MonotoneIntegrand1d on device", "[MonotoneIntegrandDevice]") {
         Kokkos::View<double*, DeviceSpace> dres("result", 2);
 
         Kokkos::parallel_for(1, KOKKOS_LAMBDA(const int i){
-            MonotoneIntegrand<decltype(expansion), Exp, decltype(dpt), decltype(dcoeffs), DeviceSpace> integrand(dcache.data(), expansion, dpt, dcoeffs, DerivativeFlags::Diagonal);
+            MonotoneIntegrand<decltype(expansion), Exp, decltype(dpt), decltype(dcoeffs), DeviceSpace> integrand(dcache.data(), expansion, dpt, dcoeffs, DerivativeFlags::Diagonal, 0.0);
             integrand(0.5, dres.data());
         });
 
@@ -846,8 +936,8 @@ TEST_CASE( "MonotoneIntegrand1d on device", "[MonotoneIntegrandDevice]") {
 
         Kokkos::parallel_for(1, KOKKOS_LAMBDA(const int i){
 
-            MonotoneIntegrand<decltype(expansion), Exp, decltype(dpt), decltype(dcoeffs), DeviceSpace> integrand(dcache.data(), expansion, dpt, dcoeffs, DerivativeFlags::Parameters);
-            MonotoneIntegrand<decltype(expansion), Exp, decltype(dpt), decltype(dcoeffs), DeviceSpace> integrand2(dcache.data(), expansion, dpt, dcoeffs, DerivativeFlags::None);
+            MonotoneIntegrand<decltype(expansion), Exp, decltype(dpt), decltype(dcoeffs), DeviceSpace> integrand(dcache.data(), expansion, dpt, dcoeffs, DerivativeFlags::Parameters, 0.0);
+            MonotoneIntegrand<decltype(expansion), Exp, decltype(dpt), decltype(dcoeffs), DeviceSpace> integrand2(dcache.data(), expansion, dpt, dcoeffs, DerivativeFlags::None, 0.0);
 
             integrand(0.5, testVal.data());
 
@@ -881,8 +971,8 @@ TEST_CASE( "MonotoneIntegrand1d on device", "[MonotoneIntegrandDevice]") {
 
         Kokkos::parallel_for(1, KOKKOS_LAMBDA(const int i){
 
-            MonotoneIntegrand<decltype(expansion), Exp, decltype(dpt), decltype(dcoeffs), DeviceSpace> integrand(dcache.data(), expansion, dpt, dcoeffs, DerivativeFlags::Mixed, workspace);
-            MonotoneIntegrand<decltype(expansion), Exp, decltype(dpt), decltype(dcoeffs), DeviceSpace> integrand2(dcache.data(), expansion, dpt, dcoeffs, DerivativeFlags::Diagonal);
+            MonotoneIntegrand<decltype(expansion), Exp, decltype(dpt), decltype(dcoeffs), DeviceSpace> integrand(dcache.data(), expansion, dpt, dcoeffs, DerivativeFlags::Mixed, 0.0, workspace);
+            MonotoneIntegrand<decltype(expansion), Exp, decltype(dpt), decltype(dcoeffs), DeviceSpace> integrand2(dcache.data(), expansion, dpt, dcoeffs, DerivativeFlags::Diagonal, 0.0);
 
             integrand(0.5, testVal.data());
 


### PR DESCRIPTION
Sometimes, maps can be more robust by forcing them to have a nonzero minimum slope.   This PR enables this by adding a nugget option to the Monotone Integrand class.  The new form of map component $T_d(x_{1:d})$ now has an additional fixed parameter $\epsilon\geq 0$ and takes the form
 
$$
T_d(x_d; x_{1:d-1}) = f(x_{1:d-1},0) + \int_0^{x_d}  \quad g(\partial_d f(x_{1:d},t)) + \epsilon  \quad dt
$$

The value of $\epsilon$ is set in `MonotoneComponent` construct but is also available in `MapOptions`.  All of the language bindings have been updated to include a `nugget` option.