### PR TITLE
PyTorch Interface

### DIFF
--- a/.github/environment.yml
+++ b/.github/environment.yml
@@ -12,5 +12,5 @@ dependencies:
   - pybind11 >=2.10
   - cereal >= 1.3
   - nlopt >= 2.7
-  - torch
+  - pytorch
 

--- a/.github/environment.yml
+++ b/.github/environment.yml
@@ -12,4 +12,5 @@ dependencies:
   - pybind11 >=2.10
   - cereal >= 1.3
   - nlopt >= 2.7
+  - torch
 

--- a/MParT/Utilities/ArrayConversions.h
+++ b/MParT/Utilities/ArrayConversions.h
@@ -96,6 +96,40 @@ namespace mpart{
         return Kokkos::View<ScalarType**, LayoutType, MemorySpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>(ptr, rows, cols);
     }
 
+    /** Constructs a Kokkos::View with strided layout from a memory address, shape tuple, and stride tuple. 
+        This is primarily used to provide an interface with pytorch in the python bindings.
+    */
+    template<typename ScalarType, typename MemorySpace=Kokkos::HostSpace>
+    StridedMatrix<ScalarType, MemorySpace> ToKokkos(std::tuple<long, std::tuple<int,int>, std::tuple<int,int>> info)    
+    {
+        ScalarType* ptr = reinterpret_cast<ScalarType*>(std::get<0>(info));
+
+        const int rows = std::get<0>(std::get<1>(info));
+        const int cols = std::get<1>(std::get<1>(info));
+        const int rowStride = std::get<0>(std::get<2>(info));
+        const int colStride = std::get<1>(std::get<2>(info));
+
+        Kokkos::LayoutStride layout(rows, rowStride, cols, colStride);
+
+        Kokkos::View<ScalarType**, Kokkos::LayoutStride, MemorySpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>> output(ptr, layout);
+        return output;
+    }
+
+    template<typename ScalarType, typename MemorySpace=Kokkos::HostSpace>
+    StridedVector<ScalarType, MemorySpace> ToKokkos(std::tuple<long, int, int> info)    
+    {
+        ScalarType* ptr = reinterpret_cast<ScalarType*>(std::get<0>(info));
+
+        const int length = std::get<1>(info);
+        const int stride = std::get<2>(info);
+
+        Kokkos::LayoutStride layout(length, stride);
+
+        Kokkos::View<ScalarType*, Kokkos::LayoutStride, MemorySpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>> output(ptr, layout);
+        return output;
+    }
+
+
     template<typename ScalarType, typename LayoutType=Kokkos::LayoutLeft, typename MemorySpace=Kokkos::HostSpace>
     inline Kokkos::View<const ScalarType**, LayoutType, MemorySpace> ToConstKokkos(const ScalarType* const_ptr, unsigned int rows, unsigned int cols)
     {

--- a/bindings/python/package/__init__.py
+++ b/bindings/python/package/__init__.py
@@ -3,3 +3,9 @@ from .pympart import *
 
 kokkos_init = Initialize(dict())
 sys.modules[__name__] = sys.modules['mpart']
+
+try:
+    from .torch import *
+except ImportError:
+    pass 
+

--- a/bindings/python/package/__init__.py
+++ b/bindings/python/package/__init__.py
@@ -6,6 +6,7 @@ sys.modules[__name__] = sys.modules['mpart']
 
 try:
     from .torch import *
+    mpart_has_torch = True
 except ImportError:
-    pass 
+    mpart_has_torch = False
 

--- a/bindings/python/package/torch.py
+++ b/bindings/python/package/torch.py
@@ -1,0 +1,73 @@
+import torch
+
+def ExtractTorchTensorData(tensor):
+    """ Extracts the pointer, shape, and stride from a pytorch tensor and returns a tuple
+        that can be passed to MParT functions that have been overloaded to accept
+        (double*, std::tuple<int,int>, std::tuple<int,int>) instead of a Kokkos::View.
+
+        Arguments:
+        ------------
+        tensor: pytorch.Tensor
+            The pytorch tensor we want to eventually wrap with a Kokkos view.
+        
+        Returns:
+        ------------
+        Tuple[int, Tuple[int,int], Tuple[int,int]]
+            A python tuple that contains all information needed to construct a Kokkos::View.
+            After casting to c++ types using pybind, this output can be passed to the 
+            mpart::ConstructViewFromPointer function.
+    """
+
+    # Make sure the tensor has double data type
+    if tensor.dtype != torch.float64:
+        raise ValueError(f'Currently only tensors with float64 datatype can be converted.  Current dtype is {tensor.dtype}')
+    
+    if len(tensor.shape)==1:
+        return tensor.data_ptr(), tensor.shape[0], tensor.stride()[0]
+    elif len(tensor.shape)==2:
+        return tensor.data_ptr(), tuple(tensor.shape), tuple(tensor.stride())
+    else:
+        raise ValueError(f'Currently only 1d and 2d tensors can be converted.')
+
+class TorchWrapper_ParameterizedFunction(torch.autograd.Function):
+
+    @staticmethod
+    def forward(ctx, input, coeffs, f):
+        ctx.save_for_backward(input, coeffs)
+        ctx.f = f
+
+        if coeffs is not None:
+            f.WrapCoeffs(ExtractTorchTensorData(coeffs))
+
+        output = torch.zeros(f.outputDim, input.shape[1], dtype=input.dtype) 
+        f.EvaluateImpl(ExtractTorchTensorData(input), ExtractTorchTensorData(output))
+        return output
+
+    @staticmethod
+    def backward(ctx, sens):
+        input, coeffs = ctx.saved_tensors
+        f = ctx.f
+
+        if coeffs is not None:
+            f.WrapCoeffs(ExtractTorchTensorData(coeffs))
+
+        # Get the gradient wrt input 
+        grad = None 
+        if input.requires_grad:          
+            grad = torch.zeros(f.inputDim, input.shape[1], dtype=input.dtype)
+
+            f.GradientImpl(ExtractTorchTensorData(input), 
+                          ExtractTorchTensorData(sens),
+                          ExtractTorchTensorData(grad))
+
+        coeff_grad = None
+        if coeffs is not None:
+            if coeffs.requires_grad:
+                coeff_grad = torch.zeros(f.numCoeffs, input.shape[1], dtype=input.dtype)
+                f.CoeffGradImpl(ExtractTorchTensorData(input),
+                                ExtractTorchTensorData(sens),
+                                ExtractTorchTensorData(coeff_grad))
+
+                coeff_grad = coeff_grad.sum(axis=1) # pytorch expects total gradient not per-sample gradient
+
+        return grad, coeff_grad, None   

--- a/bindings/python/package/torch.py
+++ b/bindings/python/package/torch.py
@@ -29,10 +29,10 @@ def ExtractTorchTensorData(tensor):
     else:
         raise ValueError(f'Currently only 1d and 2d tensors can be converted.')
 
-class TorchWrapper_ParameterizedFunction(torch.autograd.Function):
+class MpartTorchAutograd(torch.autograd.Function):
 
     @staticmethod
-    def forward(ctx, input, coeffs, f):
+    def forward(ctx, input, coeffs, f, return_logdet):
         ctx.save_for_backward(input, coeffs)
         ctx.f = f
 
@@ -41,13 +41,20 @@ class TorchWrapper_ParameterizedFunction(torch.autograd.Function):
 
         output = torch.zeros(f.outputDim, input.shape[1], dtype=input.dtype) 
         f.EvaluateImpl(ExtractTorchTensorData(input), ExtractTorchTensorData(output))
-        return output
+
+        if return_logdet:
+            logdet = torch.zeros(input.shape[1], dtype=input.dtype)
+            f.LogDeterminantImpl(ExtractTorchTensorData(input), ExtractTorchTensorData(logdet))
+
+            return output, logdet
+        else:
+            return output
 
     @staticmethod
-    def backward(ctx, sens):
+    def backward(ctx, output_sens, logdet_sens=None):
         input, coeffs = ctx.saved_tensors
         f = ctx.f
-
+        
         if coeffs is not None:
             f.WrapCoeffs(ExtractTorchTensorData(coeffs))
 
@@ -57,17 +64,76 @@ class TorchWrapper_ParameterizedFunction(torch.autograd.Function):
             grad = torch.zeros(f.inputDim, input.shape[1], dtype=input.dtype)
 
             f.GradientImpl(ExtractTorchTensorData(input), 
-                          ExtractTorchTensorData(sens),
+                          ExtractTorchTensorData(output_sens),
                           ExtractTorchTensorData(grad))
+
+            if logdet_sens is not None:
+                grad2 = torch.zeros(f.inputDim, input.shape[1], dtype=input.dtype)
+
+                f.LogDeterminantInputGradImpl(ExtractTorchTensorData(input), 
+                                              ExtractTorchTensorData(grad2))
+                grad += grad2*logdet_sens[None,:]
 
         coeff_grad = None
         if coeffs is not None:
             if coeffs.requires_grad:
                 coeff_grad = torch.zeros(f.numCoeffs, input.shape[1], dtype=input.dtype)
                 f.CoeffGradImpl(ExtractTorchTensorData(input),
-                                ExtractTorchTensorData(sens),
+                                ExtractTorchTensorData(output_sens),
                                 ExtractTorchTensorData(coeff_grad))
 
                 coeff_grad = coeff_grad.sum(axis=1) # pytorch expects total gradient not per-sample gradient
 
-        return grad, coeff_grad, None   
+                if logdet_sens is not None:
+                    grad2 = torch.zeros(f.numCoeffs, input.shape[1], dtype=input.dtype)
+
+                    f.LogDeterminantCoeffGradImpl(ExtractTorchTensorData(input), 
+                                                 ExtractTorchTensorData(grad2))
+                    
+                    coeff_grad += torch.sum(grad2*logdet_sens[None,:],axis=1)
+                    
+        return grad, coeff_grad, None, None  
+
+
+
+class TorchParameterizedFunctionBase(torch.nn.Module):
+    """ Defines a wrapper around the MParT ParameterizedFunctionBase class that
+        can be used with pytorch.  
+    """
+
+    def __init__(self, f):
+        super().__init__()
+
+        self.f = f 
+
+        coeff_tensor = torch.tensor( self.f.CoeffMap(), dtype=torch.double)
+        self.coeffs = torch.nn.Parameter(coeff_tensor)
+
+    def forward(self, x):
+        
+        return MpartTorchAutograd.apply(x, self.coeffs, self.f, False)
+
+
+class TorchConditionalMapBase(torch.nn.Module):
+    """ Defines a wrapper around the MParT ConditionalMapBase class that
+        can be used with pytorch.  The log determinant of the function's
+        Jacobian can also be return by setting the return_logdet attribute.
+        This can be done either in the constructor or afterwards.
+    """
+
+    def __init__(self, f, return_logdet=False):
+        super().__init__()
+
+        self.return_logdet = return_logdet
+        self.f = f 
+
+        coeff_tensor = torch.tensor( self.f.CoeffMap(), dtype=torch.double)
+        self.coeffs = torch.nn.Parameter(coeff_tensor)
+
+    def forward(self, x):
+        
+        return MpartTorchAutograd.apply(x, self.coeffs, self.f, self.return_logdet)
+
+
+
+    

--- a/bindings/python/src/ConditionalMapBase.cpp
+++ b/bindings/python/src/ConditionalMapBase.cpp
@@ -32,7 +32,11 @@ void mpart::binding::ConditionalMapBaseWrapper(py::module &m)
             obj->LogDeterminantInputGradImpl(ToKokkos<double,MemorySpace>(input),ToKokkos<double,MemorySpace>(output));
         })
         .def("torch", [](std::shared_ptr<ParameterizedFunctionBase<Kokkos::HostSpace>> obj, bool return_logdet){
-            return py::module::import("mpart").attr("TorchConditionalMapBase")(obj, return_logdet);
+            auto mpart = py::module::import("mpart");
+            if(!mpart.attr("mpart_has_torch").cast<bool>()){
+                throw std::runtime_error("MParT could not import pytorch.");
+            }
+            return mpart.attr("TorchConditionalMapBase")(obj, return_logdet);
         }, py::arg("return_logdet") = false)
         .def("GetBaseFunction", &ConditionalMapBase<MemorySpace>::GetBaseFunction)
 #if defined(MPART_HAS_CEREAL)

--- a/bindings/python/src/ConditionalMapBase.cpp
+++ b/bindings/python/src/ConditionalMapBase.cpp
@@ -19,10 +19,23 @@ void mpart::binding::ConditionalMapBaseWrapper(py::module &m)
     py::class_<ConditionalMapBase<MemorySpace>, ParameterizedFunctionBase<MemorySpace>, std::shared_ptr<ConditionalMapBase<MemorySpace>>>(m, tName.c_str())
 
         .def("LogDeterminant", static_cast<Eigen::VectorXd (ConditionalMapBase<MemorySpace>::*)(Eigen::Ref<const Eigen::RowMatrixXd> const&)>(&ConditionalMapBase<MemorySpace>::LogDeterminant))
+        .def("LogDeterminantImpl", [](std::shared_ptr<ConditionalMapBase<MemorySpace>> obj, std::tuple<long,std::tuple<int,int>,std::tuple<int,int>> input, std::tuple<long,int,int> output){
+            obj->LogDeterminantImpl(ToKokkos<double,MemorySpace>(input),ToKokkos<double,MemorySpace>(output));
+        })
         .def("Inverse", static_cast<Eigen::RowMatrixXd (ConditionalMapBase<MemorySpace>::*)(Eigen::Ref<const Eigen::RowMatrixXd> const&, Eigen::Ref<const Eigen::RowMatrixXd> const&)>(&ConditionalMapBase<MemorySpace>::Inverse))
         .def("LogDeterminantCoeffGrad", static_cast<Eigen::RowMatrixXd (ConditionalMapBase<MemorySpace>::*)(Eigen::Ref<const Eigen::RowMatrixXd> const&)>(&ConditionalMapBase<MemorySpace>::LogDeterminantCoeffGrad))
+        .def("LogDeterminantCoeffGradImpl", [](std::shared_ptr<ConditionalMapBase<MemorySpace>> obj, std::tuple<long,std::tuple<int,int>,std::tuple<int,int>> input, std::tuple<long,std::tuple<int,int>,std::tuple<int,int>> output){
+            obj->LogDeterminantCoeffGradImpl(ToKokkos<double,MemorySpace>(input),ToKokkos<double,MemorySpace>(output));
+        })
         .def("LogDeterminantInputGrad", static_cast<Eigen::RowMatrixXd (ConditionalMapBase<MemorySpace>::*)(Eigen::Ref<const Eigen::RowMatrixXd> const&)>(&ConditionalMapBase<MemorySpace>::LogDeterminantInputGrad))
+        .def("LogDeterminantInputGradImpl", [](std::shared_ptr<ConditionalMapBase<MemorySpace>> obj, std::tuple<long,std::tuple<int,int>,std::tuple<int,int>> input, std::tuple<long,std::tuple<int,int>,std::tuple<int,int>> output){
+            obj->LogDeterminantInputGradImpl(ToKokkos<double,MemorySpace>(input),ToKokkos<double,MemorySpace>(output));
+        })
+        .def("torch", [](std::shared_ptr<ParameterizedFunctionBase<Kokkos::HostSpace>> obj, bool return_logdet){
+            return py::module::import("mpart").attr("TorchConditionalMapBase")(obj, return_logdet);
+        }, py::arg("return_logdet") = false)
         .def("GetBaseFunction", &ConditionalMapBase<MemorySpace>::GetBaseFunction)
+#if defined(MPART_HAS_CEREAL)
         .def(py::pickle(
             [](std::shared_ptr<ConditionalMapBase<Kokkos::HostSpace>> const& ptr) { // __getstate__
                 std::stringstream ss;
@@ -38,6 +51,7 @@ void mpart::binding::ConditionalMapBaseWrapper(py::module &m)
                 return ptr;
             }
         ))
+#endif
         ;
 
 }

--- a/bindings/python/src/ConditionalMapBase.cpp
+++ b/bindings/python/src/ConditionalMapBase.cpp
@@ -23,6 +23,9 @@ void mpart::binding::ConditionalMapBaseWrapper(py::module &m)
             obj->LogDeterminantImpl(ToKokkos<double,MemorySpace>(input),ToKokkos<double,MemorySpace>(output));
         })
         .def("Inverse", static_cast<Eigen::RowMatrixXd (ConditionalMapBase<MemorySpace>::*)(Eigen::Ref<const Eigen::RowMatrixXd> const&, Eigen::Ref<const Eigen::RowMatrixXd> const&)>(&ConditionalMapBase<MemorySpace>::Inverse))
+        .def("InverseImpl", [](std::shared_ptr<ConditionalMapBase<MemorySpace>> obj, std::tuple<long,std::tuple<int,int>,std::tuple<int,int>> x, std::tuple<long,std::tuple<int,int>,std::tuple<int,int>> r, std::tuple<long,std::tuple<int,int>,std::tuple<int,int>> output){
+            obj->InverseImpl(ToKokkos<double,MemorySpace>(x), ToKokkos<double,MemorySpace>(r), ToKokkos<double,MemorySpace>(output));
+        })
         .def("LogDeterminantCoeffGrad", static_cast<Eigen::RowMatrixXd (ConditionalMapBase<MemorySpace>::*)(Eigen::Ref<const Eigen::RowMatrixXd> const&)>(&ConditionalMapBase<MemorySpace>::LogDeterminantCoeffGrad))
         .def("LogDeterminantCoeffGradImpl", [](std::shared_ptr<ConditionalMapBase<MemorySpace>> obj, std::tuple<long,std::tuple<int,int>,std::tuple<int,int>> input, std::tuple<long,std::tuple<int,int>,std::tuple<int,int>> output){
             obj->LogDeterminantCoeffGradImpl(ToKokkos<double,MemorySpace>(input),ToKokkos<double,MemorySpace>(output));

--- a/bindings/python/src/ParameterizedFunctionBase.cpp
+++ b/bindings/python/src/ParameterizedFunctionBase.cpp
@@ -1,5 +1,7 @@
 #include "CommonPybindUtilities.h"
 #include "MParT/ParameterizedFunctionBase.h"
+#include "MParT/Utilities/ArrayConversions.h"
+
 #include <pybind11/stl.h>
 #include <pybind11/eigen.h>
 
@@ -20,9 +22,21 @@ void mpart::binding::ParameterizedFunctionBaseWrapper<Kokkos::HostSpace>(py::mod
     py::class_<ParameterizedFunctionBase<Kokkos::HostSpace>, std::shared_ptr<ParameterizedFunctionBase<Kokkos::HostSpace>>>(m, "ParameterizedFunctionBase")
         .def("CoeffMap", &ParameterizedFunctionBase<Kokkos::HostSpace>::CoeffMap)
         .def("SetCoeffs", py::overload_cast<Eigen::Ref<Eigen::VectorXd>>(&ParameterizedFunctionBase<Kokkos::HostSpace>::SetCoeffs))
+        .def("WrapCoeffs", [](std::shared_ptr<ParameterizedFunctionBase<Kokkos::HostSpace>> obj, std::tuple<long,int,int> coeffs){
+            obj->WrapCoeffs(ToKokkos<double,Kokkos::HostSpace>(coeffs));
+        })
         .def("Evaluate", static_cast<Eigen::RowMatrixXd (ParameterizedFunctionBase<Kokkos::HostSpace>::*)(Eigen::Ref<const Eigen::RowMatrixXd> const&)>(&ParameterizedFunctionBase<Kokkos::HostSpace>::Evaluate))
+        .def("EvaluateImpl", [](std::shared_ptr<ParameterizedFunctionBase<Kokkos::HostSpace>> obj, std::tuple<long,std::tuple<int,int>,std::tuple<int,int>> input, std::tuple<long,std::tuple<int,int>,std::tuple<int,int>> output){
+            obj->EvaluateImpl(ToKokkos<double,Kokkos::HostSpace>(input),ToKokkos<double,Kokkos::HostSpace>(output));
+        })
         .def("Gradient", static_cast<Eigen::RowMatrixXd (ParameterizedFunctionBase<Kokkos::HostSpace>::*)(Eigen::Ref<const Eigen::RowMatrixXd> const&, Eigen::Ref<const Eigen::RowMatrixXd> const&)>(&ParameterizedFunctionBase<Kokkos::HostSpace>::Gradient))
+        .def("GradientImpl", [](std::shared_ptr<ParameterizedFunctionBase<Kokkos::HostSpace>> obj, std::tuple<long,std::tuple<int,int>,std::tuple<int,int>> input, std::tuple<long,std::tuple<int,int>,std::tuple<int,int>> sens, std::tuple<long,std::tuple<int,int>,std::tuple<int,int>> output){
+            obj->GradientImpl(ToKokkos<double,Kokkos::HostSpace>(input),ToKokkos<double,Kokkos::HostSpace>(sens), ToKokkos<double,Kokkos::HostSpace>(output));
+        })
         .def("CoeffGrad",static_cast<Eigen::RowMatrixXd (ParameterizedFunctionBase<Kokkos::HostSpace>::*)(Eigen::Ref<const Eigen::RowMatrixXd> const&, Eigen::Ref<const Eigen::RowMatrixXd> const&)>(&ParameterizedFunctionBase<Kokkos::HostSpace>::CoeffGrad))
+        .def("CoeffGradImpl",[](std::shared_ptr<ParameterizedFunctionBase<Kokkos::HostSpace>> obj, std::tuple<long,std::tuple<int,int>,std::tuple<int,int>> input, std::tuple<long,std::tuple<int,int>,std::tuple<int,int>> sens, std::tuple<long,std::tuple<int,int>,std::tuple<int,int>> output){
+            obj->CoeffGradImpl(ToKokkos<double,Kokkos::HostSpace>(input),ToKokkos<double,Kokkos::HostSpace>(sens), ToKokkos<double,Kokkos::HostSpace>(output));
+        })
         .def_readonly("numCoeffs", &ParameterizedFunctionBase<Kokkos::HostSpace>::numCoeffs)
         .def_readonly("inputDim", &ParameterizedFunctionBase<Kokkos::HostSpace>::inputDim)
         .def_readonly("outputDim", &ParameterizedFunctionBase<Kokkos::HostSpace>::outputDim)

--- a/bindings/python/src/ParameterizedFunctionBase.cpp
+++ b/bindings/python/src/ParameterizedFunctionBase.cpp
@@ -37,6 +37,9 @@ void mpart::binding::ParameterizedFunctionBaseWrapper<Kokkos::HostSpace>(py::mod
         .def("CoeffGradImpl",[](std::shared_ptr<ParameterizedFunctionBase<Kokkos::HostSpace>> obj, std::tuple<long,std::tuple<int,int>,std::tuple<int,int>> input, std::tuple<long,std::tuple<int,int>,std::tuple<int,int>> sens, std::tuple<long,std::tuple<int,int>,std::tuple<int,int>> output){
             obj->CoeffGradImpl(ToKokkos<double,Kokkos::HostSpace>(input),ToKokkos<double,Kokkos::HostSpace>(sens), ToKokkos<double,Kokkos::HostSpace>(output));
         })
+        .def("torch", [](std::shared_ptr<ParameterizedFunctionBase<Kokkos::HostSpace>> obj){
+            return py::module::import("mpart").attr("TorchParameterizedFunctionBase")(obj);
+        })
         .def_readonly("numCoeffs", &ParameterizedFunctionBase<Kokkos::HostSpace>::numCoeffs)
         .def_readonly("inputDim", &ParameterizedFunctionBase<Kokkos::HostSpace>::inputDim)
         .def_readonly("outputDim", &ParameterizedFunctionBase<Kokkos::HostSpace>::outputDim)

--- a/bindings/python/src/ParameterizedFunctionBase.cpp
+++ b/bindings/python/src/ParameterizedFunctionBase.cpp
@@ -38,7 +38,11 @@ void mpart::binding::ParameterizedFunctionBaseWrapper<Kokkos::HostSpace>(py::mod
             obj->CoeffGradImpl(ToKokkos<double,Kokkos::HostSpace>(input),ToKokkos<double,Kokkos::HostSpace>(sens), ToKokkos<double,Kokkos::HostSpace>(output));
         })
         .def("torch", [](std::shared_ptr<ParameterizedFunctionBase<Kokkos::HostSpace>> obj){
-            return py::module::import("mpart").attr("TorchParameterizedFunctionBase")(obj);
+            auto mpart = py::module::import("mpart");
+            if(!mpart.attr("mpart_has_torch").cast<bool>()){
+                throw std::runtime_error("MParT could not import pytorch.");
+            }
+            return mpart.attr("TorchParameterizedFunctionBase")(obj);
         })
         .def_readonly("numCoeffs", &ParameterizedFunctionBase<Kokkos::HostSpace>::numCoeffs)
         .def_readonly("inputDim", &ParameterizedFunctionBase<Kokkos::HostSpace>::inputDim)

--- a/bindings/python/tests/test_TorchWrapper.py
+++ b/bindings/python/tests/test_TorchWrapper.py
@@ -61,12 +61,13 @@ if haveTorch:
         tmap2 = mt.TorchParameterizedFunctionBase(tmap)
         assert tmap2.coeffs.grad is None
 
-        loss = tmap2.forward(x).sum()
+        loss = tmap2.forward(x.T).sum()
         loss.backward()
         assert tmap2.coeffs.grad is not None
 
         # Use the TorchConditionalMapBase module to compute gradients wrt to the coeffs
         tmap2 = mt.TorchConditionalMapBase(tmap)
+        assert not tmap2.return_logdet
         assert tmap2.coeffs.grad is None
 
         loss = tmap2.forward(x).sum()
@@ -84,17 +85,16 @@ if haveTorch:
         opts = mt.MapOptions()
         tmap = mt.CreateTriangular(dim,dim,3,opts) # Simple third order map
 
-        x = torch.randn(dim,numSamps, dtype=torch.double)
+        x = torch.randn(numSamps, dim, dtype=torch.double)
         tmap2 = tmap.torch()
         y = tmap2.forward(x)
-        
-        assert np.all(y.detach().numpy() == tmap.Evaluate(x.detach().numpy()))
+        assert np.all(y.detach().numpy() == tmap.Evaluate(x.T.detach().numpy()).T)
 
         tmap2 = tmap.torch(return_logdet=True)
         y, logdet = tmap2.forward(x)
         
-        assert np.all(y.detach().numpy() == tmap.Evaluate(x.detach().numpy()))
-        assert np.all(logdet.detach().numpy() == tmap.LogDeterminant(x.detach().numpy()))
+        assert np.all(y.detach().numpy() == tmap.Evaluate(x.T.detach().numpy()).T)
+        assert np.all(logdet.detach().numpy() == tmap.LogDeterminant(x.T.detach().numpy()))
 
 
 if __name__=='__main__':

--- a/bindings/python/tests/test_TorchWrapper.py
+++ b/bindings/python/tests/test_TorchWrapper.py
@@ -1,0 +1,56 @@
+try:
+    import torch
+    haveTorch = True
+except:
+    print('Could not import torch in test_TorchWrapper.py.  PyTorch interface will not be tested.')
+    haveTorch = False
+
+import mpart as mt 
+import numpy as np
+
+if haveTorch:
+
+    numSamps = 5
+    dim = 2
+    x = torch.randn(dim, numSamps, dtype=torch.double)
+    out = torch.zeros(dim,numSamps, dtype=torch.double)
+    grad = torch.zeros(dim, numSamps, dtype=torch.double)
+    sens = torch.ones(dim,numSamps, dtype=torch.double)
+
+    f = mt.IdentityMap(dim, dim)
+
+    def test_Evaluation():
+        f.EvaluateImpl(mt.ExtractTorchTensorData(x), mt.ExtractTorchTensorData(out))
+        assert torch.all(x==out)
+    
+    def test_GradientEvaluation():
+        f.GradientImpl(mt.ExtractTorchTensorData(x), mt.ExtractTorchTensorData(sens), mt.ExtractTorchTensorData(grad))
+        assert torch.all(grad==sens)
+    
+    def test_Autograd():
+        x.requires_grad = True 
+        fx = mt.TorchWrapper_ParameterizedFunction.apply(x,None,f)
+        assert torch.all(fx==x)
+
+        loss = fx.sum()
+        loss.backward()
+        assert torch.all(x.grad==sens)
+
+    def test_AutogradCoeffs():
+        x.requires_grad = False 
+
+        opts = mt.MapOptions()
+        tmap = mt.CreateTriangular(dim,dim,3,opts) # Simple third order map
+
+        coeffs = torch.randn(tmap.numCoeffs, dtype=torch.double)
+        coeffs.requires_grad = True 
+
+        # Check the autograd gradient with finite differences
+        assert torch.autograd.gradcheck(lambda c: mt.TorchWrapper_ParameterizedFunction.apply(x,c,tmap), coeffs)
+
+
+if __name__=='__main__':
+    test_Evaluation()
+    test_GradientEvaluation()
+    test_Autograd()
+    test_AutogradCoeffs()


### PR DESCRIPTION
- Allows an MParT `ParameterizedFunctionBase` or `ConditionalMapBase` object to be used as a module in torch.  This allows torch autograd to propagate gradients through maps and allows neural networks and transport maps to be blended into more complex models.
- Importantly, we do not require pytorch during compilation.  The MParT <-> PyTorch interface will only be include with the python bindings if pytorch if available at the time of `import`
- Pytorch tensors are not copied when calling MParT.  We simply wrap unmanaged Kokkos::Views around the memory in the pytorch tensor.
- Currently only supports pytorch tensors that live on the CPU, but could be extended to work with GPU tensors as well.

- An example using this interface for heteroscedastic regression is in an[ accompanying PR into MParT-examples (PR 46)](https://github.com/MeasureTransport/MParT-examples/pull/46)