### PR TITLE
Fix matlab options

### DIFF
--- a/bindings/matlab/src/ConditionalMap_mex.cpp
+++ b/bindings/matlab/src/ConditionalMap_mex.cpp
@@ -116,7 +116,7 @@ MEX_DEFINE(ConditionalMap_newAffineMapb) (int nlhs, mxArray* plhs[],
 MEX_DEFINE(ConditionalMap_newTotalTriMap) (int nlhs, mxArray* plhs[],
                                            int nrhs, const mxArray* prhs[]) {
 
-  InputArguments input(nrhs, prhs, 15);
+  InputArguments input(nrhs, prhs, 16);
   OutputArguments output(nlhs, plhs, 1);
   unsigned int inputDim = input.get<unsigned int>(0);
   unsigned int outputDim = input.get<unsigned int>(1);
@@ -134,7 +134,7 @@ MEX_DEFINE(ConditionalMap_newTotalTriMap) (int nlhs, mxArray* plhs[],
 MEX_DEFINE(ConditionalMap_newMap) (int nlhs, mxArray* plhs[],
                     int nrhs, const mxArray* prhs[]) {
 
-  InputArguments input(nrhs, prhs, 13);
+  InputArguments input(nrhs, prhs, 14);
   OutputArguments output(nlhs, plhs, 1);
   const MultiIndexSet& mset = Session<MultiIndexSet>::getConst(input.get(0));
   MapOptions opts = binding::MapOptionsFromMatlab(input.get<std::string>(1),input.get<std::string>(2),
@@ -149,7 +149,7 @@ MEX_DEFINE(ConditionalMap_newMap) (int nlhs, mxArray* plhs[],
 MEX_DEFINE(ConditionalMap_newMapFixed) (int nlhs, mxArray* plhs[],
                     int nrhs, const mxArray* prhs[]) {
 
-  InputArguments input(nrhs, prhs, 13);
+  InputArguments input(nrhs, prhs, 14);
   OutputArguments output(nlhs, plhs, 1);
   const FixedMultiIndexSet<MemorySpace>& mset = Session<FixedMultiIndexSet<MemorySpace>>::getConst(input.get(0));
   MapOptions opts = binding::MapOptionsFromMatlab(input.get<std::string>(1),input.get<std::string>(2),

--- a/bindings/matlab/src/ParameterizedFunctionBase_mex.cpp
+++ b/bindings/matlab/src/ParameterizedFunctionBase_mex.cpp
@@ -39,7 +39,7 @@ namespace {
 MEX_DEFINE(ParameterizedFunction_newMap) (int nlhs, mxArray* plhs[],
                     int nrhs, const mxArray* prhs[]) {
 
-  InputArguments input(nrhs, prhs, 14);
+  InputArguments input(nrhs, prhs, 15);
   OutputArguments output(nlhs, plhs, 1);
   unsigned int outputDim = input.get<unsigned int>(0);
   const MultiIndexSet& mset = Session<MultiIndexSet>::getConst(input.get(1));
@@ -205,7 +205,7 @@ MEX_DEFINE(MapOptions_Serialize) (int nlhs, mxArray* plhs[],
                     int nrhs, const mxArray* prhs[]) {
 
 #if defined(MPART_HAS_CEREAL)
-  InputArguments input(nrhs, prhs, 13);
+  InputArguments input(nrhs, prhs, 14);
   OutputArguments output(nlhs, plhs, 1);
 
   std::string filename = input.get<std::string>(0);


### PR DESCRIPTION
Fixes #360 , which was caused by an off-by-one error introduced in #353 .