### PR TITLE
Add move coeffs positional argument for julia binding

### DIFF
--- a/bindings/julia/src/TriangularMap.cpp
+++ b/bindings/julia/src/TriangularMap.cpp
@@ -17,8 +17,8 @@ void mpart::binding::TriangularMapWrapper(jlcxx::Module &mod) {
        .method("GetComponent", &TriangularMap<Kokkos::HostSpace>::GetComponent)
     ;
 
-    mod.method("TriangularMap", [](std::vector<std::shared_ptr<ConditionalMapBase<Kokkos::HostSpace>>> vec){
-        return std::static_pointer_cast<ConditionalMapBase<Kokkos::HostSpace>>(std::make_shared<TriangularMap<Kokkos::HostSpace>>(vec));
+    mod.method("TriangularMap", [](std::vector<std::shared_ptr<ConditionalMapBase<Kokkos::HostSpace>>> vec, bool move_coeffs=false){
+        return std::static_pointer_cast<ConditionalMapBase<Kokkos::HostSpace>>(std::make_shared<TriangularMap<Kokkos::HostSpace>>(vec, move_coeffs));
     });
 
 }

--- a/tests/Distributions/Test_Distributions_Common.h
+++ b/tests/Distributions/Test_Distributions_Common.h
@@ -2,6 +2,7 @@
 #define TEST_DISTRIBUTIONS_COMMON_H
 
 #include<algorithm>
+#include<numeric>
 #include <catch2/catch_all.hpp>
 #include "MParT/Utilities/ArrayConversions.h"
 #include "MParT/Distributions/DensityBase.h"


### PR DESCRIPTION
This was omitted in previous versions.