### PR TITLE
Added sort of nzDims in manual construction of FixedMultiIndexSet.

### DIFF
--- a/MParT/MultiIndices/FixedMultiIndexSet.h
+++ b/MParT/MultiIndices/FixedMultiIndexSet.h
@@ -33,7 +33,10 @@ public:
     /** @brief Construct a fixed multiindex set in compressed form.
 
         Only nonzero orders are stored in this representation.   For multivariate polynomials,
-        the compressed representation can yield faster polynomial evaluations.
+        the compressed representation can yield faster polynomial evaluations.  Note that 
+        the internal order of `nzDims` is guaranteed to to be increasing for each multiindex.  The
+        internal values of `nzDims` might therefore differ from `_nzDims` because they will be 
+        sorted.
     */
     FixedMultiIndexSet(unsigned int                             _dim,
                        Kokkos::View<unsigned int*, MemorySpace> _nzStarts,

--- a/src/MultiIndices/FixedMultiIndexSet.cpp
+++ b/src/MultiIndices/FixedMultiIndexSet.cpp
@@ -68,27 +68,21 @@ namespace mpart{
             
             unsigned int start = nzStarts_(mi);
             unsigned int end = nzStarts_(mi+1);
-            unsigned int minInd;
-            unsigned int temp;
+            unsigned int key, orderKey, j;
 
-            // selection sort to sort dimensions and degrees in order of increasing dimension
-            for (unsigned int ind1 = nzStarts_(mi); ind1<nzStarts_(mi+1)-1; ind1++) {
-                minInd = ind1;
+            // insertion sort 
+            for (unsigned int step = start+1; step < end; step++) {
+                key = nzDims_(step);
+                orderKey = nzOrders_(step);
+                j = step - 1;
 
-                for (unsigned int ind2=ind1+1; ind2<nzStarts_(mi+1); ind2++) {
-                    if (nzDims_(ind2) < nzDims_(minInd))
-                        minInd = ind2;
-                } 
-
-                if (minInd != ind1){
-                    temp = nzDims_(minInd);
-                    nzDims_(minInd) = nzDims_(ind1);
-                    nzDims_(ind1) = temp;
-
-                    temp = nzOrders_(minInd);
-                    nzOrders_(minInd) = nzOrders_(ind1);
-                    nzOrders_(ind1) = temp;
+                while ((key < nzDims_(j)) && (j >= start)) {
+                    nzDims_(j + 1) = nzDims_(j);
+                    nzOrders_(j + 1) = nzOrders_(j);
+                    --j;
                 }
+                nzDims_(j + 1) = key;
+                nzOrders_(j + 1) = orderKey;
             }
         }
 
@@ -196,6 +190,29 @@ FixedMultiIndexSet<MemorySpace>::FixedMultiIndexSet(unsigned int                
 
     CalculateMaxDegrees();
 }
+
+// template<>
+// FixedMultiIndexSet<Kokkos::HostSpace>::FixedMultiIndexSet(unsigned int                dim,
+//                                        Kokkos::View<unsigned int*, Kokkos::HostSpace> nzStarts,
+//                                        Kokkos::View<unsigned int*, Kokkos::HostSpace> nzDims,
+//                                        Kokkos::View<unsigned int*, Kokkos::HostSpace> nzOrders) : dim(dim),
+//                                                                                 isCompressed(true),
+//                                                                                 nzStarts(nzStarts),
+//                                                                                 nzDims(nzDims),
+//                                                                                 nzOrders(nzOrders)
+// {
+//     std::cout << "Here 0 with " << nzStarts.extent(0)-1 << " multiindices in " << dim << " dimensions " << std::endl;
+//     // Sort so that nzDims increases for each multiindex
+//     DimensionSorter<Kokkos::HostSpace> sorter(nzStarts, nzDims, nzOrders);
+//     for(int i=0; i<nzStarts.extent(0)-1; ++i){
+//         sorter(i);
+//     }
+
+//     std::cout << "Here 1" << std::endl;
+
+//     CalculateMaxDegrees();
+// }
+
 
 template<typename MemorySpace>
 FixedMultiIndexSet<MemorySpace>::FixedMultiIndexSet(unsigned int dim,

--- a/src/MultiIndices/FixedMultiIndexSet.cpp
+++ b/src/MultiIndices/FixedMultiIndexSet.cpp
@@ -191,29 +191,6 @@ FixedMultiIndexSet<MemorySpace>::FixedMultiIndexSet(unsigned int                
     CalculateMaxDegrees();
 }
 
-// template<>
-// FixedMultiIndexSet<Kokkos::HostSpace>::FixedMultiIndexSet(unsigned int                dim,
-//                                        Kokkos::View<unsigned int*, Kokkos::HostSpace> nzStarts,
-//                                        Kokkos::View<unsigned int*, Kokkos::HostSpace> nzDims,
-//                                        Kokkos::View<unsigned int*, Kokkos::HostSpace> nzOrders) : dim(dim),
-//                                                                                 isCompressed(true),
-//                                                                                 nzStarts(nzStarts),
-//                                                                                 nzDims(nzDims),
-//                                                                                 nzOrders(nzOrders)
-// {
-//     std::cout << "Here 0 with " << nzStarts.extent(0)-1 << " multiindices in " << dim << " dimensions " << std::endl;
-//     // Sort so that nzDims increases for each multiindex
-//     DimensionSorter<Kokkos::HostSpace> sorter(nzStarts, nzDims, nzOrders);
-//     for(int i=0; i<nzStarts.extent(0)-1; ++i){
-//         sorter(i);
-//     }
-
-//     std::cout << "Here 1" << std::endl;
-
-//     CalculateMaxDegrees();
-// }
-
-
 template<typename MemorySpace>
 FixedMultiIndexSet<MemorySpace>::FixedMultiIndexSet(unsigned int dim,
                                                     unsigned int maxOrder) : dim(dim), isCompressed(true)

--- a/tests/MultiIndices/Test_MultiIndexSet.cpp
+++ b/tests/MultiIndices/Test_MultiIndexSet.cpp
@@ -1,4 +1,5 @@
 #include <catch2/catch_test_macros.hpp>
+#include<Kokkos_Sort.hpp>
 
 #include "MParT/MultiIndices/FixedMultiIndexSet.h"
 #include "MParT/MultiIndices/MultiIndexSet.h"
@@ -38,7 +39,7 @@ TEST_CASE( "Testing dimension sorting in the FixedMultiIndexSet class", "[FixedM
     nzDims(1) = 1; nzOrders(1)=1; // [0,1]
     nzDims(2) = 0; nzOrders(2)=1; // The 1 in [1,2]
     nzDims(3) = 1; nzOrders(3)=2; // The 2 in [1,2]
-    
+
     FixedMultiIndexSet<Kokkos::HostSpace> mset(dim, nzStarts, nzDims, nzOrders);
 
     CHECK(mset.nzDims(3)>mset.nzDims(2));


### PR DESCRIPTION
Ensures FixedMultiIndexSets have the order required in #372 .   To make sure everything can run on host or device, this usess an implementation of selection sort inside a functor evaluated by `Kokkos::parallel_for`.    Any speed savings possible using `std::sort` or something more sophisticated is probably negligible for the dimensions we typically work with.