### PR TITLE
CreateSigmoidExpansion

### DIFF
--- a/.github/environment.yml
+++ b/.github/environment.yml
@@ -13,4 +13,5 @@ dependencies:
   - cereal >= 1.3
   - nlopt >= 2.7
   - pytorch
+  - cxx-compiler
 

--- a/.github/workflows/build-bindings.yml
+++ b/.github/workflows/build-bindings.yml
@@ -114,7 +114,9 @@ jobs:
 
       - name: Setup Matlab Tests
         continue-on-error: true
+        shell: bash -l {0}
         run: |
+          export LD_LIBRARY_PATH=/usr/local/lib64:$LD_LIBRARY_PATH
           sed -i "1s|^|addpath(genpath(\'$GITHUB_WORKSPACE/MPART_INSTALL\'))\n|" $GITHUB_WORKSPACE/mpart/bindings/matlab/tests/runtests.m
           cat $GITHUB_WORKSPACE/mpart/bindings/matlab/tests/runtests.m
 

--- a/MParT/BasisEvaluator.h
+++ b/MParT/BasisEvaluator.h
@@ -79,7 +79,7 @@ class BasisEvaluator {
    * @param dim input dimension of the multivariate basis
    * @param basis1d object(s) used to evaluate the basis
    */
-  BasisEvaluator(int dim, BasisEvaluatorType basis1d) {
+  BasisEvaluator(unsigned int dim, BasisEvaluatorType basis1d) {
     // This class should not be constructed
     assert(false);
   }
@@ -91,7 +91,7 @@ class BasisEvaluator {
    * @param maxOrder Maximum basis order to evaluate
    * @param point Input point to evaluate the \c dim th basis functions at
    */
-  KOKKOS_INLINE_FUNCTION void EvaluateAll(int dim, double *output_eval,
+  KOKKOS_INLINE_FUNCTION void EvaluateAll(unsigned int dim, double *output_eval,
                                           int maxOrder, double point) const {
     assert(false);
   }
@@ -105,7 +105,7 @@ class BasisEvaluator {
    * @param maxOrder Maximum basis order to evaluate
    * @param point Input point to evaluate the \c dim th basis functions at
    */
-  KOKKOS_INLINE_FUNCTION void EvaluateDerivatives(int dim, double *output_eval,
+  KOKKOS_INLINE_FUNCTION void EvaluateDerivatives(unsigned int dim, double *output_eval,
                                                   double *output_diff,
                                                   int maxOrder,
                                                   double point) const {
@@ -124,7 +124,7 @@ class BasisEvaluator {
    * @param point Input point to evaluate the \c dim th basis functions at
    */
   KOKKOS_INLINE_FUNCTION void EvaluateSecondDerivatives(
-      int dim, double *output_eval, double *output_diff, double *output_diff_2,
+      unsigned int dim, double *output_eval, double *output_diff, double *output_diff_2,
       int maxOrder, double point) const {
     assert(false);
   }
@@ -160,7 +160,7 @@ struct GetRectifier<BasisEvaluator<HowHomogeneous, BasisEvaluatorType, Rectifier
 template <typename BasisEvaluatorType>
 class BasisEvaluator<BasisHomogeneity::Homogeneous, BasisEvaluatorType> {
   public:
-  BasisEvaluator(int, BasisEvaluatorType const &basis1d) : basis1d_(basis1d) {}
+  BasisEvaluator(unsigned int, BasisEvaluatorType const &basis1d) : basis1d_(basis1d) {}
 
   /**
    * @brief Helper function to construct a new Basis Evaluator object
@@ -221,7 +221,7 @@ class BasisEvaluator<BasisHomogeneity::OffdiagHomogeneous,
                      Rectifier> {
   public:
   BasisEvaluator(
-      int dim,
+      unsigned int dim,
       Kokkos::pair<OffdiagEvaluatorType, DiagEvaluatorType> const &basis1d)
       : offdiag_(basis1d.first), diag_(basis1d.second), dim_(dim) {}
 
@@ -232,12 +232,12 @@ class BasisEvaluator<BasisHomogeneity::OffdiagHomogeneous,
    * @param offdiag Evaluator for offdiagonal input elements
    * @param diag Evaluator for diagonal input element
    */
-  BasisEvaluator(int dim, OffdiagEvaluatorType const &offdiag,
+  BasisEvaluator(unsigned int dim, OffdiagEvaluatorType const &offdiag,
                  DiagEvaluatorType const &diag)
       : offdiag_(offdiag), diag_(diag), dim_(dim) {}
 
   // EvaluateAll(dim, output, max_order, input)
-  KOKKOS_INLINE_FUNCTION void EvaluateAll(int dim, double *output,
+  KOKKOS_INLINE_FUNCTION void EvaluateAll(unsigned int dim, double *output,
                                           int max_order, double input) const {
     if (dim < dim_ - 1)
       offdiag_.EvaluateAll(output, max_order, input);
@@ -246,7 +246,7 @@ class BasisEvaluator<BasisHomogeneity::OffdiagHomogeneous,
   }
 
   // EvaluateDerivatives(dim, output_eval, output_deriv, max_order, input)
-  KOKKOS_INLINE_FUNCTION void EvaluateDerivatives(int dim, double *output,
+  KOKKOS_INLINE_FUNCTION void EvaluateDerivatives(unsigned int dim, double *output,
                                                   double *output_diff,
                                                   int max_order,
                                                   double input) const {
@@ -257,7 +257,7 @@ class BasisEvaluator<BasisHomogeneity::OffdiagHomogeneous,
   }
 
   // EvaluateSecondDerivatives(dim, output_eval, output_deriv, max_order, input)
-  KOKKOS_INLINE_FUNCTION void EvaluateSecondDerivatives(int dim, double *output,
+  KOKKOS_INLINE_FUNCTION void EvaluateSecondDerivatives(unsigned int dim, double *output,
                                                         double *output_diff,
                                                         double *output_diff2,
                                                         int max_order,
@@ -277,7 +277,7 @@ class BasisEvaluator<BasisHomogeneity::OffdiagHomogeneous,
   }
 #endif
   /// @brief Number of input dimensions for multivariate basis
-  int dim_;
+  unsigned int dim_;
   OffdiagEvaluatorType offdiag_;
   DiagEvaluatorType diag_;
 };
@@ -292,26 +292,26 @@ class BasisEvaluator<BasisHomogeneity::Heterogeneous,
                      std::vector<std::shared_ptr<CommonBasisEvaluatorType>>, Rectifier> {
   public:
   BasisEvaluator(
-      int dim,
+      unsigned int dim,
       std::vector<std::shared_ptr<CommonBasisEvaluatorType>> const &basis1d)
       : basis1d_(basis1d) {
     assert(dim == basis1d.size());  // TODO: Fix
   }
   // EvaluateAll(dim, output, max_order, input)
   // dim is zero-based indexing
-  KOKKOS_INLINE_FUNCTION void EvaluateAll(int dim, double *output,
+  KOKKOS_INLINE_FUNCTION void EvaluateAll(unsigned int dim, double *output,
                                           int max_order, double input) const {
     basis1d_[dim]->EvaluateAll(output, max_order, input);
   }
   // EvaluateDerivatives(dim, output_eval, output_deriv, max_order, input)
-  KOKKOS_INLINE_FUNCTION void EvaluateDerivatives(int dim, double *output,
+  KOKKOS_INLINE_FUNCTION void EvaluateDerivatives(unsigned int dim, double *output,
                                                   double *output_diff,
                                                   int max_order,
                                                   double input) const {
     basis1d_[dim]->EvaluateDerivatives(output, output_diff, max_order, input);
   }
   // EvaluateSecondDerivatives(dim, output_eval, output_deriv, max_order, input)
-  KOKKOS_INLINE_FUNCTION void EvaluateSecondDerivatives(int dim, double *output,
+  KOKKOS_INLINE_FUNCTION void EvaluateSecondDerivatives(unsigned int dim, double *output,
                                                         double *output_diff,
                                                         double *output_diff2,
                                                         int max_order,

--- a/MParT/MapFactory.h
+++ b/MParT/MapFactory.h
@@ -105,20 +105,41 @@ namespace mpart{
 
 
         /**
-        @brief Constructs a (generally) non-monotone multivariate expansion.
-        @param outputDim The output dimension of the expansion.  Each output will be defined by the same multiindex set but will have different coefficients.
-        @param mset The multiindex set specifying which terms should be used in the multivariate expansion.
-        @param options Options specifying the 1d basis functions used in the parameterization.
+        @brief Constructs a "Single entry" map, which is an identity for all but one output dimension.  The active output dimension is defined by a given component.
+        @param dim The dimension of the mapping
+        @param activeInd Which output dimension is "active", i.e., not identity
+        @param comp The component that will be used for the active output dimension.
         */
         template<typename MemorySpace>
         std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateSingleEntryMap(unsigned int dim,
-                                                                                     unsigned int activeInd,
-                                                                                     std::shared_ptr<ConditionalMapBase<MemorySpace>> const &comp);
+                                                                              unsigned int activeInd,
+                                                                              std::shared_ptr<ConditionalMapBase<MemorySpace>> const &comp);
 
+        /**
+         * @brief Create a MultivariateExpansion using a sigmoid object; INTERNAL USE ONLY
+         * 
+         * @details Using the parameters described in \c`opts`, this function creates
+         * a "multivariate expansion" object that uses a collection of sigmoid functions
+         * to map the input space to the output space. The pertinent options are
+         * - \c`opts.basisType` : The type of basis function to use in the expansion for the first \f$d-1\f$ inputs
+         * - \c`opts.posFuncType` : The type of positive function to use in the rectified basis @ref MultivariateExpansionWorker
+         * - \c`opts.edgeWidth` : The width of the "edge terms" on the last input @ref Sigmoid1d
+         * - \c`opts.sigmoidType` : The type of sigmoid function to use in the expansion @ref Sigmoid1d
+         * 
+         * By default, this constructs a total-order multi-index set. Note that, since the basis
+         * evaluator is rectified, this *will always* be a positive-valued function in the first \f$d-1\f$ inputs.
+         * As such, this factory function is largely for internal testing.
+         * 
+         * @tparam MemorySpace 
+         * @param inputDim 
+         * @param centers 
+         * @param opts 
+         * @return std::shared_ptr<ParameterizedFunctionBase<MemorySpace>> 
+         */
         template<typename MemorySpace>
         std::shared_ptr<ParameterizedFunctionBase<MemorySpace>> CreateSigmoidExpansion(
-            unsigned int inputDim, unsigned int maxOrder, StridedVector<double, MemorySpace> centers,
-            MapOptions opts, std::pair<double,double> edgeWidth={1.5,1.5});
+            unsigned int inputDim, StridedVector<double, MemorySpace> centers,
+            MapOptions opts);
 
         /** This struct is used to map the options to functions that can create a map component with types corresponding
             to the options.

--- a/MParT/MapFactory.h
+++ b/MParT/MapFactory.h
@@ -115,6 +115,11 @@ namespace mpart{
                                                                                      unsigned int activeInd,
                                                                                      std::shared_ptr<ConditionalMapBase<MemorySpace>> const &comp);
 
+        template<typename MemorySpace>
+        std::shared_ptr<ParameterizedFunctionBase<MemorySpace>> CreateSigmoidExpansion(
+            unsigned int inputDim, unsigned int maxOrder, StridedVector<double, MemorySpace> centers,
+            MapOptions opts, std::pair<double,double> edgeWidth={1.5,1.5});
+
         /** This struct is used to map the options to functions that can create a map component with types corresponding
             to the options.
         */

--- a/MParT/MapOptions.h
+++ b/MParT/MapOptions.h
@@ -27,6 +27,16 @@ namespace mpart{
         AdaptiveClenshawCurtis
     };
 
+    enum class SigmoidTypes
+    {
+        Logistic
+    };
+
+    enum class EdgeTypes
+    {
+        SoftPlus
+    };
+
     /** @brief struct to hold options used by the MapFactory methods to construct monotone components and triangular maps.
         @details
 
@@ -48,6 +58,12 @@ namespace mpart{
     {
         /** The type of 1d basis function used to define the multivariate expansion. */
         BasisTypes basisType = BasisTypes::ProbabilistHermite;
+
+        /** The type of sigmoid we want to use to define the diagonal of a rectified multivariate expansion */
+        SigmoidTypes sigmoidType = SigmoidTypes::Logistic;
+
+        /** The type of edge terms to use with sigmoids */
+        EdgeTypes edgeType = EdgeTypes::SoftPlus;
 
         /** Linearization bounds for the 1d basis function. The basis function is linearized outside [lb,ub] */
         double basisLB = -std::numeric_limits<double>::infinity();
@@ -112,6 +128,8 @@ namespace mpart{
             ret &= (basisType   == opts2.basisType);
             ret &= (basisLB     == opts2.basisLB);
             ret &= (basisUB     == opts2.basisUB);
+            ret &= (edgeType    == opts2.edgeType);
+            ret &= (sigmoidType == opts2.sigmoidType);
             ret &= (posFuncType == opts2.posFuncType);
             ret &= (quadType    == opts2.quadType);
             ret &= (quadAbsTol  == opts2.quadAbsTol);
@@ -126,13 +144,12 @@ namespace mpart{
         }
 
         virtual std::string String() {
-            std::string btypes[3] = {"ProbabilistHermite", "PhysicistHermite", "HermiteFunctions"};
-            std::string pftypes[2] = {"Exp", "SoftPlus"};
-            std::string qtypes[3] = {"ClenshawCurtis", "AdaptiveSimpson", "AdaptiveClenshawCurtis"};
             std::stringstream ss;
             ss << "basisType = " << btypes[static_cast<unsigned int>(basisType)] << "\n";
             ss << "basisLB = " << basisLB << "\n";
             ss << "basisUB = " << basisUB << "\n";
+            ss << "edgeType = " << etypes[static_cast<unsigned int>(edgeType)] << "\n";
+            ss << "sigmoidType = " << stypes[static_cast<unsigned int>(sigmoidType)] << "\n";
             ss << "basisNorm = " << (basisNorm ? "true" : "false") << "\n";
             ss << "posFuncType = " << pftypes[static_cast<unsigned int>(posFuncType)] << "\n";
             ss << "quadType = " << qtypes[static_cast<unsigned int>(quadType)] << "\n";
@@ -145,6 +162,12 @@ namespace mpart{
             ss << "nugget = " << nugget << "\n";
             return ss.str();
         }
+
+        inline static const std::string btypes[3] = {"ProbabilistHermite", "PhysicistHermite", "HermiteFunctions"};
+        inline static const std::string pftypes[2] = {"Exp", "SoftPlus"};
+        inline static const std::string qtypes[3] = {"ClenshawCurtis", "AdaptiveSimpson", "AdaptiveClenshawCurtis"};
+        inline static const std::string etypes[1] = {"SoftPlus"};
+        inline static const std::string stypes[1] = {"Logistic"};
     };
 };
 

--- a/MParT/MapOptions.h
+++ b/MParT/MapOptions.h
@@ -65,6 +65,9 @@ namespace mpart{
         /** The type of edge terms to use with sigmoids */
         EdgeTypes edgeType = EdgeTypes::SoftPlus;
 
+        /** The shape of the edge terms in a sigmoid expansion */
+        std::pair<double,double> edgeWidth = std::make_pair(1.5, 1.5);
+
         /** Linearization bounds for the 1d basis function. The basis function is linearized outside [lb,ub] */
         double basisLB = -std::numeric_limits<double>::infinity();
         double basisUB =  std::numeric_limits<double>::infinity();

--- a/MParT/MapOptions.h
+++ b/MParT/MapOptions.h
@@ -65,8 +65,8 @@ namespace mpart{
         /** The type of edge terms to use with sigmoids */
         EdgeTypes edgeType = EdgeTypes::SoftPlus;
 
-        /** The shape of the edge terms in a sigmoid expansion */
-        std::pair<double,double> edgeWidth = std::make_pair(1.5, 1.5);
+        /** The "shape" of the edge terms in a sigmoid expansion (larger is "sharper" edge terms)*/
+        double edgeShape = 1.5;
 
         /** Linearization bounds for the 1d basis function. The basis function is linearized outside [lb,ub] */
         double basisLB = -std::numeric_limits<double>::infinity();

--- a/MParT/Sigmoid.h
+++ b/MParT/Sigmoid.h
@@ -19,7 +19,7 @@ namespace mpart {
  * - \c Derivative
  * - \c SecondDerivative
  */
-namespace SigmoidTypes {
+namespace SigmoidTypeSpace {
 struct Logistic {
 	KOKKOS_INLINE_FUNCTION double static Evaluate(double x) {
 		return 0.5 + 0.5 * MathSpace::tanh(x / 2);
@@ -37,7 +37,7 @@ struct Logistic {
 					(1 - 2 * fx);  // Known expression for the second derivative of this
 	}
 };
-}  // namespace SigmoidTypes
+}  // namespace SigmoidTypeSpace
 
 /**
  * @brief Class to represent univariate function space spanned by sigmoids.
@@ -74,9 +74,9 @@ struct Logistic {
  * Currently the minimum order one can construct is 1, i.e., an affine map.
  *
  * @tparam MemorySpace Where the (nonlinear) parameters are stored
- * @tparam SigmoidType Class defining eval, @ref SigmoidTypes
+ * @tparam SigmoidType Class defining eval, @ref SigmoidTypeSpace
  */
-template <typename MemorySpace, typename SigmoidType = SigmoidTypes::Logistic, typename EdgeType = SoftPlus>
+template <typename MemorySpace, typename SigmoidType = SigmoidTypeSpace::Logistic, typename EdgeType = SoftPlus>
 class Sigmoid1d {
  public:
 	/**
@@ -121,7 +121,7 @@ class Sigmoid1d {
 	 * @param max_order Maximum order of basis function to evaluate
 	 * @param input Point to evaluate function
 	 */
-	void EvaluateAll(double* output, int max_order, double input) const {
+	KOKKOS_FUNCTION void EvaluateAll(double* output, int max_order, double input) const {
 		if (order_ < max_order) {
 			std::stringstream ss;
 			ss << "Sigmoid basis evaluation order too large.\n";
@@ -164,7 +164,7 @@ class Sigmoid1d {
 	 * @param max_order Number of sigmoids to evaluate
 	 * @param input Where to evaluate sigmoids
 	 */
-	void EvaluateDerivatives(double* output, double* output_diff, int max_order,
+	KOKKOS_FUNCTION void EvaluateDerivatives(double* output, double* output_diff, int max_order,
 							 double input) const {
 		if (order_ < max_order) {
 			std::stringstream ss;
@@ -218,7 +218,7 @@ class Sigmoid1d {
 	 * @param max_order Maximum order of sigmoid to evaluate
 	 * @param input Where to evaluate the sigmoids
 	 */
-	void EvaluateSecondDerivatives(double* output, double* output_diff,
+	KOKKOS_FUNCTION void EvaluateSecondDerivatives(double* output, double* output_diff,
 								   double* output_diff2, int max_order,
 								   double input) const {
 		if (order_ < max_order) {
@@ -278,7 +278,13 @@ class Sigmoid1d {
 	 *
 	 * @return int
 	 */
-	int GetOrder() const { return order_; }
+	KOKKOS_INLINE_FUNCTION int GetOrder() const { return order_; }
+
+	/// @brief Given the length of centers, return the number of sigmoid levels
+	static double LengthToOrder(int length) {
+		double n_sig_double = (MathSpace::sqrt(1 + 8 * length) - 1) / 2;
+		return n_sig_double;
+	}
 
  private:
 	void Validate() {
@@ -303,7 +309,7 @@ class Sigmoid1d {
 		// Arithmetic sum length calculation
 		// Number of centers should be n_sigmoid_centers = num_sigmoids*(num_sigmoids+1)/2
 		// Solve for num_sigmoids
-		double n_sig_double = (MathSpace::sqrt(1 + 8 * n_sigmoid_centers) - 1) / 2;
+		double n_sig_double = LengthToOrder(n_sigmoid_centers);
 		int n_sig = n_sig_double;
 		if (n_sig < 0 || MathSpace::abs((double)n_sig - n_sig_double) > 1e-15) {
 			std::stringstream ss;
@@ -320,6 +326,7 @@ class Sigmoid1d {
 	static int constexpr START_SIGMOIDS_IDX = 2;
 	Kokkos::View<const double*, MemorySpace> centers_, widths_, weights_;
 };
+
 }  // namespace mpart
 
 #endif  // MPART_SIGMOID_H

--- a/MParT/TrainMap.h
+++ b/MParT/TrainMap.h
@@ -53,6 +53,7 @@ struct TrainOptions {
         ss << "verbose = " << verbose;
         return ss.str();
     }
+
 };
 
 /**

--- a/MParT/TrainMapAdaptive.h
+++ b/MParT/TrainMapAdaptive.h
@@ -39,6 +39,11 @@ struct ATMOptions: public MapOptions, public TrainOptions {
 
         return ss.str();
     }
+
+    ATMOptions() = default;
+
+    ATMOptions(MapOptions mapOpts, TrainOptions trainOpts, MultiIndex maxDegrees_, unsigned int maxPatience_, unsigned int maxSize_) :
+        MapOptions(mapOpts), TrainOptions(trainOpts), maxDegrees(maxDegrees_), maxPatience(maxPatience_), maxSize(maxSize_) {}
 };
 
 /**

--- a/bindings/julia/src/CommonJuliaUtilities.cpp
+++ b/bindings/julia/src/CommonJuliaUtilities.cpp
@@ -24,6 +24,6 @@ void mpart::binding::CommonUtilitiesWrapper(jlcxx::Module &mod)
 {
     mod.method("Initialize", [](){mpart::binding::Initialize(std::vector<std::string> {});});
     mod.method("Initialize", [](std::vector<std::string> v){mpart::binding::Initialize(makeInitArguments(v));});
-    mod.method("Concurrency", &Kokkos::DefaultExecutionSpace::concurrency);
+    mod.method("Concurrency", [](){return Kokkos::DefaultExecutionSpace::concurrency();});
     mod.add_type<Kokkos::LayoutStride>("LayoutStride");
 }

--- a/bindings/julia/src/MapOptions.cpp
+++ b/bindings/julia/src/MapOptions.cpp
@@ -32,9 +32,9 @@ void mpart::binding::MapOptionsWrapper(jlcxx::Module &mod) {
     mod.add_bits<SigmoidTypes>("__SigmoidTypes", jlcxx::julia_type("CppEnum"));
     mod.set_const("__Logistic", SigmoidTypes::Logistic);
 
-    // EdgeTypes
-    mod.add_bits<EdgeTypes>("__EdgeTypes", jlcxx::julia_type("CppEnum"));
-    mod.set_const("__SoftPlus", EdgeTypes::SoftPlus);
+    // EdgeTypes: TODO: SoftPlus overlaps with PosFuncTypes, needs to be fixed
+    // mod.add_bits<EdgeTypes>("__EdgeTypes", jlcxx::julia_type("CppEnum"));
+    // mod.set_const("__SoftPlus", EdgeTypes::SoftPlus);
 
     // MapOptions
     mod.add_type<MapOptions>("__MapOptions")

--- a/bindings/julia/src/MapOptions.cpp
+++ b/bindings/julia/src/MapOptions.cpp
@@ -28,6 +28,14 @@ void mpart::binding::MapOptionsWrapper(jlcxx::Module &mod) {
     mod.set_const("__AdaptiveSimpson", QuadTypes::AdaptiveSimpson);
     mod.set_const("__AdaptiveClenshawCurtis", QuadTypes::AdaptiveClenshawCurtis);
 
+    // SigmoidTypes
+    mod.add_bits<SigmoidTypes>("__SigmoidTypes", jlcxx::julia_type("CppEnum"));
+    mod.set_const("__Logistic", SigmoidTypes::Logistic);
+
+    // EdgeTypes
+    mod.add_bits<EdgeTypes>("__EdgeTypes", jlcxx::julia_type("CppEnum"));
+    mod.set_const("__SoftPlus", EdgeTypes::SoftPlus);
+
     // MapOptions
     mod.add_type<MapOptions>("__MapOptions")
         .method("__basisType!", [](MapOptions &opts, unsigned int basis){ opts.basisType = static_cast<BasisTypes>(basis); })
@@ -36,6 +44,9 @@ void mpart::binding::MapOptionsWrapper(jlcxx::Module &mod) {
         .method("__basisNorm!", [](MapOptions &opts, bool shouldNorm){ opts.basisNorm = shouldNorm; })
         .method("__posFuncType!", [](MapOptions &opts, unsigned int f){ opts.posFuncType = static_cast<PosFuncTypes>(f); })
         .method("__quadType!", [](MapOptions &opts, unsigned int quad){ opts.quadType = static_cast<QuadTypes>(quad); })
+        .method("__sigmoidType!", [](MapOptions &opts, unsigned int sig){ opts.sigmoidType = static_cast<SigmoidTypes>(sig); })
+        .method("__edgeType!", [](MapOptions &opts, unsigned int edge){ opts.edgeType = static_cast<EdgeTypes>(edge); })
+        .method("__edgeShape!", [](MapOptions &opts, double width){ opts.edgeShape = width; })
         .method("__quadAbsTol!", [](MapOptions &opts, double tol){ opts.quadAbsTol = tol; })
         .method("__quadRelTol!", [](MapOptions &opts, double tol){ opts.quadRelTol = tol; })
         .method("__quadMaxSub!", [](MapOptions &opts, unsigned int sub){ opts.quadMaxSub = sub; })

--- a/bindings/matlab/include/MexOptionsConversions.h
+++ b/bindings/matlab/include/MexOptionsConversions.h
@@ -11,27 +11,12 @@
 namespace mpart{
 namespace binding{
 
-    MapOptions  MapOptionsFromMatlab(std::string basisType, std::string posFuncType,
-                                     std::string quadType, double quadAbsTol,
-                                     double quadRelTol, unsigned int quadMaxSub,
-                                     unsigned int quadMinSub,unsigned int quadPts,
-                                     bool contDeriv, double basisLB, double basisUB, 
-                                     bool basisNorm, double nugget);
+    MapOptions MapOptionsFromMatlab(mexplus::InputArguments &input, int start);
 
     void MapOptionsToMatlab(MapOptions opts, mexplus::OutputArguments &output, int start = 0);
 #if defined(MPART_HAS_NLOPT)
     TrainOptions TrainOptionsFromMatlab(mexplus::InputArguments &input, unsigned int start);
     ATMOptions ATMOptionsFromMatlab(mexplus::InputArguments &input, unsigned int start);
-    ATMOptions ATMOptionsFromMatlab(std::string basisType, std::string posFuncType,
-                                    std::string quadType, double quadAbsTol,
-                                    double quadRelTol, unsigned int quadMaxSub,
-                                    unsigned int quadMinSub,unsigned int quadPts,
-                                    bool contDeriv, double basisLB, double basisUB, bool basisNorm,
-                                    std::string opt_alg, double opt_stopval,
-                                    double opt_ftol_rel, double opt_ftol_abs,
-                                    double opt_xtol_rel, double opt_xtol_abs,
-                                    int opt_maxeval, double opt_maxtime, int verbose,
-                                    unsigned int maxPatience, unsigned int maxSize, MultiIndex& maxDegrees);
 #endif // defined(MPART_HAS_NLOPT)
 }
 }

--- a/bindings/matlab/include/MexOptionsConversions.h
+++ b/bindings/matlab/include/MexOptionsConversions.h
@@ -11,6 +11,9 @@
 namespace mpart{
 namespace binding{
 
+    const unsigned int MPART_MEX_MAPOPTIONS_ARGCOUNT = 16;
+    const unsigned int MPART_MEX_TRAINOPTIONS_ARGCOUNT = 9;
+
     MapOptions MapOptionsFromMatlab(mexplus::InputArguments &input, int start);
 
     void MapOptionsToMatlab(MapOptions opts, mexplus::OutputArguments &output, int start = 0);

--- a/bindings/matlab/mat/ATMOptions.m
+++ b/bindings/matlab/mat/ATMOptions.m
@@ -15,30 +15,19 @@ classdef ATMOptions < TrainOptions & MapOptions
             obj.maxDegrees = value;
         end
         function optionsArray = getMexOptions(obj)
-            optionsArray{1} = char(obj.basisType);
-            optionsArray{2} = char(obj.posFuncType);
-            optionsArray{3} = char(obj.quadType);
-            optionsArray{4} = obj.quadAbsTol;
-            optionsArray{5} = obj.quadRelTol;
-            optionsArray{6} = obj.quadMaxSub;
-            optionsArray{7} = obj.quadMinSub;
-            optionsArray{8} = obj.quadPts;
-            optionsArray{9} = obj.contDeriv;
-            optionsArray{10} = obj.basisLB;
-            optionsArray{11} = obj.basisUB;
-            optionsArray{12} = obj.basisNorm;
-            optionsArray{12+1} = char(obj.opt_alg);
-            optionsArray{12+2} = obj.opt_stopval;
-            optionsArray{12+3} = obj.opt_ftol_rel;
-            optionsArray{12+4} = obj.opt_ftol_abs;
-            optionsArray{12+5} = obj.opt_xtol_rel;
-            optionsArray{12+6} = obj.opt_xtol_abs;
-            optionsArray{12+7} = obj.opt_maxeval;
-            optionsArray{12+8} = obj.opt_maxtime;
-            optionsArray{12+9} = obj.verbose;
-            optionsArray{12+9+1} = obj.maxPatience;
-            optionsArray{12+9+2} = obj.maxSize;
-            optionsArray{12+9+3} = obj.maxDegrees.get_id();
+            getMexOptions@MapOptions(obj);
+            optionsArray{16+1} = char(obj.opt_alg);
+            optionsArray{16+2} = obj.opt_stopval;
+            optionsArray{16+3} = obj.opt_ftol_rel;
+            optionsArray{16+4} = obj.opt_ftol_abs;
+            optionsArray{16+5} = obj.opt_xtol_rel;
+            optionsArray{16+6} = obj.opt_xtol_abs;
+            optionsArray{16+7} = obj.opt_maxeval;
+            optionsArray{16+8} = obj.opt_maxtime;
+            optionsArray{16+9} = obj.verbose;
+            optionsArray{16+9+1} = obj.maxPatience;
+            optionsArray{16+9+2} = obj.maxSize;
+            optionsArray{16+9+3} = obj.maxDegrees.get_id();
         end
     end
 end

--- a/bindings/matlab/mat/MapOptions/EdgeTypes.m
+++ b/bindings/matlab/mat/MapOptions/EdgeTypes.m
@@ -1,0 +1,5 @@
+classdef EdgeTypes
+    enumeration
+       SoftPlus
+    end
+ end

--- a/bindings/matlab/mat/MapOptions/MapOptions.m
+++ b/bindings/matlab/mat/MapOptions/MapOptions.m
@@ -1,12 +1,15 @@
 classdef MapOptions
     properties (Access = public)
         basisType = BasisTypes.ProbabilistHermite;
+        sigmoidType = SigmoidTypes.Logistic;
+        edgeType = EdgeTypes.SoftPlus;
         posFuncType = PosFuncTypes.SoftPlus;
         quadType = QuadTypes.AdaptiveSimpson;
         quadAbsTol = 1e-6;
         quadRelTol = 1e-6;
         quadMaxSub = 30;
         quadMinSub = 0;
+        edgeShape = 1.5;
         quadPts = 5;
         contDeriv = true;
         basisLB = log(0);
@@ -30,6 +33,15 @@ classdef MapOptions
         end
         function obj = set.posFuncType(obj,type)
             obj.posFuncType = type;
+        end
+        function obj = set.sigmoidType(obj,type)
+            obj.sigmoidType = type;
+        end
+        function obj = set.edgeShape(obj,value)
+            obj.edgeShape = value;
+        end
+        function obj = set.edgeType(obj,value)
+            obj.edgeType = value;
         end
         function obj = set.quadType(obj,type)
             obj.quadType = type;
@@ -57,18 +69,21 @@ classdef MapOptions
         end
         function optionsArray = getMexOptions(obj)
             optionsArray{1} = char(obj.basisType);
-            optionsArray{2} = char(obj.posFuncType);
-            optionsArray{3} = char(obj.quadType);
-            optionsArray{4} = obj.quadAbsTol;
-            optionsArray{5} = obj.quadRelTol;
-            optionsArray{6} = obj.quadMaxSub;
-            optionsArray{7} = obj.quadMinSub;
-            optionsArray{8} = obj.quadPts;
-            optionsArray{9} = obj.contDeriv;
-            optionsArray{10} = obj.basisLB;
-            optionsArray{11} = obj.basisUB;
-            optionsArray{12} = obj.basisNorm;
-            optionsArray{13} = obj.nugget;
+            optionsArray{2} = char(obj.sigmoidType);
+            optionsArray{3} = char(obj.edgeType);
+            optionsArray{4} = char(obj.posFuncType);
+            optionsArray{5} = char(obj.quadType);
+            optionsArray{6} = obj.quadAbsTol;
+            optionsArray{7} = obj.quadRelTol;
+            optionsArray{8} = obj.quadMaxSub;
+            optionsArray{9} = obj.quadMinSub;
+            optionsArray{10} = obj.edgeShape;
+            optionsArray{11} = obj.quadPts;
+            optionsArray{12} = obj.contDeriv;
+            optionsArray{13} = obj.basisLB;
+            optionsArray{14} = obj.basisUB;
+            optionsArray{15} = obj.basisNorm;
+            optionsArray{16} = obj.nugget;
         end
 
         function res = eq(obj1, obj2)
@@ -78,6 +93,9 @@ classdef MapOptions
             res = res && isequal(obj1.basisUB,     obj2.basisUB);
             res = res && isequal(obj1.basisNorm,   obj2.basisNorm);
             res = res && isequal(obj1.posFuncType, obj2.posFuncType);
+            res = res && isequal(obj1.sigmoidType, obj2.sigmoidType);
+            res = res && isequal(obj1.edgeType,    obj2.edgeType);
+            res = res && isequal(obj1.edgeShape,   obj2.edgeShape);
             res = res && isequal(obj1.quadType,    obj2.quadType);
             res = res && isequal(obj1.quadAbsTol,  obj2.quadAbsTol);
             res = res && isequal(obj1.quadRelTol,  obj2.quadRelTol);
@@ -90,13 +108,13 @@ classdef MapOptions
 
         function Serialize(obj,filename)
             MParT_('MapOptions_Serialize',filename, char(obj.basisType),  ...
-             char(obj.posFuncType), char(obj.quadType), obj.quadAbsTol,   ...
-             obj.quadRelTol, obj.quadMaxSub, obj.quadMinSub, obj.quadPts, ...
-             obj.contDeriv, obj.basisLB, obj.basisUB, obj.basisNorm, obj.nugget)
+            char(obj.sigmoidType), char(obj.edgeType), char(obj.posFuncType), char(obj.quadType), ...
+             obj.quadAbsTol, obj.quadRelTol, obj.quadMaxSub, obj.quadMinSub, obj.edgeShape, ...
+             obj.quadPts, obj.contDeriv, obj.basisLB, obj.basisUB, obj.basisNorm, obj.nugget)
         end
 
         function obj = Deserialize(obj,filename)
-            options_len = 13;
+            options_len = 16;
             optionsArray = cell(options_len,1);
             input_str = [']=MParT_(',char(39),'MapOptions_Deserialize',char(39),',filename);'];
             for i=options_len:-1:1
@@ -108,19 +126,23 @@ classdef MapOptions
                 input_str = [add_str, input_str];
             end
             eval(input_str);
-            obj.basisType = optionsArray{1};
-            obj.posFuncType = optionsArray{2};
-            obj.quadType = optionsArray{3};
-            obj.quadAbsTol = optionsArray{4};
-            obj.quadRelTol = optionsArray{5};
-            obj.quadMaxSub = optionsArray{6};
-            obj.quadMinSub = optionsArray{7};
-            obj.quadPts = optionsArray{8};
-            obj.contDeriv = optionsArray{9};
-            obj.basisLB = optionsArray{10};
-            obj.basisUB = optionsArray{11};
-            obj.basisNorm = optionsArray{12};
-            obj.nugget = optionsArray{13};
+
+            obj.basisType    = optionsArray{1};
+            obj.sigmoidType  = optionsArray{2};
+            obj.edgeType     = optionsArray{3};
+            obj.posFuncType  = optionsArray{4};
+            obj.quadType     = optionsArray{5};
+            obj.quadAbsTol   = optionsArray{6};
+            obj.quadRelTol   = optionsArray{7};
+            obj.quadMaxSub   = optionsArray{8};
+            obj.quadMinSub   = optionsArray{9};
+            obj.edgeShape    = optionsArray{10};
+            obj.quadPts      = optionsArray{11};
+            obj.contDeriv    = optionsArray{12};
+            obj.basisLB      = optionsArray{13};
+            obj.basisUB      = optionsArray{14};
+            obj.basisNorm    = optionsArray{15};
+            obj.nugget       = optionsArray{16};
         end
     end
 

--- a/bindings/matlab/mat/MapOptions/SigmoidTypes.m
+++ b/bindings/matlab/mat/MapOptions/SigmoidTypes.m
@@ -1,0 +1,5 @@
+classdef SigmoidTypes
+    enumeration
+       Logistic
+    end
+ end

--- a/bindings/matlab/src/ConditionalMap_mex.cpp
+++ b/bindings/matlab/src/ConditionalMap_mex.cpp
@@ -13,6 +13,7 @@
 
 using namespace mpart;
 using namespace mexplus;
+using namespace mpart::binding;
 using MemorySpace = Kokkos::HostSpace;
 
 namespace {
@@ -116,7 +117,7 @@ MEX_DEFINE(ConditionalMap_newAffineMapb) (int nlhs, mxArray* plhs[],
 MEX_DEFINE(ConditionalMap_newTotalTriMap) (int nlhs, mxArray* plhs[],
                                            int nrhs, const mxArray* prhs[]) {
 
-  InputArguments input(nrhs, prhs, 16);
+  InputArguments input(nrhs, prhs, 3 + MPART_MEX_MAPOPTIONS_ARGCOUNT);
   OutputArguments output(nlhs, plhs, 1);
   unsigned int inputDim = input.get<unsigned int>(0);
   unsigned int outputDim = input.get<unsigned int>(1);
@@ -130,7 +131,7 @@ MEX_DEFINE(ConditionalMap_newTotalTriMap) (int nlhs, mxArray* plhs[],
 MEX_DEFINE(ConditionalMap_newMap) (int nlhs, mxArray* plhs[],
                     int nrhs, const mxArray* prhs[]) {
 
-  InputArguments input(nrhs, prhs, 14);
+  InputArguments input(nrhs, prhs, 1 + MPART_MEX_MAPOPTIONS_ARGCOUNT);
   OutputArguments output(nlhs, plhs, 1);
   const MultiIndexSet& mset = Session<MultiIndexSet>::getConst(input.get(0));
   MapOptions opts = binding::MapOptionsFromMatlab(input, 1);
@@ -141,7 +142,7 @@ MEX_DEFINE(ConditionalMap_newMap) (int nlhs, mxArray* plhs[],
 MEX_DEFINE(ConditionalMap_newMapFixed) (int nlhs, mxArray* plhs[],
                     int nrhs, const mxArray* prhs[]) {
 
-  InputArguments input(nrhs, prhs, 14);
+  InputArguments input(nrhs, prhs, 1 + MPART_MEX_MAPOPTIONS_ARGCOUNT);
   OutputArguments output(nlhs, plhs, 1);
   const FixedMultiIndexSet<MemorySpace>& mset = Session<FixedMultiIndexSet<MemorySpace>>::getConst(input.get(0));
   MapOptions opts = binding::MapOptionsFromMatlab(input, 1);

--- a/bindings/matlab/src/ConditionalMap_mex.cpp
+++ b/bindings/matlab/src/ConditionalMap_mex.cpp
@@ -122,11 +122,7 @@ MEX_DEFINE(ConditionalMap_newTotalTriMap) (int nlhs, mxArray* plhs[],
   unsigned int outputDim = input.get<unsigned int>(1);
   unsigned int totalOrder = input.get<unsigned int>(2);
 
-  MapOptions opts = binding::MapOptionsFromMatlab(input.get<std::string>(3),input.get<std::string>(4),
-                                         input.get<std::string>(5),input.get<double>(6),
-                                         input.get<double>(7),input.get<unsigned int>(8),
-                                         input.get<unsigned int>(9),input.get<unsigned int>(10),
-                                         input.get<bool>(11),input.get<double>(12),input.get<double>(13),input.get<bool>(14), input.get<double>(15));
+  MapOptions opts = binding::MapOptionsFromMatlab(input, 3);
 
   output.set(0, Session<ConditionalMapMex>::create(new ConditionalMapMex(inputDim,outputDim,totalOrder,opts)));
 }
@@ -137,11 +133,7 @@ MEX_DEFINE(ConditionalMap_newMap) (int nlhs, mxArray* plhs[],
   InputArguments input(nrhs, prhs, 14);
   OutputArguments output(nlhs, plhs, 1);
   const MultiIndexSet& mset = Session<MultiIndexSet>::getConst(input.get(0));
-  MapOptions opts = binding::MapOptionsFromMatlab(input.get<std::string>(1),input.get<std::string>(2),
-                                         input.get<std::string>(3),input.get<double>(4),
-                                         input.get<double>(5),input.get<unsigned int>(6),
-                                         input.get<unsigned int>(7),input.get<unsigned int>(8),
-                                         input.get<bool>(9),input.get<double>(10),input.get<double>(11),input.get<bool>(12), input.get<double>(13));
+  MapOptions opts = binding::MapOptionsFromMatlab(input, 1);
 
   output.set(0, Session<ConditionalMapMex>::create(new ConditionalMapMex(mset.Fix(),opts)));
 }
@@ -152,11 +144,7 @@ MEX_DEFINE(ConditionalMap_newMapFixed) (int nlhs, mxArray* plhs[],
   InputArguments input(nrhs, prhs, 14);
   OutputArguments output(nlhs, plhs, 1);
   const FixedMultiIndexSet<MemorySpace>& mset = Session<FixedMultiIndexSet<MemorySpace>>::getConst(input.get(0));
-  MapOptions opts = binding::MapOptionsFromMatlab(input.get<std::string>(1),input.get<std::string>(2),
-                                         input.get<std::string>(3),input.get<double>(4),
-                                         input.get<double>(5),input.get<unsigned int>(6),
-                                         input.get<unsigned int>(7),input.get<unsigned int>(8),
-                                         input.get<bool>(9),input.get<double>(10),input.get<double>(11),input.get<bool>(12), input.get<double>(13));
+  MapOptions opts = binding::MapOptionsFromMatlab(input, 1);
 
   output.set(0, Session<ConditionalMapMex>::create(new ConditionalMapMex(mset,opts)));
 }

--- a/bindings/matlab/src/MexOptionsConversions.cpp
+++ b/bindings/matlab/src/MexOptionsConversions.cpp
@@ -3,9 +3,6 @@
 
 using namespace mpart;
 
-#define MPART_MEX_MAPOPTIONS_ARGCOUNT 16
-#define MPART_MEX_TRAINOPTIONS_ARGCOUNT 9
-
 MapOptions MapOptionsFromMatlabArgs(
     std::string basisType, std::string sigmoidType,
     std::string edgeType, std::string posFuncType,

--- a/bindings/matlab/src/MexOptionsConversions.cpp
+++ b/bindings/matlab/src/MexOptionsConversions.cpp
@@ -3,11 +3,17 @@
 
 using namespace mpart;
 
-MapOptions  mpart::binding::MapOptionsFromMatlab(std::string basisType, std::string posFuncType,
-                                        std::string quadType, double quadAbsTol,
-                                        double quadRelTol, unsigned int quadMaxSub,
-                                        unsigned int quadMinSub,unsigned int quadPts,
-                                        bool contDeriv, double basisLB, double basisUB, bool basisNorm, double nugget)
+#define MPART_MEX_MAPOPTIONS_ARGCOUNT 16
+#define MPART_MEX_TRAINOPTIONS_ARGCOUNT 9
+
+MapOptions MapOptionsFromMatlabArgs(
+    std::string basisType, std::string sigmoidType,
+    std::string edgeType, std::string posFuncType,
+    std::string quadType, double quadAbsTol,
+    double quadRelTol, unsigned int quadMaxSub,
+    unsigned int quadMinSub, double edgeShape,
+    unsigned int quadPts, bool contDeriv, double basisLB,
+    double basisUB, bool basisNorm, double nugget)
 {
     MapOptions opts;
 
@@ -39,10 +45,23 @@ MapOptions  mpart::binding::MapOptionsFromMatlab(std::string basisType, std::str
     std::cout << "Unknown quadType, value is set to default" <<std::endl;
     }
 
+    if (sigmoidType == "Logistic") {
+    opts.sigmoidType    = SigmoidTypes::Logistic;
+    } else {
+    std::cout << "Unknown sigmoidType, value is set to default" <<std::endl;
+    }
+
+    if (edgeType == "SoftPlus") {
+    opts.edgeType    = EdgeTypes::SoftPlus;
+    } else {
+    std::cout << "Unknown edgeType, value is set to default" <<std::endl;
+    }
+
     opts.quadAbsTol = quadAbsTol;
     opts.quadRelTol = quadRelTol;
     opts.quadMaxSub = quadMaxSub;
     opts.quadMinSub = quadMinSub;
+    opts.edgeShape = edgeShape;
     opts.quadPts = quadPts;
     opts.contDeriv = contDeriv;
     opts.basisLB = basisLB;
@@ -52,37 +71,50 @@ MapOptions  mpart::binding::MapOptionsFromMatlab(std::string basisType, std::str
     return opts;
 }
 
+
+MapOptions mpart::binding::MapOptionsFromMatlab(mexplus::InputArguments &input, int start) {
+    return MapOptionsFromMatlabArgs(
+        input.get<std::string>(start + 0), input.get<std::string>(start + 1),
+        input.get<std::string>(start + 2), input.get<std::string>(start + 3),
+        input.get<std::string>(start + 4), input.get<double>(start + 5),
+        input.get<double>(start + 6), input.get<unsigned int>(start + 7),
+        input.get<unsigned int>(start + 8), input.get<double>(start + 9),
+        input.get<unsigned int>(start + 10), input.get<bool>(start + 11),
+        input.get<double>(start + 12), input.get<double>(start + 13),
+        input.get<bool>(start + 14), input.get<double>(start + 15)
+    );
+}
+
 void mpart::binding::MapOptionsToMatlab(MapOptions opts, mexplus::OutputArguments &output, int start)
 {
     int i = start; // Alias
-    switch(opts.basisType) {
-        case BasisTypes::ProbabilistHermite: output.set(i,"ProbabilistHermite");break;
-        case BasisTypes::PhysicistHermite: output.set(i,"PhysicistHermite");break;
-        case BasisTypes::HermiteFunctions: output.set(i,"HermiteFunctions");break;
-        default: output.set(i,"");break;
+    output.set(i++, MapOptions::btypes[static_cast<unsigned int>(opts.basisType)]); // basisType
+    output.set(i++, MapOptions::stypes[static_cast<unsigned int>(opts.sigmoidType)]); // sigmoidType
+    output.set(i++, MapOptions::etypes[static_cast<unsigned int>(opts.edgeType)]); // edgeType
+    output.set(i++, MapOptions::pftypes[static_cast<unsigned int>(opts.posFuncType)]); // posFuncType
+    output.set(i++, MapOptions::qtypes[static_cast<unsigned int>(opts.quadType)]); // quadType
+    
+    constexpr int numScalars = 10;
+    // bools describe which are integers
+    const std::pair<double,bool> optsScalars[numScalars] = {
+        {double(opts.quadAbsTol),0},
+        {double(opts.quadRelTol),0},
+        {double(opts.quadMaxSub),1},
+        {double(opts.quadMinSub),1},
+        {double(opts.edgeShape),0},
+        {double(opts.quadPts),1},
+        {double(opts.basisLB),0},
+        {double(opts.basisUB),0},
+        {double(opts.nugget),0}
+    };
+    for(int j = 0; j < numScalars; j++) {
+        std::pair<double, bool> p = optsScalars[j];
+        if(p.second) {
+            output.set(i+j,static_cast<unsigned int>(p.first));
+        } else {
+            output.set(i+j,p.first);
+        }
     }
-    switch(opts.posFuncType) {
-        case PosFuncTypes::Exp: output.set(i+1,"Exp");break;
-        case PosFuncTypes::SoftPlus: output.set(i+1,"SoftPlus");break;
-        default: output.set(i+1,"");break;
-    }
-    switch(opts.quadType) {
-        case QuadTypes::ClenshawCurtis: output.set(i+2,"ClenshawCurtis"); break;
-        case QuadTypes::AdaptiveSimpson: output.set(i+2,"AdaptiveSimpson");break;
-        case QuadTypes::AdaptiveClenshawCurtis: output.set(i+2,"AdaptiveClenshawCurtis");break;
-        default: output.set(i+2,"");break;
-    }
-
-    output.set(i+3,opts.quadAbsTol);
-    output.set(i+4,opts.quadRelTol);
-    output.set(i+5,opts.quadMaxSub);
-    output.set(i+6,opts.quadMinSub);
-    output.set(i+7,opts.quadPts);
-    output.set(i+8,opts.contDeriv);
-    output.set(i+9,opts.basisLB);
-    output.set(i+10,opts.basisUB);
-    output.set(i+11,opts.basisNorm);
-    output.set(i+12,opts.nugget);
 }
 
 #if defined(MPART_HAS_NLOPT)
@@ -102,84 +134,12 @@ TrainOptions mpart::binding::TrainOptionsFromMatlab(mexplus::InputArguments &inp
 }
 
 ATMOptions mpart::binding::ATMOptionsFromMatlab(mexplus::InputArguments &input, unsigned int start) {
-    MultiIndex& maxDegrees = *mexplus::Session<MultiIndex>::get(input.get(start+23));
-    return ATMOptionsFromMatlab(input.get<std::string>(start + 0), input.get<std::string>(start + 1),
-                                input.get<std::string>(start + 2), input.get<double>(start + 3),
-                                input.get<double>(start + 4), input.get<unsigned int>(start + 5),
-                                input.get<unsigned int>(start + 6),input.get<unsigned int>(start + 7),
-                                input.get<bool>(start + 8), input.get<double>(start + 9),
-                                input.get<double>(start + 10), input.get<bool>(start + 11),
-                                input.get<std::string>(start + 12), input.get<double>(start + 13),
-                                input.get<double>(start + 14), input.get<double>(start + 15),
-                                input.get<double>(start + 16), input.get<double>(start + 17),
-                                input.get<int>(start + 18), input.get<double>(start + 19),
-                                input.get<int>(start + 20), input.get<unsigned int>(start + 21),
-                                input.get<unsigned int>(start + 22), maxDegrees);
-}
-
-ATMOptions  mpart::binding::ATMOptionsFromMatlab(std::string basisType, std::string posFuncType,
-                                        std::string quadType, double quadAbsTol,
-                                        double quadRelTol, unsigned int quadMaxSub,
-                                        unsigned int quadMinSub,unsigned int quadPts,
-                                        bool contDeriv, double basisLB, double basisUB, bool basisNorm,
-                                        std::string opt_alg, double opt_stopval,
-                                        double opt_ftol_rel, double opt_ftol_abs,
-                                        double opt_xtol_rel, double opt_xtol_abs,
-                                        int opt_maxeval, double opt_maxtime, int verbose,
-                                        unsigned int maxPatience, unsigned int maxSize, MultiIndex& maxDegrees)
-{
-    ATMOptions opts;
-
-    if (basisType == "ProbabilistHermite") {
-    opts.basisType    = BasisTypes::ProbabilistHermite;
-    } else if (basisType == "PhysicistHermite") {
-    opts.basisType    = BasisTypes::PhysicistHermite;
-    } else if (basisType == "HermiteFunctions") {
-    opts.basisType    = BasisTypes::HermiteFunctions;
-    } else {
-    std::cout << "Unknown basisType, value is set to default" <<std::endl;
-    }
-
-    if (posFuncType == "Exp") {
-    opts.posFuncType    = PosFuncTypes::Exp;
-    } else if (posFuncType == "SoftPlus") {
-    opts.posFuncType    = PosFuncTypes::SoftPlus;
-    } else {
-    std::cout << "Unknown posFuncType type, value is set to default" <<std::endl;
-    }
-
-    if (quadType == "ClenshawCurtis") {
-    opts.quadType    = QuadTypes::ClenshawCurtis;
-    } else if (quadType == "AdaptiveSimpson") {
-    opts.quadType    = QuadTypes::AdaptiveSimpson;
-    } else if (quadType == "AdaptiveClenshawCurtis") {
-    opts.quadType    = QuadTypes::AdaptiveClenshawCurtis;
-    } else {
-    std::cout << "Unknown quadType, value is set to default" <<std::endl;
-    }
-
-    opts.quadAbsTol = quadAbsTol;
-    opts.quadRelTol = quadRelTol;
-    opts.quadMaxSub = quadMaxSub;
-    opts.quadMinSub = quadMinSub;
-    opts.quadPts = quadPts;
-    opts.contDeriv = contDeriv;
-    opts.basisLB = basisLB;
-    opts.basisUB = basisUB;
-    opts.basisNorm = basisNorm;
-    opts.opt_alg = opt_alg;
-    opts.opt_stopval = opt_stopval;
-    opts.opt_ftol_rel = opt_ftol_rel;
-    opts.opt_ftol_abs = opt_ftol_abs;
-    opts.opt_xtol_rel = opt_xtol_rel;
-    opts.opt_xtol_abs = opt_xtol_abs;
-    opts.opt_maxeval = opt_maxeval;
-    opts.opt_maxtime = opt_maxtime;
-    opts.verbose = verbose;
-    opts.maxPatience = maxPatience;
-    opts.maxSize = maxSize;
-    opts.maxDegrees = maxDegrees;
-
-    return opts;
+    MapOptions opts = MapOptionsFromMatlab(input, start);
+    TrainOptions trainOpts = TrainOptionsFromMatlab(input, start + MPART_MEX_MAPOPTIONS_ARGCOUNT);
+    unsigned int atmStart = start + MPART_MEX_MAPOPTIONS_ARGCOUNT + MPART_MEX_TRAINOPTIONS_ARGCOUNT;
+    MultiIndex& maxDegrees = *mexplus::Session<MultiIndex>::get(input.get(atmStart));
+    unsigned int maxPatience = input.get<unsigned int>(atmStart + 1);
+    unsigned int maxSize = input.get<unsigned int>(atmStart + 2);
+    return ATMOptions(opts, trainOpts, maxDegrees, maxPatience, maxSize);
 }
 #endif // defined(MPART_HAS_NLOPT)

--- a/bindings/matlab/src/ParameterizedFunctionBase_mex.cpp
+++ b/bindings/matlab/src/ParameterizedFunctionBase_mex.cpp
@@ -43,11 +43,7 @@ MEX_DEFINE(ParameterizedFunction_newMap) (int nlhs, mxArray* plhs[],
   OutputArguments output(nlhs, plhs, 1);
   unsigned int outputDim = input.get<unsigned int>(0);
   const MultiIndexSet& mset = Session<MultiIndexSet>::getConst(input.get(1));
-  MapOptions opts = MapOptionsFromMatlab(input.get<std::string>(2),input.get<std::string>(3),
-                                         input.get<std::string>(4),input.get<double>(5),
-                                         input.get<double>(6),input.get<unsigned int>(7),
-                                         input.get<unsigned int>(8),input.get<unsigned int>(9),
-                                         input.get<bool>(10),input.get<double>(11),input.get<double>(12),input.get<bool>(13),input.get<double>(14));
+  MapOptions opts = MapOptionsFromMatlab(input, 2);
 
   output.set(0, Session<ParameterizedFunctionMex>::create(new ParameterizedFunctionMex(outputDim,mset.Fix(),opts)));
 }

--- a/bindings/matlab/src/ParameterizedFunctionBase_mex.cpp
+++ b/bindings/matlab/src/ParameterizedFunctionBase_mex.cpp
@@ -205,11 +205,7 @@ MEX_DEFINE(MapOptions_Serialize) (int nlhs, mxArray* plhs[],
   OutputArguments output(nlhs, plhs, 1);
 
   std::string filename = input.get<std::string>(0);
-  MapOptions opts = MapOptionsFromMatlab(input.get<std::string>(1),input.get<std::string>(2),
-                                         input.get<std::string>(3),input.get<double>(4),
-                                         input.get<double>(5),input.get<unsigned int>(6),
-                                         input.get<unsigned int>(7),input.get<unsigned int>(8),
-                                         input.get<bool>(9),input.get<double>(10),input.get<double>(11),input.get<bool>(12),input.get<double>(13));
+  MapOptions opts = MapOptionsFromMatlab(input, 1);
   std::ofstream os (filename);
   cereal::BinaryOutputArchive oarchive(os);
   oarchive(opts);

--- a/bindings/python/src/MapOptions.cpp
+++ b/bindings/python/src/MapOptions.cpp
@@ -34,6 +34,14 @@ void mpart::binding::MapOptionsWrapper(py::module &m)
     .value("AdaptiveSimpson",QuadTypes::AdaptiveSimpson)
     .value("AdaptiveClenshawCurtis",QuadTypes::AdaptiveClenshawCurtis);
 
+    // SigmoidTypes
+    py::enum_<SigmoidTypes>(m, "SigmoidTypes")
+    .value("Logistic",SigmoidTypes::Logistic);
+
+    // EdgeTypes
+    py::enum_<EdgeTypes>(m, "EdgeTypes")
+    .value("SoftPlus",EdgeTypes::SoftPlus);
+
     // MapOptions
     py::class_<MapOptions, std::shared_ptr<MapOptions>>(m, "MapOptions")
     .def(py::init<>())
@@ -45,6 +53,9 @@ void mpart::binding::MapOptionsWrapper(py::module &m)
     .def_readwrite("basisUB", &MapOptions::basisUB)
     .def_readwrite("basisNorm", &MapOptions::basisNorm)
     .def_readwrite("posFuncType", &MapOptions::posFuncType)
+    .def_readwrite("edgeType", &MapOptions::edgeType)
+    .def_readwrite("edgeShape", &MapOptions::edgeShape)
+    .def_readwrite("sigmoidType", &MapOptions::sigmoidType)
     .def_readwrite("quadType", &MapOptions::quadType)
     .def_readwrite("quadAbsTol", &MapOptions::quadAbsTol)
     .def_readwrite("quadRelTol", &MapOptions::quadRelTol)

--- a/src/MapFactory.cpp
+++ b/src/MapFactory.cpp
@@ -11,6 +11,7 @@
 #include "MParT/MultivariateExpansionWorker.h"
 #include "MParT/PositiveBijectors.h"
 #include "MParT/LinearizedBasis.h"
+#include "MParT/Sigmoid.h"
 
 using namespace mpart;
 
@@ -168,14 +169,112 @@ std::shared_ptr<ParameterizedFunctionBase<MemorySpace>> mpart::MapFactory::Creat
 }
 
 
+template <typename MemorySpace, typename OffdiagEval, typename Rectifier, typename SigmoidType, typename EdgeType>
+using SigmoidBasisEval = BasisEvaluator<BasisHomogeneity::OffdiagHomogeneous, Kokkos::pair<OffdiagEval, Sigmoid1d<MemorySpace, SigmoidType, EdgeType>>, Rectifier>;
+
+template <typename MemorySpace, typename OffdiagEval, typename Rectifier, typename SigmoidType, typename EdgeType>
+std::shared_ptr<ParameterizedFunctionBase<MemorySpace>> CreateSigmoidExpansionTemplate(unsigned int inputDim, unsigned int maxOrder, StridedVector<double, MemorySpace> centers, std::pair<double,double> edgeWidth) {
+    using BasisEval_T = SigmoidBasisEval<MemorySpace, OffdiagEval, Rectifier, SigmoidType, EdgeType>;
+    Kokkos::View<double*, MemorySpace> widths("Sigmoid Widths", centers.size());
+    Kokkos::View<double*, MemorySpace> weights("Sigmoid Weights", centers.size());
+    int sigmoid_count = centers.size() - 2;
+    double max_order_double = Sigmoid1d<MemorySpace, SigmoidType, EdgeType>::LengthToOrder(sigmoid_count);
+    int max_order = int(max_order_double);
+    if(max_order_double  != double(max_order)) {
+        std::stringstream ss;
+        ss << "Incorrect length of centers, " << centers.size() << ".\n";
+        ss << "Length should be of form 2+(1+2+3+...+n) for some order n";
+        ProcAgnosticError<MemorySpace, std::invalid_argument>::error(
+            ss.str().c_str());
+    }
+    double left_edge = edgeWidth.first;
+    double right_edge = edgeWidth.second;
+    Kokkos::parallel_for(max_order+2, KOKKOS_LAMBDA(unsigned int i) {
+        if (i == max_order) {
+            widths(0) = left_edge;
+            weights(0) = 1./left_edge;
+            return;
+        } else if (i == max_order+1) {
+            widths(1) = right_edge;
+            weights(1) = 1./right_edge;
+            return;
+        }
+        int start_idx = 2+(i*(i+1))/2;
+
+        for(unsigned int j = 0; j < i; j++) {
+            double prev_center, next_center;
+            if(j == 0 || i == 0) {// Use center for left edge term
+                prev_center = centers(0);
+            } else {
+                prev_center = centers(start_idx+j-1);
+            }
+            if(j == i-1 || i == 0) { // Use center for right edge term
+                next_center = centers(1);
+            } else {
+                next_center = centers(start_idx+j);
+            }
+            widths(start_idx + j) = 2/(next_center - prev_center);
+            weights(start_idx + j) = 1.;
+        }
+    });
+    Sigmoid1d<MemorySpace, SigmoidType, EdgeType> sig(centers, widths, weights);
+    OffdiagEval basis1d;
+    BasisEval_T basisEval {inputDim, basis1d, sig};
+    FixedMultiIndexSet<MemorySpace> mset(inputDim, maxOrder);
+    auto output = std::make_shared<MultivariateExpansion<BasisEval_T, MemorySpace>>(1, mset, basisEval);
+    output->WrapCoeffs(Kokkos::View<double*,MemorySpace>("Component Coefficients", output->numCoeffs));
+    return output;
+}
+
+template<typename MemorySpace>
+std::shared_ptr<ParameterizedFunctionBase<MemorySpace>> MapFactory::CreateSigmoidExpansion(
+    unsigned int inputDim, unsigned int maxOrder, StridedVector<double, MemorySpace> centers,
+    MapOptions opts, std::pair<double,double> edgeWidth) {
+    // Check that the opts are valid
+    if (opts.basisType != BasisTypes::HermiteFunctions) {
+        std::string basisString = MapOptions::btypes[static_cast<unsigned int>(opts.basisType)];
+        std::stringstream ss;
+        ss << "Unsupported basis type for sigmoid expansion: " << basisString;
+        ProcAgnosticError<MemorySpace, std::invalid_argument>::error(ss.str().c_str());
+    }
+    if(opts.posFuncType != PosFuncTypes::Exp && opts.posFuncType != PosFuncTypes::SoftPlus) {
+        std::string posString = MapOptions::pftypes[static_cast<unsigned int>(opts.posFuncType)];
+        std::stringstream ss;
+        ss << "Unsupported positive function type for sigmoid expansion: " << posString;
+        ProcAgnosticError<MemorySpace, std::invalid_argument>::error(ss.str().c_str());
+    }
+    if(opts.edgeType != EdgeTypes::SoftPlus) {
+        std::string edgeString = MapOptions::etypes[static_cast<unsigned int>(opts.edgeType)];
+        std::stringstream ss;
+        ss << "Unsupported edge type for sigmoid expansion: " << edgeString;
+        ProcAgnosticError<MemorySpace, std::invalid_argument>::error(ss.str().c_str());
+    }
+    if(opts.sigmoidType != SigmoidTypes::Logistic) {
+        std::string sigmoidString = MapOptions::stypes[static_cast<unsigned int>(opts.sigmoidType)];
+        std::stringstream ss;
+        ss << "Unsupported sigmoid type for sigmoid expansion: " << sigmoidString;
+        ProcAgnosticError<MemorySpace, std::invalid_argument>::error(ss.str().c_str());
+    }
+    // Dispatch to the correct sigmoid expansion template
+    if(opts.posFuncType == PosFuncTypes::Exp) {
+        return CreateSigmoidExpansionTemplate<MemorySpace, HermiteFunction, Exp, SigmoidTypeSpace::Logistic, SoftPlus>(inputDim, maxOrder, centers, edgeWidth);
+    } else if(opts.posFuncType == PosFuncTypes::SoftPlus) {
+        return CreateSigmoidExpansionTemplate<MemorySpace, HermiteFunction, SoftPlus, SigmoidTypeSpace::Logistic, SoftPlus>(inputDim, maxOrder, centers, edgeWidth);
+    }
+    else {
+        return nullptr;
+    }
+}
+
 template std::shared_ptr<ConditionalMapBase<Kokkos::HostSpace>> mpart::MapFactory::CreateComponent<Kokkos::HostSpace>(FixedMultiIndexSet<Kokkos::HostSpace> const&, MapOptions);
 template std::shared_ptr<ParameterizedFunctionBase<Kokkos::HostSpace>> mpart::MapFactory::CreateExpansion<Kokkos::HostSpace>(unsigned int, FixedMultiIndexSet<Kokkos::HostSpace> const&, MapOptions);
 template std::shared_ptr<ConditionalMapBase<Kokkos::HostSpace>> mpart::MapFactory::CreateTriangular<Kokkos::HostSpace>(unsigned int, unsigned int, unsigned int, MapOptions);
 template std::shared_ptr<ConditionalMapBase<Kokkos::HostSpace>> mpart::MapFactory::CreateSingleEntryMap(unsigned int, unsigned int, std::shared_ptr<ConditionalMapBase<Kokkos::HostSpace>> const&);
-
+template std::shared_ptr<ParameterizedFunctionBase<Kokkos::HostSpace>> mpart::MapFactory::CreateSigmoidExpansion<Kokkos::HostSpace>(unsigned int, unsigned int, StridedVector<double, Kokkos::HostSpace>, MapOptions, std::pair<double, double>);
 #if defined(MPART_ENABLE_GPU)
     template std::shared_ptr<ConditionalMapBase<DeviceSpace>> mpart::MapFactory::CreateComponent<DeviceSpace>(FixedMultiIndexSet<DeviceSpace> const&, MapOptions);
     template std::shared_ptr<ParameterizedFunctionBase<DeviceSpace>> mpart::MapFactory::CreateExpansion<DeviceSpace>(unsigned int, FixedMultiIndexSet<DeviceSpace> const&, MapOptions);
     template std::shared_ptr<ConditionalMapBase<DeviceSpace>> mpart::MapFactory::CreateTriangular<DeviceSpace>(unsigned int, unsigned int, unsigned int, MapOptions);
     template std::shared_ptr<ConditionalMapBase<DeviceSpace>> mpart::MapFactory::CreateSingleEntryMap(unsigned int, unsigned int, std::shared_ptr<ConditionalMapBase<DeviceSpace>> const&);
+    template std::shared_ptr<ParameterizedFunctionBase<DeviceSpace>> mpart::MapFactory::CreateSigmoidExpansion<DeviceSpace>(unsigned int, unsigned int, StridedVector<double, DeviceSpace>, MapOptions, std::pair<double, double>);
 #endif

--- a/tests/Test_BasisEvaluator.cpp
+++ b/tests/Test_BasisEvaluator.cpp
@@ -60,7 +60,7 @@ struct NegativeEvaluator: public TestEvaluators {
 };
 
 TEST_CASE( "Testing basis evaluators", "[BasisEvaluators]") {
-    int dim = 3;
+    unsigned int dim = 3;
     const int max_order = 3;
     const double point = 2.3049201;
     double out[max_order+1];

--- a/tests/Test_MultivariateExpansionWorker.cpp
+++ b/tests/Test_MultivariateExpansionWorker.cpp
@@ -12,7 +12,7 @@ using namespace mpart;
 using namespace Catch;
 
 using HomogeneousEval_T = BasisEvaluator<BasisHomogeneity::Homogeneous, ProbabilistHermite>;
-using Sigmoid_T = Sigmoid1d<Kokkos::HostSpace,SigmoidTypes::Logistic>;
+using Sigmoid_T = Sigmoid1d<Kokkos::HostSpace,SigmoidTypeSpace::Logistic>;
 using OffdiagHomogeneousEval_T = BasisEvaluator<BasisHomogeneity::OffdiagHomogeneous, Kokkos::pair<ProbabilistHermite,Sigmoid_T>, Identity>;
 using RectifiedOffdiagHomogeneousEval_T = BasisEvaluator<
     BasisHomogeneity::OffdiagHomogeneous,
@@ -22,10 +22,10 @@ using RectifiedOffdiagHomogeneousEval_T = BasisEvaluator<
 using HeterogeneousEval_T = BasisEvaluator<BasisHomogeneity::Heterogeneous, std::vector<std::shared_ptr<ProbabilistHermite>>>;
 
 template<typename T>
-T CreateEvaluator(int) {assert(false);}
+T CreateEvaluator(unsigned int) {assert(false);}
 
 template<>
-HomogeneousEval_T CreateEvaluator<HomogeneousEval_T>(int) {
+HomogeneousEval_T CreateEvaluator<HomogeneousEval_T>(unsigned int) {
     return HomogeneousEval_T{};
 }
 
@@ -47,18 +47,18 @@ Sigmoid_T CreateDefaultSigmoids() {
         }
     }
 
-    return Sigmoid1d<Kokkos::HostSpace,SigmoidTypes::Logistic> {centers, widths, weights};
+    return Sigmoid1d<Kokkos::HostSpace,SigmoidTypeSpace::Logistic> {centers, widths, weights};
 }
 
 template<>
-OffdiagHomogeneousEval_T CreateEvaluator<OffdiagHomogeneousEval_T>(int dim) {
+OffdiagHomogeneousEval_T CreateEvaluator<OffdiagHomogeneousEval_T>(unsigned int dim) {
     ProbabilistHermite offdiag;
     Sigmoid_T diag = CreateDefaultSigmoids();
     return OffdiagHomogeneousEval_T {dim, Kokkos::make_pair(offdiag, diag)};
 }
 
 template<>
-RectifiedOffdiagHomogeneousEval_T CreateEvaluator<RectifiedOffdiagHomogeneousEval_T>(int dim) {
+RectifiedOffdiagHomogeneousEval_T CreateEvaluator<RectifiedOffdiagHomogeneousEval_T>(unsigned int dim) {
     ProbabilistHermite offdiag;
     Sigmoid_T diag = CreateDefaultSigmoids();
     return RectifiedOffdiagHomogeneousEval_T {dim, Kokkos::make_pair(offdiag, diag)};

--- a/tests/Test_Sigmoid.cpp
+++ b/tests/Test_Sigmoid.cpp
@@ -50,15 +50,15 @@ void TestSigmoidGradients(Function Sigmoid, unsigned int N_grad_points, double f
     }
 }
 
-TEMPLATE_TEST_CASE("Sigmoid1d","[sigmoid1d]", SigmoidTypes::Logistic) {
+TEMPLATE_TEST_CASE("Sigmoid1d","[sigmoid1d]", SigmoidTypeSpace::Logistic) {
     SECTION("Initialization") {
         Kokkos::View<double*, MemorySpace> centers("Sigmoid Centers", 2);
-        Kokkos::View<double*, MemorySpace> widths("Sigmoid Widths", 1);
-        Kokkos::View<double*, MemorySpace> weights("Sigmoid weights", 1);
+        Kokkos::View<double*, MemorySpace> widths("Sigmoid Widths", 3);
+        Kokkos::View<double*, MemorySpace> weights("Sigmoid weights", 2);
 
         CHECK_THROWS_AS((Sigmoid1d<MemorySpace,TestType>(centers, widths, weights)), std::invalid_argument);
         CHECK_THROWS_AS((Sigmoid1d<MemorySpace,TestType>(centers, widths)), std::invalid_argument);
-        int N_wrong = 1+2+3+5;
+        int N_wrong = 2+1+2+3+5;
         centers = Kokkos::View<double*, MemorySpace>("Sigmoid Centers", N_wrong);
         widths = Kokkos::View<double*, MemorySpace>("Sigmoid widths", N_wrong);
         weights = Kokkos::View<double*, MemorySpace>("Sigmoid weights", N_wrong);


### PR DESCRIPTION
This creates a factory method, `CreateSigmoidExpansion`, which does exactly what it sounds like. To be clear, this is not a useful function as-is (stated in the included documentation), because it only uses a rectified BasisEvaluator; i.e. this can only evaluate a multivariate expansion of the form
$$T(x,y) = \sum_{\vec{\alpha}} c_{\vec{\alpha}} r(\Psi_{\vec{\alpha}(x)}(x))s_{\alpha(y)}(y)$$

where $r:\mathbb{R}\to\mathbb{R}^+$, $\vec{\alpha}$ is our multi-index with off-diagonal and diagonal elements corresponding to $x$ and $y$ respectively, and all coefficients with $\vec{\alpha}(y)$ should be positive. What this means is that even the elements of the expansion that do *not* correspond to $y$ are always one sign. This *might* be useful; I genuinely have no idea. However, this is a stepping stone PR to create an easy-to-use `RectifiedMultivariateExpansion` by creating much of the software machinery for it.

Note that this has breaking changes for `MapOptions`, which means that you won't be able to deserialize options from a previous version within this version; I'm not super happy about this, but this is a compromise that doesn't seem easy to avoid. We've already created a type `MapOptions`, which seems to subsume all possible options a map should have from a UX perspective. If I create a new map (not based on the MonotoneComponent) that has its own options, surely `MapOptions` should work to construct that. Otherwise, what's the point? So I'm not really happy about creating a new option type just for a different kind of map to tell our users that "We have maps, but also we have these other things that are also maps but they take different options even though they're the same thing conceptually". On the other hand, renaming it is a bad decision because then we'd have to change basically everything. This is minimally invasive, though unfortunately it is possibly annoying. However, it's easy to print out mapoptions in human-readable format, so porting any serialized version should be easy.