### PR TITLE
Compact monotone component

### DIFF
--- a/MParT/BasisEvaluator.h
+++ b/MParT/BasisEvaluator.h
@@ -234,7 +234,7 @@ class BasisEvaluator<BasisHomogeneity::OffdiagHomogeneous,
    * @param offdiag Evaluator for offdiagonal input elements
    * @param diag Evaluator for diagonal input element
    */
-  BasisEvaluator(unsigned int dim, OffdiagEvaluatorType const &offdiag = OffdiagEvaluatorType(),
+  BasisEvaluator(unsigned int dim = 0, OffdiagEvaluatorType const &offdiag = OffdiagEvaluatorType(),
                  DiagEvaluatorType const &diag = DiagEvaluatorType())
       : offdiag_(offdiag), diag_(diag), dim_(dim) {}
 

--- a/MParT/MapFactory.h
+++ b/MParT/MapFactory.h
@@ -224,7 +224,7 @@ namespace mpart{
             static FactoryFunctionType GetFactoryFunction(MapOptions opts)
             {
                 bool isLinearized = (!isinf(opts.basisLB)) ||(!isinf(opts.basisUB));
-                bool isCompact = false; // TODO: Create Options type here
+                bool isCompact = opts.isCompact;
                 OptionsKeyType optionsKey(opts.basisType, isLinearized, opts.posFuncType, opts.quadType, isCompact);
 
                 auto factoryMap = GetFactoryMap();

--- a/MParT/MapFactory.h
+++ b/MParT/MapFactory.h
@@ -217,14 +217,15 @@ namespace mpart{
         */
         template<typename MemorySpace>
         struct CompFactoryImpl{
-            typedef std::tuple<BasisTypes, bool, PosFuncTypes, QuadTypes> OptionsKeyType;
+            typedef std::tuple<BasisTypes, bool, PosFuncTypes, QuadTypes, bool> OptionsKeyType;
             typedef std::function<std::shared_ptr<ConditionalMapBase<MemorySpace>>(FixedMultiIndexSet<MemorySpace> const&, MapOptions options)> FactoryFunctionType;
             typedef std::map<OptionsKeyType, FactoryFunctionType> FactoryMapType;
 
             static FactoryFunctionType GetFactoryFunction(MapOptions opts)
             {
                 bool isLinearized = (!isinf(opts.basisLB)) ||(!isinf(opts.basisUB));
-                OptionsKeyType optionsKey(opts.basisType, isLinearized, opts.posFuncType, opts.quadType);
+                bool isCompact = false; // TODO: Create Options type here
+                OptionsKeyType optionsKey(opts.basisType, isLinearized, opts.posFuncType, opts.quadType, isCompact);
 
                 auto factoryMap = GetFactoryMap();
 

--- a/MParT/MapOptions.h
+++ b/MParT/MapOptions.h
@@ -77,6 +77,8 @@ namespace mpart{
         double basisLB = -std::numeric_limits<double>::infinity();
         double basisUB =  std::numeric_limits<double>::infinity();
 
+        /** Whether the map should be compactly supported (cannot be linearized, only works with certain other map options */
+        bool isCompact = false;
 
         /** The type of positive bijector used inside the monotonicity-guaranteeing integral
             formulation.

--- a/MParT/MapOptions.h
+++ b/MParT/MapOptions.h
@@ -12,7 +12,8 @@ namespace mpart{
     {
         ProbabilistHermite,
         PhysicistHermite,
-        HermiteFunctions
+        HermiteFunctions,
+        SinusoidLegendre
     };
 
     enum class PosFuncTypes

--- a/MParT/MapOptions.h
+++ b/MParT/MapOptions.h
@@ -13,7 +13,7 @@ namespace mpart{
         ProbabilistHermite,
         PhysicistHermite,
         HermiteFunctions,
-        SinusoidLegendre
+        Legendre
     };
 
     enum class PosFuncTypes

--- a/MParT/MonotoneComponent.h
+++ b/MParT/MonotoneComponent.h
@@ -417,6 +417,9 @@ public:
                 double y_scale = ys(ptInd);
                 if constexpr(isCompact) y_scale *= eval(1);
                 output(ptInd) = RootFinding::InverseSingleBracket<MemorySpace>(y_scale, eval, pt(pt.extent(0)-1), xtol, ytol, info);
+                if constexpr(isCompact) {
+                    output(ptInd) = fmin(fmax(output(ptInd), 0.0), 1.0);
+                }
             }
         };
 

--- a/MParT/MonotoneComponent.h
+++ b/MParT/MonotoneComponent.h
@@ -1110,7 +1110,7 @@ public:
     }
 
     template <class Archive>
-    static void load_and_construct( Archive & ar, cereal::construct<MonotoneComponent<ExpansionType, PosFuncType,QuadratureType,MemorySpace>> & construct )
+    static void load_and_construct( Archive & ar, cereal::construct<MonotoneComponent<ExpansionType, PosFuncType,QuadratureType,MemorySpace,isCompact>> & construct )
     {   
         ExpansionType expansion;
         QuadratureType quad;

--- a/MParT/MonotoneComponent.h
+++ b/MParT/MonotoneComponent.h
@@ -849,7 +849,7 @@ public:
         checkMixedJacobianInput("ContinuousMixedJacobian", jacobian.extent(0), jacobian.extent(1), numTerms, numPts);
 
         // Ask the expansion how much memory it would like for it's one-point cache
-        quad_.SetDim(numTerms+1);
+        if constexpr(isCompact) quad_.SetDim(numTerms+1);
         const unsigned int workspaceSize = quad_.WorkspaceSize();
         const unsigned int cacheSize = expansion_.CacheSize();
 
@@ -891,7 +891,6 @@ public:
                     MonotoneIntegrand<ExpansionType, PosFuncType, decltype(pt),decltype(coeffs), MemorySpace> integrand_denom(cache.data(), expansion_, pt, 1., coeffs, DerivativeFlags::Parameters, nugget_);
                     quad_.Integrate(workspace.data(), integrand_denom, 0, 1, integral_denom.data());
 
-                    expansion_.FillCache2(cache.data(), pt, 0., DerivativeFlags::Parameters);
                     numer_diag_deriv = PosFuncType::Evaluate(df);
                     denom_eval = integral_denom(0);
                     denom_eval_sq = denom_eval*denom_eval;
@@ -925,12 +924,13 @@ public:
 
         checkMixedJacobianInput("ContinuousMixedInputJacobian", jacobian.extent(0), jacobian.extent(1), dim, numPts);
 
-        // Ask the expansion how much memory it would like for its one-point cache
+        // Ask the expansion how much memory it would like for it's one-point cache
+        if constexpr(isCompact) quad_.SetDim(dim_+1);
         const unsigned int workspaceSize = quad_.WorkspaceSize();
-        const unsigned int cacheSize = expansion_.CacheSize() + isCompact*(workspaceSize + dim_ + 1);
+        const unsigned int cacheSize = expansion_.CacheSize();
 
         // Create a policy with enough scratch memory to cache the polynomial evaluations
-        auto cacheBytes = Kokkos::View<double*,MemorySpace>::shmem_size(cacheSize);
+        auto cacheBytes = Kokkos::View<double*,MemorySpace>::shmem_size(cacheSize + isCompact*(workspaceSize + dim_ + 1));
 
         auto functor = KOKKOS_CLASS_LAMBDA (typename Kokkos::TeamPolicy<ExecutionSpace>::member_type team_member) {
 
@@ -963,13 +963,15 @@ public:
                     integral_denom = Kokkos::View<double*,MemorySpace>(team_member.thread_scratch(1), dim_+1);
                     workspace = Kokkos::View<double*,MemorySpace>(team_member.thread_scratch(1), workspaceSize);
 
-                    expansion_.FillCache2(cache.data(), pt, 1., DerivativeFlags::Input);
+                    MonotoneIntegrand<ExpansionType, PosFuncType, decltype(pt),decltype(coeffs), MemorySpace> integrand_denom(cache.data(), expansion_, pt, 1., coeffs, DerivativeFlags::Input, nugget_);
+                    quad_.Integrate(workspace.data(), integrand_denom, 0, 1, integral_denom.data());
+
                     numer_diag_deriv = PosFuncType::Evaluate(df);
                     denom_eval = integral_denom(0);
                     denom_eval_sq = denom_eval*denom_eval;
                 }
 
-                for(unsigned int i=0; i<dim_; ++i){
+                for(unsigned int i=0; i<dim_-isCompact; ++i){
                     // Scale the jacobian by dg(df)
                     double numer_mixed_grad = jacView(i)*dgdf;
                     if constexpr(isCompact) {
@@ -980,6 +982,8 @@ public:
                         jacView(i) = numer_mixed_grad;
                     }
                 }
+                if constexpr(isCompact) jacView(dim_-1) = jacView(dim_-1)*dgdf/denom_eval;
+                
             }
 
         };

--- a/MParT/MultivariateExpansionWorker.h
+++ b/MParT/MultivariateExpansionWorker.h
@@ -130,6 +130,27 @@ public:
     KOKKOS_INLINE_FUNCTION unsigned int InputSize() const {return multiSet_.Length();};
 
     /**
+     @brief Fills cache to evaluate f(0)
+     @details
+     @param polyCache A pointer to the start of the cache.  This memory must be allocated before calling this function.
+     @param derivType
+
+     @see FillCache1, FillCache2
+     */
+    KOKKOS_FUNCTION void FillCache0(double*          polyCache,
+                                    DerivativeFlags::DerivativeType derivType) const
+    {
+        // Only allowed to evaluate, fail if you want derivatives; while possible this is a safety precaution
+        if(derivType == DerivativeFlags::None || derivType == DerivativeFlags::Parameters){
+            for(unsigned int d=0; d<dim_; ++d) {
+                basis1d_.EvaluateAll(d, &polyCache[startPos_(d)], maxDegrees_(d), 0.);
+            }
+        } else {
+            ProcAgnosticError<std::invalid_argument>("Cannot get derivatives for FillCache0");
+        }
+    }
+
+    /**
      @brief Precomputes parts of the cache using all but the last component of the point, i.e., using only \f$x_1,x_2,\ldots,x_{d-1}\f$, not \f$x_d\f$.
      @details
      @tparam PointType The vector type used to define the point.  Can be anything allowing access to components with operator().  Examples are Kokkos::View<double*> or Eigen::VectorXd.  Only the first d-1 components of the vector will be accessed in this function.

--- a/MParT/OrthogonalPolynomial.h
+++ b/MParT/OrthogonalPolynomial.h
@@ -1,5 +1,5 @@
-#ifndef ORTHOGONALPOLYNOMIAL_H
-#define ORTHOGONALPOLYNOMIAL_H
+#ifndef MPART_ORTHOGONALPOLYNOMIAL_H
+#define MPART_ORTHOGONALPOLYNOMIAL_H
 
 #include <Kokkos_Core.hpp>
 #include <cmath>
@@ -326,6 +326,21 @@ protected:
 
 typedef OrthogonalPolynomial<PhysicistHermiteMixer> PhysicistHermite;
 
+
+class ShiftedLegendreMixer{ // Polynomials orthogonal on U[0,1]
+public:
+    KOKKOS_INLINE_FUNCTION double Normalization(unsigned int polyOrder) const { return 1./(2*polyOrder+1);}
+protected:
+    // \f[ p_{k}(x) = (a_k x + b_k) p_{k-1}(x) - c_k p_{k-2}(x) \f]
+    KOKKOS_INLINE_FUNCTION double ak(unsigned int k) const {return  2. * (2. * k - 1)/k;}
+    KOKKOS_INLINE_FUNCTION double bk(unsigned int k) const {return -(2. * k - 1)/k;}
+    KOKKOS_INLINE_FUNCTION double ck(unsigned int k) const {return (k-1.)/k;}
+    KOKKOS_INLINE_FUNCTION double phi0(double) const {return 1.0;}
+    KOKKOS_INLINE_FUNCTION double phi1(double x) const {return 2*x-1;}
+    KOKKOS_INLINE_FUNCTION double phi1_deriv(double) const{return 2.0;};
+};
+
+using ShiftedLegendre = OrthogonalPolynomial<ShiftedLegendreMixer>;
 
 } // namespace mpart
 

--- a/MParT/UnivariateBases.h
+++ b/MParT/UnivariateBases.h
@@ -1,0 +1,155 @@
+#ifndef MPART_UNIVARIATEBASES_H
+#define MPART_UNIVARIATEBASES_H
+
+#include <Kokkos_Core.hpp>
+#include <cmath>
+
+#include <iostream>
+
+#include "MParT/Utilities/MathFunctions.h"
+
+namespace mpart{
+
+/**
+ * @brief Generic class to represent functions
+ * \f[p_0(x)\equiv 1,p_k(x)=sin(2\pi k x)\f]
+ */
+class SineBasis
+{
+public:
+    static constexpr double PI2 = 2*M_PI;
+
+    /* Evaluates all polynomials up to a specified order. */
+    KOKKOS_FUNCTION void EvaluateAll(double*              output,
+                                     unsigned int         maxOrder,
+                                     double               x) const
+    {
+        output[0] = 1.;
+        
+        double sin_x, cos_x, cos_kx;
+
+        if(maxOrder>0) {
+            sin_x = sin(PI2*x);
+            cos_x = cos(PI2*x);
+            cos_kx = cos_x;
+            output[1] = sin_x;
+        }
+
+        for(unsigned int order=2; order<=maxOrder; ++order) {
+            output[order] = output[order-1]*cos_x + cos_kx*sin_x;
+            cos_kx = cos_kx*cos_x - output[order-1]*sin_x;
+        }
+    }
+
+    /** Evaluates the derivative of every polynomial in this family up to degree maxOrder (inclusive).
+        The results are stored in the memory pointed to by the derivs pointer.
+    */
+    KOKKOS_FUNCTION void EvaluateDerivatives(double*      derivs,
+                             unsigned int maxOrder,
+                             double       x) const
+    {
+        derivs[0] = 0.;
+        
+        double sin_x, cos_x, sin_kx;
+
+        if(maxOrder>0) {
+            sin_x = sin(PI2*x);
+            cos_x = cos(PI2*x);
+            sin_kx = sin_x;
+            derivs[1] = cos_x;
+        }
+
+        // d_x sin(2pi k x) = 2pi k cos(2pi k x)
+        for(unsigned int order=2; order<=maxOrder; ++order) {
+            derivs[order] = derivs[order-1]*cos_x - sin_kx*sin_x;
+            sin_kx = sin_kx*cos_x + derivs[order-1]*sin_x;
+            derivs[order-2] *= PI2*(order-2);
+        }
+        if(maxOrder>0) derivs[maxOrder-1] *= PI2*(maxOrder-1);
+        derivs[maxOrder] *= PI2*(maxOrder);
+    }
+
+    /** Evaluates the value and derivative of every polynomial in this family up to degree maxOrder (inclusive).
+        The results are stored in the memory pointed to by the derivs pointer.
+    */
+    KOKKOS_FUNCTION void EvaluateDerivatives(double*      vals,
+                           double*      derivs,
+                           unsigned int maxOrder,
+                           double       x) const
+    {
+        vals[0] = 1.;
+        derivs[0] = 0.;
+        
+        double sin_x, cos_x;
+
+        if(maxOrder>0) {
+            sin_x = sin(PI2*x);
+            cos_x = cos(PI2*x);
+            vals[1] = sin_x;
+            derivs[1] = cos_x;
+        }
+
+        for(unsigned int order=2; order<=maxOrder; ++order) {
+            vals[order] = vals[order-1]*cos_x + derivs[order-1]*sin_x;
+            derivs[order] = derivs[order-1]*cos_x - vals[order-1]*sin_x;
+            derivs[order-2] *= PI2*(order-2);
+        }
+        if(maxOrder>0) derivs[maxOrder-1] *= PI2*(maxOrder-1);
+        derivs[maxOrder] *= PI2*(maxOrder);
+    }
+
+    KOKKOS_FUNCTION void EvaluateSecondDerivatives(double*      vals,
+                                   double*      derivs,
+                                   double*      secondDerivs,
+                                   unsigned int maxOrder,
+                                   double       x) const
+    {
+        vals[0] = 1.;
+        derivs[0] = 0.;
+        secondDerivs[0] = 0.;
+        
+        double sin_x, cos_x;
+
+        if(maxOrder>0) {
+            sin_x = sin(PI2*x);
+            cos_x = cos(PI2*x);
+            vals[1] = sin_x;
+            derivs[1] = cos_x;
+            secondDerivs[1] = -PI2*PI2*vals[1];
+        }
+
+        for(unsigned int order=2; order<=maxOrder; ++order) {
+            vals[order] = vals[order-1]*cos_x + derivs[order-1]*sin_x;
+            derivs[order] = derivs[order-1]*cos_x - vals[order-1]*sin_x;
+            derivs[order-2] *= PI2*(order-2);
+            secondDerivs[order] = -(PI2*order)*(PI2*order)*vals[order];
+        }
+        if(maxOrder > 0) derivs[maxOrder-1] *= PI2*(maxOrder-1);
+        derivs[maxOrder] *= PI2*(maxOrder);
+    }
+
+
+
+    KOKKOS_FUNCTION double Evaluate(unsigned int const order,
+                    double const x) const
+    {
+        return order == 0 ? 1. : sin(PI2*order*x);
+    }
+
+    KOKKOS_FUNCTION double Derivative(unsigned int const order,
+                      double const x) const
+    {
+        return order == 0 ? 0. : PI2*order*cos(PI2*order*x);
+    }
+
+    KOKKOS_FUNCTION double SecondDerivative(unsigned int const order,
+                      double const x) const
+    {
+        return -(PI2*order)*(PI2*order)*sin(PI2*order*x);
+    }
+
+};
+
+} // namespace mpart
+
+#endif

--- a/MParT/Utilities/Serialization.h
+++ b/MParT/Utilities/Serialization.h
@@ -11,8 +11,10 @@
 
 // A macro that can be used for registering the various MonotoneComponent classes with CEREAL
 // This macro is used in the MapFactoryImpl*.cpp files 
-#define REGISTER_MONO_COMP(BASIS_HOMOGENEITY, BASIS_TYPE, POS_TYPE, QUAD_TYPE, MEMORY_SPACE, IS_COMPACT) \
-    CEREAL_REGISTER_TYPE(mpart::MonotoneComponent<mpart::MultivariateExpansionWorker<mpart::BasisEvaluator<BASIS_HOMOGENEITY, BASIS_TYPE>, MEMORY_SPACE>, mpart::POS_TYPE, mpart::QUAD_TYPE<MEMORY_SPACE>, MEMORY_SPACE, IS_COMPACT>)
+#define REGISTER_HOMOGENEOUS_MONO_COMP(BASIS_TYPE, POS_TYPE, QUAD_TYPE, MEMORY_SPACE, IS_COMPACT) \
+    CEREAL_REGISTER_TYPE(mpart::MonotoneComponent<mpart::MultivariateExpansionWorker<mpart::BasisEvaluator<BasisHomogeneity::Homogeneous, BASIS_TYPE>, MEMORY_SPACE>, mpart::POS_TYPE, mpart::QUAD_TYPE<MEMORY_SPACE>, MEMORY_SPACE, IS_COMPACT>)
+#define REGISTER_OFFDIAGHOMOGENEOUS_MONO_COMP(BASIS_TYPE_1, BASIS_TYPE_2, RECTIFIER, POS_TYPE, QUAD_TYPE, MEMORY_SPACE, IS_COMPACT) \
+    CEREAL_REGISTER_TYPE(mpart::MonotoneComponent<mpart::MultivariateExpansionWorker<mpart::BasisEvaluator<BasisHomogeneity::OffdiagHomogeneous, Kokkos::pair<BASIS_TYPE_1, BASIS_TYPE_2>, RECTIFIER>, MEMORY_SPACE>, mpart::POS_TYPE, mpart::QUAD_TYPE<MEMORY_SPACE>, MEMORY_SPACE, IS_COMPACT>)
 
 
 namespace cereal {

--- a/MParT/Utilities/Serialization.h
+++ b/MParT/Utilities/Serialization.h
@@ -11,8 +11,8 @@
 
 // A macro that can be used for registering the various MonotoneComponent classes with CEREAL
 // This macro is used in the MapFactoryImpl*.cpp files 
-#define REGISTER_MONO_COMP(BASIS_HOMOGENEITY, BASIS_TYPE, POS_TYPE, QUAD_TYPE, MEMORY_SPACE) \
-    CEREAL_REGISTER_TYPE(mpart::MonotoneComponent<mpart::MultivariateExpansionWorker<mpart::BasisEvaluator<BASIS_HOMOGENEITY, BASIS_TYPE>, MEMORY_SPACE>, mpart::POS_TYPE, mpart::QUAD_TYPE<MEMORY_SPACE>, MEMORY_SPACE>)
+#define REGISTER_MONO_COMP(BASIS_HOMOGENEITY, BASIS_TYPE, POS_TYPE, QUAD_TYPE, MEMORY_SPACE, IS_COMPACT) \
+    CEREAL_REGISTER_TYPE(mpart::MonotoneComponent<mpart::MultivariateExpansionWorker<mpart::BasisEvaluator<BASIS_HOMOGENEITY, BASIS_TYPE>, MEMORY_SPACE>, mpart::POS_TYPE, mpart::QUAD_TYPE<MEMORY_SPACE>, MEMORY_SPACE, IS_COMPACT>)
 
 
 namespace cereal {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,6 +54,7 @@ target_sources(mpart
     MapFactoryImpl16.cpp
     MapFactoryImpl17.cpp
     MapFactoryImpl18.cpp
+    MapFactoryImpl19.cpp
 
     ${MPART_OPT_FILES}
     Initialization.cpp

--- a/src/MapFactoryImpl1.cpp
+++ b/src/MapFactoryImpl1.cpp
@@ -46,15 +46,15 @@ static auto reg_host_phys_acc_splus_compact = mpart::MapFactory::CompFactoryImpl
 #endif
 
 #if defined(MPART_HAS_CEREAL)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, Exp, AdaptiveClenshawCurtis, Kokkos::HostSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, SoftPlus, AdaptiveClenshawCurtis, Kokkos::HostSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, Exp, AdaptiveClenshawCurtis, Kokkos::HostSpace, true)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, SoftPlus, AdaptiveClenshawCurtis, Kokkos::HostSpace, true)
+REGISTER_HOMOGENEOUS_MONO_COMP(PhysicistHermite, Exp, AdaptiveClenshawCurtis, Kokkos::HostSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(PhysicistHermite, SoftPlus, AdaptiveClenshawCurtis, Kokkos::HostSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(PhysicistHermite, Exp, AdaptiveClenshawCurtis, Kokkos::HostSpace, true)
+REGISTER_HOMOGENEOUS_MONO_COMP(PhysicistHermite, SoftPlus, AdaptiveClenshawCurtis, Kokkos::HostSpace, true)
 #if defined(MPART_ENABLE_GPU)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, Exp, AdaptiveClenshawCurtis, mpart::DeviceSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, SoftPlus, AdaptiveClenshawCurtis, mpart::DeviceSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, Exp, AdaptiveClenshawCurtis, mpart::DeviceSpace, true)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, SoftPlus, AdaptiveClenshawCurtis, mpart::DeviceSpace, true)
+REGISTER_HOMOGENEOUS_MONO_COMP(PhysicistHermite, Exp, AdaptiveClenshawCurtis, mpart::DeviceSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(PhysicistHermite, SoftPlus, AdaptiveClenshawCurtis, mpart::DeviceSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(PhysicistHermite, Exp, AdaptiveClenshawCurtis, mpart::DeviceSpace, true)
+REGISTER_HOMOGENEOUS_MONO_COMP(PhysicistHermite, SoftPlus, AdaptiveClenshawCurtis, mpart::DeviceSpace, true)
 #endif
 
 CEREAL_REGISTER_DYNAMIC_INIT(mpartInitMapFactory1)

--- a/src/MapFactoryImpl1.cpp
+++ b/src/MapFactoryImpl1.cpp
@@ -13,7 +13,7 @@
 using namespace mpart;
 
 
-template<typename MemorySpace, typename PosFuncType>
+template<typename MemorySpace, typename PosFuncType, bool isCompact>
 std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_Phys_ACC(FixedMultiIndexSet<MemorySpace> const& mset, MapOptions opts)
 {
     BasisEvaluator<BasisHomogeneity::Homogeneous,PhysicistHermite> basis1d(opts.basisNorm);
@@ -24,27 +24,38 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_Phys_ACC(Fi
     MultivariateExpansionWorker<BasisEvaluator<BasisHomogeneity::Homogeneous,PhysicistHermite>,MemorySpace> expansion(mset, basis1d);
     std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
-    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv, opts.nugget);
+    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace, isCompact>>(expansion, quad, opts.contDeriv, opts.nugget);
 
     Kokkos::View<const double*, MemorySpace> coeffs = Kokkos::View<double*,MemorySpace>("Component Coefficients", mset.Size());
     output->SetCoeffs(coeffs);
     return output;
 }
 
-static auto reg_host_phys_acc_exp = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, false, PosFuncTypes::Exp, QuadTypes::AdaptiveClenshawCurtis), CreateComponentImpl_Phys_ACC<Kokkos::HostSpace, Exp>));
-static auto reg_host_phys_acc_splus = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, false, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveClenshawCurtis), CreateComponentImpl_Phys_ACC<Kokkos::HostSpace, SoftPlus>));
+static auto reg_host_phys_acc_exp = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, false, PosFuncTypes::Exp, QuadTypes::AdaptiveClenshawCurtis, false), CreateComponentImpl_Phys_ACC<Kokkos::HostSpace, Exp, false>));
+static auto reg_host_phys_acc_splus = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, false, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveClenshawCurtis, false), CreateComponentImpl_Phys_ACC<Kokkos::HostSpace, SoftPlus, false>));
 #if defined(MPART_ENABLE_GPU)
-    static auto reg_device_phys_acc_exp = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, false, PosFuncTypes::Exp, QuadTypes::AdaptiveClenshawCurtis), CreateComponentImpl_Phys_ACC<mpart::DeviceSpace, Exp>));
-    static auto reg_device_phys_acc_splus = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, false, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveClenshawCurtis), CreateComponentImpl_Phys_ACC<mpart::DeviceSpace, SoftPlus>));
+    static auto reg_device_phys_acc_exp = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, false, PosFuncTypes::Exp, QuadTypes::AdaptiveClenshawCurtis, false), CreateComponentImpl_Phys_ACC<mpart::DeviceSpace, Exp, false>));
+    static auto reg_device_phys_acc_splus = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, false, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveClenshawCurtis, false), CreateComponentImpl_Phys_ACC<mpart::DeviceSpace, SoftPlus, false>));
+#endif
+
+static auto reg_host_phys_acc_exp_compact = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, false, PosFuncTypes::Exp, QuadTypes::AdaptiveClenshawCurtis, true), CreateComponentImpl_Phys_ACC<Kokkos::HostSpace, Exp, true>));
+static auto reg_host_phys_acc_splus_compact = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, false, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveClenshawCurtis, true), CreateComponentImpl_Phys_ACC<Kokkos::HostSpace, SoftPlus, true>));
+#if defined(MPART_ENABLE_GPU)
+    static auto reg_device_phys_acc_exp_compact = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, false, PosFuncTypes::Exp, QuadTypes::AdaptiveClenshawCurtis, true), CreateComponentImpl_Phys_ACC<mpart::DeviceSpace, Exp, true>));
+    static auto reg_device_phys_acc_splus_compact = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, false, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveClenshawCurtis, true), CreateComponentImpl_Phys_ACC<mpart::DeviceSpace, SoftPlus, true>));
 #endif
 
 #if defined(MPART_HAS_CEREAL)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, Exp, AdaptiveClenshawCurtis, Kokkos::HostSpace)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, SoftPlus, AdaptiveClenshawCurtis, Kokkos::HostSpace)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, Exp, AdaptiveClenshawCurtis, Kokkos::HostSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, SoftPlus, AdaptiveClenshawCurtis, Kokkos::HostSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, Exp, AdaptiveClenshawCurtis, Kokkos::HostSpace, true)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, SoftPlus, AdaptiveClenshawCurtis, Kokkos::HostSpace, true)
 #if defined(MPART_ENABLE_GPU)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, Exp, AdaptiveClenshawCurtis, mpart::DeviceSpace)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, SoftPlus, AdaptiveClenshawCurtis, mpart::DeviceSpace)
-#endif 
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, Exp, AdaptiveClenshawCurtis, mpart::DeviceSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, SoftPlus, AdaptiveClenshawCurtis, mpart::DeviceSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, Exp, AdaptiveClenshawCurtis, mpart::DeviceSpace, true)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, SoftPlus, AdaptiveClenshawCurtis, mpart::DeviceSpace, true)
+#endif
 
 CEREAL_REGISTER_DYNAMIC_INIT(mpartInitMapFactory1)
 #endif 

--- a/src/MapFactoryImpl10.cpp
+++ b/src/MapFactoryImpl10.cpp
@@ -40,11 +40,11 @@ static auto reg_host_linphys_acc_splus = mpart::MapFactory::CompFactoryImpl<Kokk
 #endif
 
 #if defined(MPART_HAS_CEREAL)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::PhysicistHermite>, Exp, AdaptiveClenshawCurtis, Kokkos::HostSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::PhysicistHermite>, SoftPlus, AdaptiveClenshawCurtis, Kokkos::HostSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(LinearizedBasis<mpart::PhysicistHermite>, Exp, AdaptiveClenshawCurtis, Kokkos::HostSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(LinearizedBasis<mpart::PhysicistHermite>, SoftPlus, AdaptiveClenshawCurtis, Kokkos::HostSpace, false)
 #if defined(MPART_ENABLE_GPU)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::PhysicistHermite>, Exp, AdaptiveClenshawCurtis, mpart::DeviceSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::PhysicistHermite>, SoftPlus, AdaptiveClenshawCurtis, mpart::DeviceSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(LinearizedBasis<mpart::PhysicistHermite>, Exp, AdaptiveClenshawCurtis, mpart::DeviceSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(LinearizedBasis<mpart::PhysicistHermite>, SoftPlus, AdaptiveClenshawCurtis, mpart::DeviceSpace, false)
 #endif 
 CEREAL_REGISTER_DYNAMIC_INIT(mpartInitMapFactory10)
 #endif 

--- a/src/MapFactoryImpl10.cpp
+++ b/src/MapFactoryImpl10.cpp
@@ -24,7 +24,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_LinPhys_ACC
     MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
     std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
-    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv, opts.nugget);
+    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace, false>>(expansion, quad, opts.contDeriv, opts.nugget);
 
     Kokkos::View<const double*,MemorySpace> coeffs = Kokkos::View<double*,MemorySpace>("Component Coefficients", mset.Size());
     output->SetCoeffs(coeffs);
@@ -32,19 +32,19 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_LinPhys_ACC
     return output;
 }
 
-static auto reg_host_linphys_acc_exp = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, true, PosFuncTypes::Exp, QuadTypes::AdaptiveClenshawCurtis), CreateComponentImpl_LinPhys_ACC<Kokkos::HostSpace, Exp>));
-static auto reg_host_linphys_acc_splus = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, true, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveClenshawCurtis), CreateComponentImpl_LinPhys_ACC<Kokkos::HostSpace, SoftPlus>));
+static auto reg_host_linphys_acc_exp = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, true, PosFuncTypes::Exp, QuadTypes::AdaptiveClenshawCurtis, false), CreateComponentImpl_LinPhys_ACC<Kokkos::HostSpace, Exp>));
+static auto reg_host_linphys_acc_splus = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, true, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveClenshawCurtis, false), CreateComponentImpl_LinPhys_ACC<Kokkos::HostSpace, SoftPlus>));
 #if defined(MPART_ENABLE_GPU)
-    static auto reg_device_linphys_acc_exp = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, true, PosFuncTypes::Exp, QuadTypes::AdaptiveClenshawCurtis), CreateComponentImpl_LinPhys_ACC<mpart::DeviceSpace, Exp>));
-    static auto reg_device_linphys_acc_splus = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, true, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveClenshawCurtis), CreateComponentImpl_LinPhys_ACC<mpart::DeviceSpace, SoftPlus>));
+    static auto reg_device_linphys_acc_exp = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, true, PosFuncTypes::Exp, QuadTypes::AdaptiveClenshawCurtis, false), CreateComponentImpl_LinPhys_ACC<mpart::DeviceSpace, Exp>));
+    static auto reg_device_linphys_acc_splus = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, true, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveClenshawCurtis, false), CreateComponentImpl_LinPhys_ACC<mpart::DeviceSpace, SoftPlus>));
 #endif
 
 #if defined(MPART_HAS_CEREAL)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::PhysicistHermite>, Exp, AdaptiveClenshawCurtis, Kokkos::HostSpace)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::PhysicistHermite>, SoftPlus, AdaptiveClenshawCurtis, Kokkos::HostSpace)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::PhysicistHermite>, Exp, AdaptiveClenshawCurtis, Kokkos::HostSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::PhysicistHermite>, SoftPlus, AdaptiveClenshawCurtis, Kokkos::HostSpace, false)
 #if defined(MPART_ENABLE_GPU)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::PhysicistHermite>, Exp, AdaptiveClenshawCurtis, mpart::DeviceSpace)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::PhysicistHermite>, SoftPlus, AdaptiveClenshawCurtis, mpart::DeviceSpace)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::PhysicistHermite>, Exp, AdaptiveClenshawCurtis, mpart::DeviceSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::PhysicistHermite>, SoftPlus, AdaptiveClenshawCurtis, mpart::DeviceSpace, false)
 #endif 
 CEREAL_REGISTER_DYNAMIC_INIT(mpartInitMapFactory10)
 #endif 

--- a/src/MapFactoryImpl11.cpp
+++ b/src/MapFactoryImpl11.cpp
@@ -38,11 +38,11 @@ static auto reg_host_linphys_cc_splus = mpart::MapFactory::CompFactoryImpl<Kokko
 #endif
 
 #if defined(MPART_HAS_CEREAL)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::PhysicistHermite>, Exp, ClenshawCurtisQuadrature, Kokkos::HostSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::PhysicistHermite>, SoftPlus, ClenshawCurtisQuadrature, Kokkos::HostSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(LinearizedBasis<mpart::PhysicistHermite>, Exp, ClenshawCurtisQuadrature, Kokkos::HostSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(LinearizedBasis<mpart::PhysicistHermite>, SoftPlus, ClenshawCurtisQuadrature, Kokkos::HostSpace, false)
 #if defined(MPART_ENABLE_GPU)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::PhysicistHermite>, Exp, ClenshawCurtisQuadrature, mpart::DeviceSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::PhysicistHermite>, SoftPlus, ClenshawCurtisQuadrature, mpart::DeviceSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(LinearizedBasis<mpart::PhysicistHermite>, Exp, ClenshawCurtisQuadrature, mpart::DeviceSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(LinearizedBasis<mpart::PhysicistHermite>, SoftPlus, ClenshawCurtisQuadrature, mpart::DeviceSpace, false)
 #endif 
 CEREAL_REGISTER_DYNAMIC_INIT(mpartInitMapFactory11)
 #endif 

--- a/src/MapFactoryImpl11.cpp
+++ b/src/MapFactoryImpl11.cpp
@@ -22,7 +22,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_LinPhys_CC(
     MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
     std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
-    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv, opts.nugget);
+    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace, false>>(expansion, quad, opts.contDeriv, opts.nugget);
 
     Kokkos::View<const double*,MemorySpace> coeffs = Kokkos::View<double*,MemorySpace>("Component Coefficients", mset.Size());
     output->SetCoeffs(coeffs);
@@ -30,19 +30,19 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_LinPhys_CC(
     return output;
 }
 
-static auto reg_host_linphys_cc_exp = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, true, PosFuncTypes::Exp, QuadTypes::ClenshawCurtis), CreateComponentImpl_LinPhys_CC<Kokkos::HostSpace, Exp>));
-static auto reg_host_linphys_cc_splus = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, true, PosFuncTypes::SoftPlus, QuadTypes::ClenshawCurtis), CreateComponentImpl_LinPhys_CC<Kokkos::HostSpace, SoftPlus>));
+static auto reg_host_linphys_cc_exp = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, true, PosFuncTypes::Exp, QuadTypes::ClenshawCurtis, false), CreateComponentImpl_LinPhys_CC<Kokkos::HostSpace, Exp>));
+static auto reg_host_linphys_cc_splus = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, true, PosFuncTypes::SoftPlus, QuadTypes::ClenshawCurtis, false), CreateComponentImpl_LinPhys_CC<Kokkos::HostSpace, SoftPlus>));
 #if defined(MPART_ENABLE_GPU)
-    static auto reg_device_linphys_cc_exp = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, true, PosFuncTypes::Exp, QuadTypes::ClenshawCurtis), CreateComponentImpl_LinPhys_CC<mpart::DeviceSpace, Exp>));
-    static auto reg_device_linphys_cc_splus = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, true, PosFuncTypes::SoftPlus, QuadTypes::ClenshawCurtis), CreateComponentImpl_LinPhys_CC<mpart::DeviceSpace, SoftPlus>));
+    static auto reg_device_linphys_cc_exp = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, true, PosFuncTypes::Exp, QuadTypes::ClenshawCurtis, false), CreateComponentImpl_LinPhys_CC<mpart::DeviceSpace, Exp>));
+    static auto reg_device_linphys_cc_splus = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, true, PosFuncTypes::SoftPlus, QuadTypes::ClenshawCurtis, false), CreateComponentImpl_LinPhys_CC<mpart::DeviceSpace, SoftPlus>));
 #endif
 
 #if defined(MPART_HAS_CEREAL)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::PhysicistHermite>, Exp, ClenshawCurtisQuadrature, Kokkos::HostSpace)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::PhysicistHermite>, SoftPlus, ClenshawCurtisQuadrature, Kokkos::HostSpace)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::PhysicistHermite>, Exp, ClenshawCurtisQuadrature, Kokkos::HostSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::PhysicistHermite>, SoftPlus, ClenshawCurtisQuadrature, Kokkos::HostSpace, false)
 #if defined(MPART_ENABLE_GPU)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::PhysicistHermite>, Exp, ClenshawCurtisQuadrature, mpart::DeviceSpace)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::PhysicistHermite>, SoftPlus, ClenshawCurtisQuadrature, mpart::DeviceSpace)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::PhysicistHermite>, Exp, ClenshawCurtisQuadrature, mpart::DeviceSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::PhysicistHermite>, SoftPlus, ClenshawCurtisQuadrature, mpart::DeviceSpace, false)
 #endif 
 CEREAL_REGISTER_DYNAMIC_INIT(mpartInitMapFactory11)
 #endif 

--- a/src/MapFactoryImpl12.cpp
+++ b/src/MapFactoryImpl12.cpp
@@ -21,7 +21,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_LinPhys_AS(
     MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
     std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
-    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv, opts.nugget);
+    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace, false>>(expansion, quad, opts.contDeriv, opts.nugget);
 
     Kokkos::View<const double*,MemorySpace> coeffs = Kokkos::View<double*,MemorySpace>("Component Coefficients", mset.Size());
     output->SetCoeffs(coeffs);
@@ -29,19 +29,19 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_LinPhys_AS(
     return output;
 }
 
-static auto reg_host_linphys_as_exp = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, true, PosFuncTypes::Exp, QuadTypes::AdaptiveSimpson), CreateComponentImpl_LinPhys_AS<Kokkos::HostSpace, Exp>));
-static auto reg_host_linphys_as_splus = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, true, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveSimpson), CreateComponentImpl_LinPhys_AS<Kokkos::HostSpace, SoftPlus>));
+static auto reg_host_linphys_as_exp = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, true, PosFuncTypes::Exp, QuadTypes::AdaptiveSimpson, false), CreateComponentImpl_LinPhys_AS<Kokkos::HostSpace, Exp>));
+static auto reg_host_linphys_as_splus = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, true, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveSimpson, false), CreateComponentImpl_LinPhys_AS<Kokkos::HostSpace, SoftPlus>));
 #if defined(MPART_ENABLE_GPU)
-    static auto reg_device_linphys_as_exp = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, true, PosFuncTypes::Exp, QuadTypes::AdaptiveSimpson), CreateComponentImpl_LinPhys_AS<mpart::DeviceSpace, Exp>));
-    static auto reg_device_linphys_as_splus = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, true, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveSimpson), CreateComponentImpl_LinPhys_AS<mpart::DeviceSpace, SoftPlus>));
+    static auto reg_device_linphys_as_exp = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, true, PosFuncTypes::Exp, QuadTypes::AdaptiveSimpson, false), CreateComponentImpl_LinPhys_AS<mpart::DeviceSpace, Exp>));
+    static auto reg_device_linphys_as_splus = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, true, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveSimpson, false), CreateComponentImpl_LinPhys_AS<mpart::DeviceSpace, SoftPlus>));
 #endif
 
 #if defined(MPART_HAS_CEREAL)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::PhysicistHermite>, Exp, AdaptiveSimpson, Kokkos::HostSpace)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::PhysicistHermite>, SoftPlus, AdaptiveSimpson, Kokkos::HostSpace)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::PhysicistHermite>, Exp, AdaptiveSimpson, Kokkos::HostSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::PhysicistHermite>, SoftPlus, AdaptiveSimpson, Kokkos::HostSpace, false)
 #if defined(MPART_ENABLE_GPU)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::PhysicistHermite>, Exp, AdaptiveSimpson, mpart::DeviceSpace)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::PhysicistHermite>, SoftPlus, AdaptiveSimpson, mpart::DeviceSpace)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::PhysicistHermite>, Exp, AdaptiveSimpson, mpart::DeviceSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::PhysicistHermite>, SoftPlus, AdaptiveSimpson, mpart::DeviceSpace, false)
 #endif 
 CEREAL_REGISTER_DYNAMIC_INIT(mpartInitMapFactory12)
 #endif

--- a/src/MapFactoryImpl12.cpp
+++ b/src/MapFactoryImpl12.cpp
@@ -37,11 +37,11 @@ static auto reg_host_linphys_as_splus = mpart::MapFactory::CompFactoryImpl<Kokko
 #endif
 
 #if defined(MPART_HAS_CEREAL)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::PhysicistHermite>, Exp, AdaptiveSimpson, Kokkos::HostSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::PhysicistHermite>, SoftPlus, AdaptiveSimpson, Kokkos::HostSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(LinearizedBasis<mpart::PhysicistHermite>, Exp, AdaptiveSimpson, Kokkos::HostSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(LinearizedBasis<mpart::PhysicistHermite>, SoftPlus, AdaptiveSimpson, Kokkos::HostSpace, false)
 #if defined(MPART_ENABLE_GPU)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::PhysicistHermite>, Exp, AdaptiveSimpson, mpart::DeviceSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::PhysicistHermite>, SoftPlus, AdaptiveSimpson, mpart::DeviceSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(LinearizedBasis<mpart::PhysicistHermite>, Exp, AdaptiveSimpson, mpart::DeviceSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(LinearizedBasis<mpart::PhysicistHermite>, SoftPlus, AdaptiveSimpson, mpart::DeviceSpace, false)
 #endif 
 CEREAL_REGISTER_DYNAMIC_INIT(mpartInitMapFactory12)
 #endif

--- a/src/MapFactoryImpl13.cpp
+++ b/src/MapFactoryImpl13.cpp
@@ -23,7 +23,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_LinProb_ACC
     MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
     std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
-    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv, opts.nugget);
+    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace, false>>(expansion, quad, opts.contDeriv, opts.nugget);
 
     Kokkos::View<const double*,MemorySpace> coeffs = Kokkos::View<double*,MemorySpace>("Component Coefficients", mset.Size());
     output->SetCoeffs(coeffs);
@@ -31,19 +31,19 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_LinProb_ACC
     return output;
 }
 
-static auto reg_host_linprob_acc_exp = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, true, PosFuncTypes::Exp, QuadTypes::AdaptiveClenshawCurtis), CreateComponentImpl_LinProb_ACC<Kokkos::HostSpace, Exp>));
-static auto reg_host_linprob_acc_splus = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, true, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveClenshawCurtis), CreateComponentImpl_LinProb_ACC<Kokkos::HostSpace, SoftPlus>));
+static auto reg_host_linprob_acc_exp = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, true, PosFuncTypes::Exp, QuadTypes::AdaptiveClenshawCurtis, false), CreateComponentImpl_LinProb_ACC<Kokkos::HostSpace, Exp>));
+static auto reg_host_linprob_acc_splus = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, true, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveClenshawCurtis, false), CreateComponentImpl_LinProb_ACC<Kokkos::HostSpace, SoftPlus>));
 #if defined(MPART_ENABLE_GPU)
-    static auto reg_device_linprob_acc_exp = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, true, PosFuncTypes::Exp, QuadTypes::AdaptiveClenshawCurtis), CreateComponentImpl_LinProb_ACC<mpart::DeviceSpace, Exp>));
-    static auto reg_device_linprob_acc_splus = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, true, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveClenshawCurtis), CreateComponentImpl_LinProb_ACC<mpart::DeviceSpace, SoftPlus>));
+    static auto reg_device_linprob_acc_exp = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, true, PosFuncTypes::Exp, QuadTypes::AdaptiveClenshawCurtis, false), CreateComponentImpl_LinProb_ACC<mpart::DeviceSpace, Exp>));
+    static auto reg_device_linprob_acc_splus = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, true, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveClenshawCurtis, false), CreateComponentImpl_LinProb_ACC<mpart::DeviceSpace, SoftPlus>));
 #endif
 
 #if defined(MPART_HAS_CEREAL)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::ProbabilistHermite>, Exp, AdaptiveClenshawCurtis, Kokkos::HostSpace)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::ProbabilistHermite>, SoftPlus, AdaptiveClenshawCurtis, Kokkos::HostSpace)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::ProbabilistHermite>, Exp, AdaptiveClenshawCurtis, Kokkos::HostSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::ProbabilistHermite>, SoftPlus, AdaptiveClenshawCurtis, Kokkos::HostSpace, false)
 #if defined(MPART_ENABLE_GPU)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::ProbabilistHermite>, Exp, AdaptiveClenshawCurtis, mpart::DeviceSpace)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::ProbabilistHermite>, SoftPlus, AdaptiveClenshawCurtis, mpart::DeviceSpace)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::ProbabilistHermite>, Exp, AdaptiveClenshawCurtis, mpart::DeviceSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::ProbabilistHermite>, SoftPlus, AdaptiveClenshawCurtis, mpart::DeviceSpace, false)
 #endif 
 CEREAL_REGISTER_DYNAMIC_INIT(mpartInitMapFactory13)
 #endif 

--- a/src/MapFactoryImpl13.cpp
+++ b/src/MapFactoryImpl13.cpp
@@ -39,11 +39,11 @@ static auto reg_host_linprob_acc_splus = mpart::MapFactory::CompFactoryImpl<Kokk
 #endif
 
 #if defined(MPART_HAS_CEREAL)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::ProbabilistHermite>, Exp, AdaptiveClenshawCurtis, Kokkos::HostSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::ProbabilistHermite>, SoftPlus, AdaptiveClenshawCurtis, Kokkos::HostSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(LinearizedBasis<mpart::ProbabilistHermite>, Exp, AdaptiveClenshawCurtis, Kokkos::HostSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(LinearizedBasis<mpart::ProbabilistHermite>, SoftPlus, AdaptiveClenshawCurtis, Kokkos::HostSpace, false)
 #if defined(MPART_ENABLE_GPU)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::ProbabilistHermite>, Exp, AdaptiveClenshawCurtis, mpart::DeviceSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::ProbabilistHermite>, SoftPlus, AdaptiveClenshawCurtis, mpart::DeviceSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(LinearizedBasis<mpart::ProbabilistHermite>, Exp, AdaptiveClenshawCurtis, mpart::DeviceSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(LinearizedBasis<mpart::ProbabilistHermite>, SoftPlus, AdaptiveClenshawCurtis, mpart::DeviceSpace, false)
 #endif 
 CEREAL_REGISTER_DYNAMIC_INIT(mpartInitMapFactory13)
 #endif 

--- a/src/MapFactoryImpl14.cpp
+++ b/src/MapFactoryImpl14.cpp
@@ -21,7 +21,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_LinProb_CC(
     MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
     std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
-    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv, opts.nugget);
+    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace, false>>(expansion, quad, opts.contDeriv, opts.nugget);
 
     Kokkos::View<const double*,MemorySpace> coeffs = Kokkos::View<double*,MemorySpace>("Component Coefficients", mset.Size());
     output->SetCoeffs(coeffs);
@@ -29,19 +29,19 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_LinProb_CC(
     return output;
 }
 
-static auto reg_host_linprob_cc_exp = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, true, PosFuncTypes::Exp, QuadTypes::ClenshawCurtis), CreateComponentImpl_LinProb_CC<Kokkos::HostSpace, Exp>));
-static auto reg_host_linprob_cc_splus = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, true, PosFuncTypes::SoftPlus, QuadTypes::ClenshawCurtis), CreateComponentImpl_LinProb_CC<Kokkos::HostSpace, SoftPlus>));
+static auto reg_host_linprob_cc_exp = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, true, PosFuncTypes::Exp, QuadTypes::ClenshawCurtis, false), CreateComponentImpl_LinProb_CC<Kokkos::HostSpace, Exp>));
+static auto reg_host_linprob_cc_splus = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, true, PosFuncTypes::SoftPlus, QuadTypes::ClenshawCurtis, false), CreateComponentImpl_LinProb_CC<Kokkos::HostSpace, SoftPlus>));
 #if defined(MPART_ENABLE_GPU)
-    static auto reg_device_linprob_cc_exp = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, true, PosFuncTypes::Exp, QuadTypes::ClenshawCurtis), CreateComponentImpl_LinProb_CC<mpart::DeviceSpace, Exp>));
-    static auto reg_device_linprob_cc_splus = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, true, PosFuncTypes::SoftPlus, QuadTypes::ClenshawCurtis), CreateComponentImpl_LinProb_CC<mpart::DeviceSpace, SoftPlus>));
+    static auto reg_device_linprob_cc_exp = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, true, PosFuncTypes::Exp, QuadTypes::ClenshawCurtis, false), CreateComponentImpl_LinProb_CC<mpart::DeviceSpace, Exp>));
+    static auto reg_device_linprob_cc_splus = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, true, PosFuncTypes::SoftPlus, QuadTypes::ClenshawCurtis, false), CreateComponentImpl_LinProb_CC<mpart::DeviceSpace, SoftPlus>));
 #endif
 
 #if defined(MPART_HAS_CEREAL)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::ProbabilistHermite>, Exp, ClenshawCurtisQuadrature, Kokkos::HostSpace)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::ProbabilistHermite>, SoftPlus, ClenshawCurtisQuadrature, Kokkos::HostSpace)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::ProbabilistHermite>, Exp, ClenshawCurtisQuadrature, Kokkos::HostSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::ProbabilistHermite>, SoftPlus, ClenshawCurtisQuadrature, Kokkos::HostSpace, false)
 #if defined(MPART_ENABLE_GPU)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::ProbabilistHermite>, Exp, ClenshawCurtisQuadrature, mpart::DeviceSpace)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::ProbabilistHermite>, SoftPlus, ClenshawCurtisQuadrature, mpart::DeviceSpace)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::ProbabilistHermite>, Exp, ClenshawCurtisQuadrature, mpart::DeviceSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::ProbabilistHermite>, SoftPlus, ClenshawCurtisQuadrature, mpart::DeviceSpace, false)
 #endif 
 CEREAL_REGISTER_DYNAMIC_INIT(mpartInitMapFactory14)
 #endif 

--- a/src/MapFactoryImpl14.cpp
+++ b/src/MapFactoryImpl14.cpp
@@ -37,11 +37,11 @@ static auto reg_host_linprob_cc_splus = mpart::MapFactory::CompFactoryImpl<Kokko
 #endif
 
 #if defined(MPART_HAS_CEREAL)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::ProbabilistHermite>, Exp, ClenshawCurtisQuadrature, Kokkos::HostSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::ProbabilistHermite>, SoftPlus, ClenshawCurtisQuadrature, Kokkos::HostSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(LinearizedBasis<mpart::ProbabilistHermite>, Exp, ClenshawCurtisQuadrature, Kokkos::HostSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(LinearizedBasis<mpart::ProbabilistHermite>, SoftPlus, ClenshawCurtisQuadrature, Kokkos::HostSpace, false)
 #if defined(MPART_ENABLE_GPU)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::ProbabilistHermite>, Exp, ClenshawCurtisQuadrature, mpart::DeviceSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::ProbabilistHermite>, SoftPlus, ClenshawCurtisQuadrature, mpart::DeviceSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(LinearizedBasis<mpart::ProbabilistHermite>, Exp, ClenshawCurtisQuadrature, mpart::DeviceSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(LinearizedBasis<mpart::ProbabilistHermite>, SoftPlus, ClenshawCurtisQuadrature, mpart::DeviceSpace, false)
 #endif 
 CEREAL_REGISTER_DYNAMIC_INIT(mpartInitMapFactory14)
 #endif 

--- a/src/MapFactoryImpl15.cpp
+++ b/src/MapFactoryImpl15.cpp
@@ -37,11 +37,11 @@ static auto reg_host_linprob_as_splus = mpart::MapFactory::CompFactoryImpl<Kokko
 #endif
 
 #if defined(MPART_HAS_CEREAL)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::ProbabilistHermite>, Exp, AdaptiveSimpson, Kokkos::HostSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::ProbabilistHermite>, SoftPlus, AdaptiveSimpson, Kokkos::HostSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(LinearizedBasis<mpart::ProbabilistHermite>, Exp, AdaptiveSimpson, Kokkos::HostSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(LinearizedBasis<mpart::ProbabilistHermite>, SoftPlus, AdaptiveSimpson, Kokkos::HostSpace, false)
 #if defined(MPART_ENABLE_GPU)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::ProbabilistHermite>, Exp, AdaptiveSimpson, mpart::DeviceSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::ProbabilistHermite>, SoftPlus, AdaptiveSimpson, mpart::DeviceSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(LinearizedBasis<mpart::ProbabilistHermite>, Exp, AdaptiveSimpson, mpart::DeviceSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(LinearizedBasis<mpart::ProbabilistHermite>, SoftPlus, AdaptiveSimpson, mpart::DeviceSpace, false)
 #endif 
 CEREAL_REGISTER_DYNAMIC_INIT(mpartInitMapFactory15)
 #endif 

--- a/src/MapFactoryImpl15.cpp
+++ b/src/MapFactoryImpl15.cpp
@@ -21,7 +21,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_LinProb_AS(
     MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
     std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
-    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv, opts.nugget);
+    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace, false>>(expansion, quad, opts.contDeriv, opts.nugget);
 
     Kokkos::View<const double*,MemorySpace> coeffs = Kokkos::View<double*,MemorySpace>("Component Coefficients", mset.Size());
     output->SetCoeffs(coeffs);
@@ -29,19 +29,19 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_LinProb_AS(
     return output;
 }
 
-static auto reg_host_linprob_as_exp = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, true, PosFuncTypes::Exp, QuadTypes::AdaptiveSimpson), CreateComponentImpl_LinProb_AS<Kokkos::HostSpace, Exp>));
-static auto reg_host_linprob_as_splus = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, true, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveSimpson), CreateComponentImpl_LinProb_AS<Kokkos::HostSpace, SoftPlus>));
+static auto reg_host_linprob_as_exp = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, true, PosFuncTypes::Exp, QuadTypes::AdaptiveSimpson, false), CreateComponentImpl_LinProb_AS<Kokkos::HostSpace, Exp>));
+static auto reg_host_linprob_as_splus = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, true, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveSimpson, false), CreateComponentImpl_LinProb_AS<Kokkos::HostSpace, SoftPlus>));
 #if defined(MPART_ENABLE_GPU)
-    static auto reg_device_linprob_as_exp = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, true, PosFuncTypes::Exp, QuadTypes::AdaptiveSimpson), CreateComponentImpl_LinProb_AS<mpart::DeviceSpace, Exp>));
-    static auto reg_device_linprob_as_splus = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, true, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveSimpson), CreateComponentImpl_LinProb_AS<mpart::DeviceSpace, SoftPlus>));
+    static auto reg_device_linprob_as_exp = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, true, PosFuncTypes::Exp, QuadTypes::AdaptiveSimpson, false), CreateComponentImpl_LinProb_AS<mpart::DeviceSpace, Exp>));
+    static auto reg_device_linprob_as_splus = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, true, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveSimpson, false), CreateComponentImpl_LinProb_AS<mpart::DeviceSpace, SoftPlus>));
 #endif
 
 #if defined(MPART_HAS_CEREAL)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::ProbabilistHermite>, Exp, AdaptiveSimpson, Kokkos::HostSpace)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::ProbabilistHermite>, SoftPlus, AdaptiveSimpson, Kokkos::HostSpace)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::ProbabilistHermite>, Exp, AdaptiveSimpson, Kokkos::HostSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::ProbabilistHermite>, SoftPlus, AdaptiveSimpson, Kokkos::HostSpace, false)
 #if defined(MPART_ENABLE_GPU)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::ProbabilistHermite>, Exp, AdaptiveSimpson, mpart::DeviceSpace)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::ProbabilistHermite>, SoftPlus, AdaptiveSimpson, mpart::DeviceSpace)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::ProbabilistHermite>, Exp, AdaptiveSimpson, mpart::DeviceSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::ProbabilistHermite>, SoftPlus, AdaptiveSimpson, mpart::DeviceSpace, false)
 #endif 
 CEREAL_REGISTER_DYNAMIC_INIT(mpartInitMapFactory15)
 #endif 

--- a/src/MapFactoryImpl16.cpp
+++ b/src/MapFactoryImpl16.cpp
@@ -37,11 +37,11 @@ static auto reg_host_linhf_as_splus = mpart::MapFactory::CompFactoryImpl<Kokkos:
 #endif
 
 #if defined(MPART_HAS_CEREAL)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::HermiteFunction>, Exp, AdaptiveSimpson, Kokkos::HostSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::HermiteFunction>, SoftPlus, AdaptiveSimpson, Kokkos::HostSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(LinearizedBasis<mpart::HermiteFunction>, Exp, AdaptiveSimpson, Kokkos::HostSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(LinearizedBasis<mpart::HermiteFunction>, SoftPlus, AdaptiveSimpson, Kokkos::HostSpace, false)
 #if defined(MPART_ENABLE_GPU)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::HermiteFunction>, Exp, AdaptiveSimpson, mpart::DeviceSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::HermiteFunction>, SoftPlus, AdaptiveSimpson, mpart::DeviceSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(LinearizedBasis<mpart::HermiteFunction>, Exp, AdaptiveSimpson, mpart::DeviceSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(LinearizedBasis<mpart::HermiteFunction>, SoftPlus, AdaptiveSimpson, mpart::DeviceSpace, false)
 #endif 
 CEREAL_REGISTER_DYNAMIC_INIT(mpartInitMapFactory16)
 #endif 

--- a/src/MapFactoryImpl16.cpp
+++ b/src/MapFactoryImpl16.cpp
@@ -21,7 +21,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_LinHF_AS(Fi
     MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
     std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
-    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv, opts.nugget);
+    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace, false>>(expansion, quad, opts.contDeriv, opts.nugget);
 
     Kokkos::View<const double*,MemorySpace> coeffs = Kokkos::View<double*,MemorySpace>("Component Coefficients", mset.Size());
     output->SetCoeffs(coeffs);
@@ -29,19 +29,19 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_LinHF_AS(Fi
     return output;
 }
 
-static auto reg_host_linhf_as_exp = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, true, PosFuncTypes::Exp, QuadTypes::AdaptiveSimpson), CreateComponentImpl_LinHF_AS<Kokkos::HostSpace, Exp>));
-static auto reg_host_linhf_as_splus = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, true, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveSimpson), CreateComponentImpl_LinHF_AS<Kokkos::HostSpace, SoftPlus>));
+static auto reg_host_linhf_as_exp = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, true, PosFuncTypes::Exp, QuadTypes::AdaptiveSimpson, false), CreateComponentImpl_LinHF_AS<Kokkos::HostSpace, Exp>));
+static auto reg_host_linhf_as_splus = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, true, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveSimpson, false), CreateComponentImpl_LinHF_AS<Kokkos::HostSpace, SoftPlus>));
 #if defined(MPART_ENABLE_GPU)
-    static auto reg_device_linhf_as_exp = mpart::MapFactory::CompFactoryImpl<DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, true, PosFuncTypes::Exp, QuadTypes::AdaptiveSimpson), CreateComponentImpl_LinHF_AS<mpart::DeviceSpace, Exp>));
-    static auto reg_device_linhf_as_splus = mpart::MapFactory::CompFactoryImpl<DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, true, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveSimpson), CreateComponentImpl_LinHF_AS<mpart::DeviceSpace, SoftPlus>));
+    static auto reg_device_linhf_as_exp = mpart::MapFactory::CompFactoryImpl<DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, true, PosFuncTypes::Exp, QuadTypes::AdaptiveSimpson, false), CreateComponentImpl_LinHF_AS<mpart::DeviceSpace, Exp>));
+    static auto reg_device_linhf_as_splus = mpart::MapFactory::CompFactoryImpl<DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, true, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveSimpson, false), CreateComponentImpl_LinHF_AS<mpart::DeviceSpace, SoftPlus>));
 #endif
 
 #if defined(MPART_HAS_CEREAL)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::HermiteFunction>, Exp, AdaptiveSimpson, Kokkos::HostSpace)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::HermiteFunction>, SoftPlus, AdaptiveSimpson, Kokkos::HostSpace)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::HermiteFunction>, Exp, AdaptiveSimpson, Kokkos::HostSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::HermiteFunction>, SoftPlus, AdaptiveSimpson, Kokkos::HostSpace, false)
 #if defined(MPART_ENABLE_GPU)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::HermiteFunction>, Exp, AdaptiveSimpson, mpart::DeviceSpace)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::HermiteFunction>, SoftPlus, AdaptiveSimpson, mpart::DeviceSpace)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::HermiteFunction>, Exp, AdaptiveSimpson, mpart::DeviceSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::HermiteFunction>, SoftPlus, AdaptiveSimpson, mpart::DeviceSpace, false)
 #endif 
 CEREAL_REGISTER_DYNAMIC_INIT(mpartInitMapFactory16)
 #endif 

--- a/src/MapFactoryImpl17.cpp
+++ b/src/MapFactoryImpl17.cpp
@@ -21,7 +21,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_LinHF_CC(Fi
     MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
     std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
-    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv, opts.nugget);
+    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace, false>>(expansion, quad, opts.contDeriv, opts.nugget);
 
     Kokkos::View<const double*,MemorySpace> coeffs = Kokkos::View<double*,MemorySpace>("Component Coefficients", mset.Size());
     output->SetCoeffs(coeffs);
@@ -29,19 +29,19 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_LinHF_CC(Fi
     return output;
 }
 
-static auto reg_host_linhf_cc_exp = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, true, PosFuncTypes::Exp, QuadTypes::ClenshawCurtis), CreateComponentImpl_LinHF_CC<Kokkos::HostSpace, Exp>));
-static auto reg_host_linhf_cc_splus = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, true, PosFuncTypes::SoftPlus, QuadTypes::ClenshawCurtis), CreateComponentImpl_LinHF_CC<Kokkos::HostSpace, SoftPlus>));
+static auto reg_host_linhf_cc_exp = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, true, PosFuncTypes::Exp, QuadTypes::ClenshawCurtis, false), CreateComponentImpl_LinHF_CC<Kokkos::HostSpace, Exp>));
+static auto reg_host_linhf_cc_splus = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, true, PosFuncTypes::SoftPlus, QuadTypes::ClenshawCurtis, false), CreateComponentImpl_LinHF_CC<Kokkos::HostSpace, SoftPlus>));
 #if defined(MPART_ENABLE_GPU)
-    static auto reg_device_linhf_cc_exp = mpart::MapFactory::CompFactoryImpl<DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, true, PosFuncTypes::Exp, QuadTypes::ClenshawCurtis), CreateComponentImpl_LinHF_CC<mpart::DeviceSpace, Exp>));
-    static auto reg_device_linhf_cc_splus = mpart::MapFactory::CompFactoryImpl<DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, true, PosFuncTypes::SoftPlus, QuadTypes::ClenshawCurtis), CreateComponentImpl_LinHF_CC<mpart::DeviceSpace, SoftPlus>));
+    static auto reg_device_linhf_cc_exp = mpart::MapFactory::CompFactoryImpl<DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, true, PosFuncTypes::Exp, QuadTypes::ClenshawCurtis, false), CreateComponentImpl_LinHF_CC<mpart::DeviceSpace, Exp>));
+    static auto reg_device_linhf_cc_splus = mpart::MapFactory::CompFactoryImpl<DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, true, PosFuncTypes::SoftPlus, QuadTypes::ClenshawCurtis, false), CreateComponentImpl_LinHF_CC<mpart::DeviceSpace, SoftPlus>));
 #endif
 
 #if defined(MPART_HAS_CEREAL)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::HermiteFunction>, Exp, ClenshawCurtisQuadrature, Kokkos::HostSpace)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::HermiteFunction>, SoftPlus, ClenshawCurtisQuadrature, Kokkos::HostSpace)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::HermiteFunction>, Exp, ClenshawCurtisQuadrature, Kokkos::HostSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::HermiteFunction>, SoftPlus, ClenshawCurtisQuadrature, Kokkos::HostSpace, false)
 #if defined(MPART_ENABLE_GPU)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::HermiteFunction>, Exp, ClenshawCurtisQuadrature, mpart::DeviceSpace)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::HermiteFunction>, SoftPlus, ClenshawCurtisQuadrature, mpart::DeviceSpace)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::HermiteFunction>, Exp, ClenshawCurtisQuadrature, mpart::DeviceSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::HermiteFunction>, SoftPlus, ClenshawCurtisQuadrature, mpart::DeviceSpace, false)
 #endif 
 CEREAL_REGISTER_DYNAMIC_INIT(mpartInitMapFactory17)
 #endif 

--- a/src/MapFactoryImpl17.cpp
+++ b/src/MapFactoryImpl17.cpp
@@ -37,11 +37,11 @@ static auto reg_host_linhf_cc_splus = mpart::MapFactory::CompFactoryImpl<Kokkos:
 #endif
 
 #if defined(MPART_HAS_CEREAL)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::HermiteFunction>, Exp, ClenshawCurtisQuadrature, Kokkos::HostSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::HermiteFunction>, SoftPlus, ClenshawCurtisQuadrature, Kokkos::HostSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(LinearizedBasis<mpart::HermiteFunction>, Exp, ClenshawCurtisQuadrature, Kokkos::HostSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(LinearizedBasis<mpart::HermiteFunction>, SoftPlus, ClenshawCurtisQuadrature, Kokkos::HostSpace, false)
 #if defined(MPART_ENABLE_GPU)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::HermiteFunction>, Exp, ClenshawCurtisQuadrature, mpart::DeviceSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::HermiteFunction>, SoftPlus, ClenshawCurtisQuadrature, mpart::DeviceSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(LinearizedBasis<mpart::HermiteFunction>, Exp, ClenshawCurtisQuadrature, mpart::DeviceSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(LinearizedBasis<mpart::HermiteFunction>, SoftPlus, ClenshawCurtisQuadrature, mpart::DeviceSpace, false)
 #endif 
 CEREAL_REGISTER_DYNAMIC_INIT(mpartInitMapFactory17)
 #endif 

--- a/src/MapFactoryImpl18.cpp
+++ b/src/MapFactoryImpl18.cpp
@@ -22,7 +22,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_LinHF_ACC(F
     MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
     std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
-    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv, opts.nugget);
+    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace, false>>(expansion, quad, opts.contDeriv, opts.nugget);
 
     Kokkos::View<const double*,MemorySpace> coeffs = Kokkos::View<double*,MemorySpace>("Component Coefficients", mset.Size());
     output->SetCoeffs(coeffs);
@@ -30,19 +30,19 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_LinHF_ACC(F
     return output;
 }
 
-static auto reg_host_linhf_acc_exp = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, true, PosFuncTypes::Exp, QuadTypes::AdaptiveClenshawCurtis), CreateComponentImpl_LinHF_ACC<Kokkos::HostSpace, Exp>));
-static auto reg_host_linhf_acc_splus = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, true, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveClenshawCurtis), CreateComponentImpl_LinHF_ACC<Kokkos::HostSpace, SoftPlus>));
+static auto reg_host_linhf_acc_exp = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, true, PosFuncTypes::Exp, QuadTypes::AdaptiveClenshawCurtis, false), CreateComponentImpl_LinHF_ACC<Kokkos::HostSpace, Exp>));
+static auto reg_host_linhf_acc_splus = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, true, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveClenshawCurtis, false), CreateComponentImpl_LinHF_ACC<Kokkos::HostSpace, SoftPlus>));
 #if defined(MPART_ENABLE_GPU)
-    static auto reg_device_linhf_acc_exp = mpart::MapFactory::CompFactoryImpl<DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, true, PosFuncTypes::Exp, QuadTypes::AdaptiveClenshawCurtis), CreateComponentImpl_LinHF_ACC<mpart::DeviceSpace, Exp>));
-    static auto reg_device_linhf_acc_splus = mpart::MapFactory::CompFactoryImpl<DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, true, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveClenshawCurtis), CreateComponentImpl_LinHF_ACC<mpart::DeviceSpace, SoftPlus>));
+    static auto reg_device_linhf_acc_exp = mpart::MapFactory::CompFactoryImpl<DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, true, PosFuncTypes::Exp, QuadTypes::AdaptiveClenshawCurtis, false), CreateComponentImpl_LinHF_ACC<mpart::DeviceSpace, Exp>));
+    static auto reg_device_linhf_acc_splus = mpart::MapFactory::CompFactoryImpl<DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, true, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveClenshawCurtis, false), CreateComponentImpl_LinHF_ACC<mpart::DeviceSpace, SoftPlus>));
 #endif
 
 #if defined(MPART_HAS_CEREAL)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::HermiteFunction>, Exp, AdaptiveClenshawCurtis, Kokkos::HostSpace)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::HermiteFunction>, SoftPlus, AdaptiveClenshawCurtis, Kokkos::HostSpace)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::HermiteFunction>, Exp, AdaptiveClenshawCurtis, Kokkos::HostSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::HermiteFunction>, SoftPlus, AdaptiveClenshawCurtis, Kokkos::HostSpace, false)
 #if defined(MPART_ENABLE_GPU)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::HermiteFunction>, Exp, AdaptiveClenshawCurtis, mpart::DeviceSpace)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::HermiteFunction>, SoftPlus, AdaptiveClenshawCurtis, mpart::DeviceSpace)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::HermiteFunction>, Exp, AdaptiveClenshawCurtis, mpart::DeviceSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::HermiteFunction>, SoftPlus, AdaptiveClenshawCurtis, mpart::DeviceSpace, false)
 #endif 
 CEREAL_REGISTER_DYNAMIC_INIT(mpartInitMapFactory18)
 #endif 

--- a/src/MapFactoryImpl18.cpp
+++ b/src/MapFactoryImpl18.cpp
@@ -38,11 +38,11 @@ static auto reg_host_linhf_acc_splus = mpart::MapFactory::CompFactoryImpl<Kokkos
 #endif
 
 #if defined(MPART_HAS_CEREAL)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::HermiteFunction>, Exp, AdaptiveClenshawCurtis, Kokkos::HostSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::HermiteFunction>, SoftPlus, AdaptiveClenshawCurtis, Kokkos::HostSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(LinearizedBasis<mpart::HermiteFunction>, Exp, AdaptiveClenshawCurtis, Kokkos::HostSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(LinearizedBasis<mpart::HermiteFunction>, SoftPlus, AdaptiveClenshawCurtis, Kokkos::HostSpace, false)
 #if defined(MPART_ENABLE_GPU)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::HermiteFunction>, Exp, AdaptiveClenshawCurtis, mpart::DeviceSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, LinearizedBasis<mpart::HermiteFunction>, SoftPlus, AdaptiveClenshawCurtis, mpart::DeviceSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(LinearizedBasis<mpart::HermiteFunction>, Exp, AdaptiveClenshawCurtis, mpart::DeviceSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(LinearizedBasis<mpart::HermiteFunction>, SoftPlus, AdaptiveClenshawCurtis, mpart::DeviceSpace, false)
 #endif 
 CEREAL_REGISTER_DYNAMIC_INIT(mpartInitMapFactory18)
 #endif 

--- a/src/MapFactoryImpl19.cpp
+++ b/src/MapFactoryImpl19.cpp
@@ -1,0 +1,48 @@
+#include "MParT/MapFactory.h"
+
+#include "MParT/MonotoneComponent.h"
+#include "MParT/TriangularMap.h"
+#include "MParT/Quadrature.h"
+
+#include "MParT/UnivariateBases.h"
+#include "MParT/OrthogonalPolynomial.h"
+#include "MParT/MultivariateExpansionWorker.h"
+#include "MParT/PositiveBijectors.h"
+
+using namespace mpart;
+
+using BasisType = Kokkos::pair<SineBasis, ShiftedLegendre>;
+
+template<typename MemorySpace, typename PosFuncType>
+std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_SL_CC(FixedMultiIndexSet<MemorySpace> const& mset, MapOptions opts)
+{
+    BasisEvaluator<BasisHomogeneity::OffdiagHomogeneous,BasisType,Identity> basis1d(mset.Length());
+    ClenshawCurtisQuadrature<MemorySpace> quad(opts.quadPts, 1);
+
+    MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
+    std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
+
+    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace, true>>(expansion, quad, opts.contDeriv, opts.nugget);
+
+    Kokkos::View<const double*,MemorySpace> coeffs = Kokkos::View<double*,MemorySpace>("Component Coefficients", mset.Size());
+    output->SetCoeffs(coeffs);
+
+    return output;
+}
+
+static auto reg_host_sl_cc_exp_compact = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::SinusoidLegendre, false, PosFuncTypes::Exp, QuadTypes::ClenshawCurtis, true), CreateComponentImpl_SL_CC<Kokkos::HostSpace, Exp>));
+static auto reg_host_sl_cc_splus_compact = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::SinusoidLegendre, false, PosFuncTypes::SoftPlus, QuadTypes::ClenshawCurtis, true), CreateComponentImpl_SL_CC<Kokkos::HostSpace, SoftPlus>));
+#if defined(MPART_ENABLE_GPU)
+    static auto reg_device_sl_cc_exp_compact = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::SinusoidLegendre, false, PosFuncTypes::Exp, QuadTypes::ClenshawCurtis, true), CreateComponentImpl_SL_CC<mpart::DeviceSpace, Exp>));
+    static auto reg_device_sl_cc_splus_compact = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::SinusoidLegendre, false, PosFuncTypes::SoftPlus, QuadTypes::ClenshawCurtis, true), CreateComponentImpl_SL_CC<mpart::DeviceSpace, SoftPlus>));
+#endif
+
+#if defined(MPART_HAS_CEREAL)
+REGISTER_OFFDIAGHOMOGENEOUS_MONO_COMP(SineBasis, ShiftedLegendre, Identity, Exp, ClenshawCurtisQuadrature, Kokkos::HostSpace, true)
+REGISTER_OFFDIAGHOMOGENEOUS_MONO_COMP(SineBasis, ShiftedLegendre, Identity, SoftPlus, ClenshawCurtisQuadrature, Kokkos::HostSpace, true)
+#if defined(MPART_ENABLE_GPU)
+REGISTER_OFFDIAGHOMOGENEOUS_MONO_COMP(SineBasis, ShiftedLegendre, Identity, Exp, ClenshawCurtisQuadrature, mpart::DeviceSpace, true)
+REGISTER_OFFDIAGHOMOGENEOUS_MONO_COMP(SineBasis, ShiftedLegendre, Identity, SoftPlus, ClenshawCurtisQuadrature, mpart::DeviceSpace, true)
+#endif
+CEREAL_REGISTER_DYNAMIC_INIT(mpartInitMapFactory19)
+#endif

--- a/src/MapFactoryImpl2.cpp
+++ b/src/MapFactoryImpl2.cpp
@@ -42,15 +42,15 @@ static auto reg_host_phys_cc_splus_compact = mpart::MapFactory::CompFactoryImpl<
 #endif
 
 #if defined(MPART_HAS_CEREAL)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, Exp, ClenshawCurtisQuadrature, Kokkos::HostSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, SoftPlus, ClenshawCurtisQuadrature, Kokkos::HostSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, Exp, ClenshawCurtisQuadrature, Kokkos::HostSpace, true)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, SoftPlus, ClenshawCurtisQuadrature, Kokkos::HostSpace, true)
+REGISTER_HOMOGENEOUS_MONO_COMP(PhysicistHermite, Exp, ClenshawCurtisQuadrature, Kokkos::HostSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(PhysicistHermite, SoftPlus, ClenshawCurtisQuadrature, Kokkos::HostSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(PhysicistHermite, Exp, ClenshawCurtisQuadrature, Kokkos::HostSpace, true)
+REGISTER_HOMOGENEOUS_MONO_COMP(PhysicistHermite, SoftPlus, ClenshawCurtisQuadrature, Kokkos::HostSpace, true)
 #if defined(MPART_ENABLE_GPU)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, Exp, ClenshawCurtisQuadrature, mpart::DeviceSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, SoftPlus, ClenshawCurtisQuadrature, mpart::DeviceSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, Exp, ClenshawCurtisQuadrature, mpart::DeviceSpace, true)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, SoftPlus, ClenshawCurtisQuadrature, mpart::DeviceSpace, true)
+REGISTER_HOMOGENEOUS_MONO_COMP(PhysicistHermite, Exp, ClenshawCurtisQuadrature, mpart::DeviceSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(PhysicistHermite, SoftPlus, ClenshawCurtisQuadrature, mpart::DeviceSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(PhysicistHermite, Exp, ClenshawCurtisQuadrature, mpart::DeviceSpace, true)
+REGISTER_HOMOGENEOUS_MONO_COMP(PhysicistHermite, SoftPlus, ClenshawCurtisQuadrature, mpart::DeviceSpace, true)
 #endif 
 CEREAL_REGISTER_DYNAMIC_INIT(mpartInitMapFactory2)
 #endif 

--- a/src/MapFactoryImpl2.cpp
+++ b/src/MapFactoryImpl2.cpp
@@ -11,7 +11,7 @@
 using namespace mpart;
 
 
-template<typename MemorySpace, typename PosFuncType>
+template<typename MemorySpace, typename PosFuncType, bool isCompact>
 std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_Phys_CC(FixedMultiIndexSet<MemorySpace> const& mset, MapOptions opts)
 {
     BasisEvaluator<BasisHomogeneity::Homogeneous,PhysicistHermite> basis1d(opts.basisNorm);
@@ -20,26 +20,37 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_Phys_CC(Fix
     MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
     std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
-    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv, opts.nugget);
+    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace, isCompact>>(expansion, quad, opts.contDeriv, opts.nugget);
 
     Kokkos::View<const double*,MemorySpace> coeffs = Kokkos::View<double*,MemorySpace>("Component Coefficients", mset.Size());
     output->SetCoeffs(coeffs);
     return output;
 }
 
-static auto reg_host_phys_cc_exp = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, false, PosFuncTypes::Exp, QuadTypes::ClenshawCurtis), CreateComponentImpl_Phys_CC<Kokkos::HostSpace, Exp>));
-static auto reg_host_phys_cc_splus = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, false, PosFuncTypes::SoftPlus, QuadTypes::ClenshawCurtis), CreateComponentImpl_Phys_CC<Kokkos::HostSpace, SoftPlus>));
+static auto reg_host_phys_cc_exp = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, false, PosFuncTypes::Exp, QuadTypes::ClenshawCurtis, false), CreateComponentImpl_Phys_CC<Kokkos::HostSpace, Exp, false>));
+static auto reg_host_phys_cc_splus = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, false, PosFuncTypes::SoftPlus, QuadTypes::ClenshawCurtis, false), CreateComponentImpl_Phys_CC<Kokkos::HostSpace, SoftPlus, false>));
 #if defined(MPART_ENABLE_GPU)
-    static auto reg_device_phys_cc_exp = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, false, PosFuncTypes::Exp, QuadTypes::ClenshawCurtis), CreateComponentImpl_Phys_CC<mpart::DeviceSpace, Exp>));
-    static auto reg_device_phys_cc_splus = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, false, PosFuncTypes::SoftPlus, QuadTypes::ClenshawCurtis), CreateComponentImpl_Phys_CC<mpart::DeviceSpace, SoftPlus>));
+    static auto reg_device_phys_cc_exp = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, false, PosFuncTypes::Exp, QuadTypes::ClenshawCurtis, false), CreateComponentImpl_Phys_CC<mpart::DeviceSpace, Exp, false>));
+    static auto reg_device_phys_cc_splus = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, false, PosFuncTypes::SoftPlus, QuadTypes::ClenshawCurtis, false), CreateComponentImpl_Phys_CC<mpart::DeviceSpace, SoftPlus, false>));
+#endif
+
+static auto reg_host_phys_cc_exp_compact = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, false, PosFuncTypes::Exp, QuadTypes::ClenshawCurtis, true), CreateComponentImpl_Phys_CC<Kokkos::HostSpace, Exp, true>));
+static auto reg_host_phys_cc_splus_compact = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, false, PosFuncTypes::SoftPlus, QuadTypes::ClenshawCurtis, true), CreateComponentImpl_Phys_CC<Kokkos::HostSpace, SoftPlus, true>));
+#if defined(MPART_ENABLE_GPU)
+    static auto reg_device_phys_cc_exp_compact = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, false, PosFuncTypes::Exp, QuadTypes::ClenshawCurtis, true), CreateComponentImpl_Phys_CC<mpart::DeviceSpace, Exp, true>));
+    static auto reg_device_phys_cc_splus_compact = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, false, PosFuncTypes::SoftPlus, QuadTypes::ClenshawCurtis, true), CreateComponentImpl_Phys_CC<mpart::DeviceSpace, SoftPlus, true>));
 #endif
 
 #if defined(MPART_HAS_CEREAL)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, Exp, ClenshawCurtisQuadrature, Kokkos::HostSpace)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, SoftPlus, ClenshawCurtisQuadrature, Kokkos::HostSpace)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, Exp, ClenshawCurtisQuadrature, Kokkos::HostSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, SoftPlus, ClenshawCurtisQuadrature, Kokkos::HostSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, Exp, ClenshawCurtisQuadrature, Kokkos::HostSpace, true)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, SoftPlus, ClenshawCurtisQuadrature, Kokkos::HostSpace, true)
 #if defined(MPART_ENABLE_GPU)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, Exp, ClenshawCurtisQuadrature, mpart::DeviceSpace)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, SoftPlus, ClenshawCurtisQuadrature, mpart::DeviceSpace)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, Exp, ClenshawCurtisQuadrature, mpart::DeviceSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, SoftPlus, ClenshawCurtisQuadrature, mpart::DeviceSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, Exp, ClenshawCurtisQuadrature, mpart::DeviceSpace, true)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, SoftPlus, ClenshawCurtisQuadrature, mpart::DeviceSpace, true)
 #endif 
 CEREAL_REGISTER_DYNAMIC_INIT(mpartInitMapFactory2)
 #endif 

--- a/src/MapFactoryImpl3.cpp
+++ b/src/MapFactoryImpl3.cpp
@@ -10,7 +10,7 @@
 
 using namespace mpart;
 
-template<typename MemorySpace, typename PosFuncType>
+template<typename MemorySpace, typename PosFuncType, bool isCompact>
 std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_Phys_AS(FixedMultiIndexSet<MemorySpace> const& mset, MapOptions opts)
 {
     BasisEvaluator<BasisHomogeneity::Homogeneous,PhysicistHermite> basis1d(opts.basisNorm);
@@ -19,7 +19,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_Phys_AS(Fix
     MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
     std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
-    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv, opts.nugget);
+    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace, isCompact>>(expansion, quad, opts.contDeriv, opts.nugget);
 
     Kokkos::View<const double*,MemorySpace> coeffs = Kokkos::View<double*,MemorySpace>("Component Coefficients", mset.Size());
     output->SetCoeffs(coeffs);
@@ -27,19 +27,30 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_Phys_AS(Fix
     return output;
 }
 
-static auto reg_host_phys_as_exp = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, false, PosFuncTypes::Exp, QuadTypes::AdaptiveSimpson), CreateComponentImpl_Phys_AS<Kokkos::HostSpace, Exp>));
-static auto reg_host_phys_as_splus = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, false, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveSimpson), CreateComponentImpl_Phys_AS<Kokkos::HostSpace, SoftPlus>));
+static auto reg_host_phys_as_exp = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, false, PosFuncTypes::Exp, QuadTypes::AdaptiveSimpson, false), CreateComponentImpl_Phys_AS<Kokkos::HostSpace, Exp, false>));
+static auto reg_host_phys_as_splus = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, false, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveSimpson, false), CreateComponentImpl_Phys_AS<Kokkos::HostSpace, SoftPlus, false>));
 #if defined(MPART_ENABLE_GPU)
-    static auto reg_device_phys_as_exp = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, false, PosFuncTypes::Exp, QuadTypes::AdaptiveSimpson), CreateComponentImpl_Phys_AS<mpart::DeviceSpace, Exp>));
-    static auto reg_device_phys_as_splus = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, false, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveSimpson), CreateComponentImpl_Phys_AS<mpart::DeviceSpace, SoftPlus>));
+    static auto reg_device_phys_as_exp = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, false, PosFuncTypes::Exp, QuadTypes::AdaptiveSimpson, false), CreateComponentImpl_Phys_AS<mpart::DeviceSpace, Exp, false>));
+    static auto reg_device_phys_as_splus = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, false, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveSimpson, false), CreateComponentImpl_Phys_AS<mpart::DeviceSpace, SoftPlus, false>));
+#endif
+
+static auto reg_host_phys_as_exp_compact = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, false, PosFuncTypes::Exp, QuadTypes::AdaptiveSimpson, true), CreateComponentImpl_Phys_AS<Kokkos::HostSpace, Exp, true>));
+static auto reg_host_phys_as_splus_compact = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, false, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveSimpson, true), CreateComponentImpl_Phys_AS<Kokkos::HostSpace, SoftPlus, true>));
+#if defined(MPART_ENABLE_GPU)
+    static auto reg_device_phys_as_exp_compact = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, false, PosFuncTypes::Exp, QuadTypes::AdaptiveSimpson, true), CreateComponentImpl_Phys_AS<mpart::DeviceSpace, Exp, true>));
+    static auto reg_device_phys_as_splus_compact = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::PhysicistHermite, false, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveSimpson, true), CreateComponentImpl_Phys_AS<mpart::DeviceSpace, SoftPlus, true>));
 #endif
 
 #if defined(MPART_HAS_CEREAL)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, Exp, AdaptiveSimpson, Kokkos::HostSpace)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, SoftPlus, AdaptiveSimpson, Kokkos::HostSpace)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, Exp, AdaptiveSimpson, Kokkos::HostSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, SoftPlus, AdaptiveSimpson, Kokkos::HostSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, Exp, AdaptiveSimpson, Kokkos::HostSpace, true)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, SoftPlus, AdaptiveSimpson, Kokkos::HostSpace, true)
 #if defined(MPART_ENABLE_GPU)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, Exp, AdaptiveSimpson, mpart::DeviceSpace)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, SoftPlus, AdaptiveSimpson, mpart::DeviceSpace)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, Exp, AdaptiveSimpson, mpart::DeviceSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, SoftPlus, AdaptiveSimpson, mpart::DeviceSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, Exp, AdaptiveSimpson, mpart::DeviceSpace, true)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, SoftPlus, AdaptiveSimpson, mpart::DeviceSpace, true)
 #endif 
 CEREAL_REGISTER_DYNAMIC_INIT(mpartInitMapFactory3)
 #endif 

--- a/src/MapFactoryImpl3.cpp
+++ b/src/MapFactoryImpl3.cpp
@@ -42,15 +42,15 @@ static auto reg_host_phys_as_splus_compact = mpart::MapFactory::CompFactoryImpl<
 #endif
 
 #if defined(MPART_HAS_CEREAL)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, Exp, AdaptiveSimpson, Kokkos::HostSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, SoftPlus, AdaptiveSimpson, Kokkos::HostSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, Exp, AdaptiveSimpson, Kokkos::HostSpace, true)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, SoftPlus, AdaptiveSimpson, Kokkos::HostSpace, true)
+REGISTER_HOMOGENEOUS_MONO_COMP(PhysicistHermite, Exp, AdaptiveSimpson, Kokkos::HostSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(PhysicistHermite, SoftPlus, AdaptiveSimpson, Kokkos::HostSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(PhysicistHermite, Exp, AdaptiveSimpson, Kokkos::HostSpace, true)
+REGISTER_HOMOGENEOUS_MONO_COMP(PhysicistHermite, SoftPlus, AdaptiveSimpson, Kokkos::HostSpace, true)
 #if defined(MPART_ENABLE_GPU)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, Exp, AdaptiveSimpson, mpart::DeviceSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, SoftPlus, AdaptiveSimpson, mpart::DeviceSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, Exp, AdaptiveSimpson, mpart::DeviceSpace, true)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, PhysicistHermite, SoftPlus, AdaptiveSimpson, mpart::DeviceSpace, true)
+REGISTER_HOMOGENEOUS_MONO_COMP(PhysicistHermite, Exp, AdaptiveSimpson, mpart::DeviceSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(PhysicistHermite, SoftPlus, AdaptiveSimpson, mpart::DeviceSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(PhysicistHermite, Exp, AdaptiveSimpson, mpart::DeviceSpace, true)
+REGISTER_HOMOGENEOUS_MONO_COMP(PhysicistHermite, SoftPlus, AdaptiveSimpson, mpart::DeviceSpace, true)
 #endif 
 CEREAL_REGISTER_DYNAMIC_INIT(mpartInitMapFactory3)
 #endif 

--- a/src/MapFactoryImpl4.cpp
+++ b/src/MapFactoryImpl4.cpp
@@ -10,7 +10,7 @@
 
 using namespace mpart;
 
-template<typename MemorySpace, typename PosFuncType>
+template<typename MemorySpace, typename PosFuncType, bool isCompact>
 std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_Prob_ACC(FixedMultiIndexSet<MemorySpace> const& mset, MapOptions opts)
 {
     BasisEvaluator<BasisHomogeneity::Homogeneous,ProbabilistHermite> basis1d(opts.basisNorm);
@@ -21,7 +21,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_Prob_ACC(Fi
     MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
     std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
-    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv, opts.nugget);
+    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace, isCompact>>(expansion, quad, opts.contDeriv, opts.nugget);
     
     Kokkos::View<const double*,MemorySpace> coeffs = Kokkos::View<double*,MemorySpace>("Component Coefficients", mset.Size());
     output->SetCoeffs(coeffs);
@@ -29,19 +29,30 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_Prob_ACC(Fi
     return output;
 }
 
-static auto reg_host_prob_acc_exp = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, false, PosFuncTypes::Exp, QuadTypes::AdaptiveClenshawCurtis), CreateComponentImpl_Prob_ACC<Kokkos::HostSpace, Exp>));
-static auto reg_host_prob_acc_splus = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, false, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveClenshawCurtis), CreateComponentImpl_Prob_ACC<Kokkos::HostSpace, SoftPlus>));
+static auto reg_host_prob_acc_exp = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, false, PosFuncTypes::Exp, QuadTypes::AdaptiveClenshawCurtis, false), CreateComponentImpl_Prob_ACC<Kokkos::HostSpace, Exp, false>));
+static auto reg_host_prob_acc_splus = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, false, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveClenshawCurtis, false), CreateComponentImpl_Prob_ACC<Kokkos::HostSpace, SoftPlus, false>));
 #if defined(MPART_ENABLE_GPU)
-    static auto reg_device_prob_acc_exp = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, false, PosFuncTypes::Exp, QuadTypes::AdaptiveClenshawCurtis), CreateComponentImpl_Prob_ACC<mpart::DeviceSpace, Exp>));
-    static auto reg_device_prob_acc_splus = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, false, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveClenshawCurtis), CreateComponentImpl_Prob_ACC<mpart::DeviceSpace, SoftPlus>));
+    static auto reg_device_prob_acc_exp = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, false, PosFuncTypes::Exp, QuadTypes::AdaptiveClenshawCurtis, false), CreateComponentImpl_Prob_ACC<mpart::DeviceSpace, Exp, false>));
+    static auto reg_device_prob_acc_splus = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, false, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveClenshawCurtis, false), CreateComponentImpl_Prob_ACC<mpart::DeviceSpace, SoftPlus, false>));
+#endif
+
+static auto reg_host_prob_acc_exp_compact = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, false, PosFuncTypes::Exp, QuadTypes::AdaptiveClenshawCurtis, true), CreateComponentImpl_Prob_ACC<Kokkos::HostSpace, Exp, true>));
+static auto reg_host_prob_acc_splus_compact = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, false, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveClenshawCurtis, true), CreateComponentImpl_Prob_ACC<Kokkos::HostSpace, SoftPlus, true>));
+#if defined(MPART_ENABLE_GPU)
+    static auto reg_device_prob_acc_exp_compact = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, false, PosFuncTypes::Exp, QuadTypes::AdaptiveClenshawCurtis, true), CreateComponentImpl_Prob_ACC<mpart::DeviceSpace, Exp, true>));
+    static auto reg_device_prob_acc_splus_compact = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, false, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveClenshawCurtis, true), CreateComponentImpl_Prob_ACC<mpart::DeviceSpace, SoftPlus, true>));
 #endif
 
 #if defined(MPART_HAS_CEREAL)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, Exp, AdaptiveClenshawCurtis, Kokkos::HostSpace)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, SoftPlus, AdaptiveClenshawCurtis, Kokkos::HostSpace)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, Exp, AdaptiveClenshawCurtis, Kokkos::HostSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, SoftPlus, AdaptiveClenshawCurtis, Kokkos::HostSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, Exp, AdaptiveClenshawCurtis, Kokkos::HostSpace, true)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, SoftPlus, AdaptiveClenshawCurtis, Kokkos::HostSpace, true)
 #if defined(MPART_ENABLE_GPU)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, Exp, AdaptiveClenshawCurtis, mpart::DeviceSpace)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, SoftPlus, AdaptiveClenshawCurtis, mpart::DeviceSpace)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, Exp, AdaptiveClenshawCurtis, mpart::DeviceSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, SoftPlus, AdaptiveClenshawCurtis, mpart::DeviceSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, Exp, AdaptiveClenshawCurtis, mpart::DeviceSpace, true)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, SoftPlus, AdaptiveClenshawCurtis, mpart::DeviceSpace, true)
 #endif 
 CEREAL_REGISTER_DYNAMIC_INIT(mpartInitMapFactory4)
 #endif 

--- a/src/MapFactoryImpl4.cpp
+++ b/src/MapFactoryImpl4.cpp
@@ -44,15 +44,15 @@ static auto reg_host_prob_acc_splus_compact = mpart::MapFactory::CompFactoryImpl
 #endif
 
 #if defined(MPART_HAS_CEREAL)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, Exp, AdaptiveClenshawCurtis, Kokkos::HostSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, SoftPlus, AdaptiveClenshawCurtis, Kokkos::HostSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, Exp, AdaptiveClenshawCurtis, Kokkos::HostSpace, true)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, SoftPlus, AdaptiveClenshawCurtis, Kokkos::HostSpace, true)
+REGISTER_HOMOGENEOUS_MONO_COMP(ProbabilistHermite, Exp, AdaptiveClenshawCurtis, Kokkos::HostSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(ProbabilistHermite, SoftPlus, AdaptiveClenshawCurtis, Kokkos::HostSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(ProbabilistHermite, Exp, AdaptiveClenshawCurtis, Kokkos::HostSpace, true)
+REGISTER_HOMOGENEOUS_MONO_COMP(ProbabilistHermite, SoftPlus, AdaptiveClenshawCurtis, Kokkos::HostSpace, true)
 #if defined(MPART_ENABLE_GPU)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, Exp, AdaptiveClenshawCurtis, mpart::DeviceSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, SoftPlus, AdaptiveClenshawCurtis, mpart::DeviceSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, Exp, AdaptiveClenshawCurtis, mpart::DeviceSpace, true)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, SoftPlus, AdaptiveClenshawCurtis, mpart::DeviceSpace, true)
+REGISTER_HOMOGENEOUS_MONO_COMP(ProbabilistHermite, Exp, AdaptiveClenshawCurtis, mpart::DeviceSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(ProbabilistHermite, SoftPlus, AdaptiveClenshawCurtis, mpart::DeviceSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(ProbabilistHermite, Exp, AdaptiveClenshawCurtis, mpart::DeviceSpace, true)
+REGISTER_HOMOGENEOUS_MONO_COMP(ProbabilistHermite, SoftPlus, AdaptiveClenshawCurtis, mpart::DeviceSpace, true)
 #endif 
 CEREAL_REGISTER_DYNAMIC_INIT(mpartInitMapFactory4)
 #endif 

--- a/src/MapFactoryImpl5.cpp
+++ b/src/MapFactoryImpl5.cpp
@@ -42,15 +42,15 @@ static auto reg_host_prob_cc_splus_compact = mpart::MapFactory::CompFactoryImpl<
 #endif
 
 #if defined(MPART_HAS_CEREAL)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, Exp, ClenshawCurtisQuadrature, Kokkos::HostSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, SoftPlus, ClenshawCurtisQuadrature, Kokkos::HostSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, Exp, ClenshawCurtisQuadrature, Kokkos::HostSpace, true)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, SoftPlus, ClenshawCurtisQuadrature, Kokkos::HostSpace, true)
+REGISTER_HOMOGENEOUS_MONO_COMP(ProbabilistHermite, Exp, ClenshawCurtisQuadrature, Kokkos::HostSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(ProbabilistHermite, SoftPlus, ClenshawCurtisQuadrature, Kokkos::HostSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(ProbabilistHermite, Exp, ClenshawCurtisQuadrature, Kokkos::HostSpace, true)
+REGISTER_HOMOGENEOUS_MONO_COMP(ProbabilistHermite, SoftPlus, ClenshawCurtisQuadrature, Kokkos::HostSpace, true)
 #if defined(MPART_ENABLE_GPU)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, Exp, ClenshawCurtisQuadrature, mpart::DeviceSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, SoftPlus, ClenshawCurtisQuadrature, mpart::DeviceSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, Exp, ClenshawCurtisQuadrature, mpart::DeviceSpace, true)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, SoftPlus, ClenshawCurtisQuadrature, mpart::DeviceSpace, true)
+REGISTER_HOMOGENEOUS_MONO_COMP(ProbabilistHermite, Exp, ClenshawCurtisQuadrature, mpart::DeviceSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(ProbabilistHermite, SoftPlus, ClenshawCurtisQuadrature, mpart::DeviceSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(ProbabilistHermite, Exp, ClenshawCurtisQuadrature, mpart::DeviceSpace, true)
+REGISTER_HOMOGENEOUS_MONO_COMP(ProbabilistHermite, SoftPlus, ClenshawCurtisQuadrature, mpart::DeviceSpace, true)
 #endif 
 CEREAL_REGISTER_DYNAMIC_INIT(mpartInitMapFactory5)
 #endif

--- a/src/MapFactoryImpl5.cpp
+++ b/src/MapFactoryImpl5.cpp
@@ -10,7 +10,7 @@
 
 using namespace mpart;
 
-template<typename MemorySpace, typename PosFuncType>
+template<typename MemorySpace, typename PosFuncType, bool isCompact>
 std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_Prob_CC(FixedMultiIndexSet<MemorySpace> const& mset, MapOptions opts)
 {
     BasisEvaluator<BasisHomogeneity::Homogeneous,ProbabilistHermite> basis1d(opts.basisNorm);
@@ -19,7 +19,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_Prob_CC(Fix
     MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
     std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
-    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv, opts.nugget);
+    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace, isCompact>>(expansion, quad, opts.contDeriv, opts.nugget);
 
     Kokkos::View<const double*,MemorySpace> coeffs = Kokkos::View<double*,MemorySpace>("Component Coefficients", mset.Size());
     output->SetCoeffs(coeffs);
@@ -27,19 +27,30 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_Prob_CC(Fix
     return output;
 }
 
-static auto reg_host_prob_cc_exp = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, false, PosFuncTypes::Exp, QuadTypes::ClenshawCurtis), CreateComponentImpl_Prob_CC<Kokkos::HostSpace, Exp>));
-static auto reg_host_prob_cc_splus = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, false, PosFuncTypes::SoftPlus, QuadTypes::ClenshawCurtis), CreateComponentImpl_Prob_CC<Kokkos::HostSpace, SoftPlus>));
+static auto reg_host_prob_cc_exp = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, false, PosFuncTypes::Exp, QuadTypes::ClenshawCurtis, false), CreateComponentImpl_Prob_CC<Kokkos::HostSpace, Exp, false>));
+static auto reg_host_prob_cc_splus = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, false, PosFuncTypes::SoftPlus, QuadTypes::ClenshawCurtis, false), CreateComponentImpl_Prob_CC<Kokkos::HostSpace, SoftPlus, false>));
 #if defined(MPART_ENABLE_GPU)
-    static auto reg_device_prob_cc_exp = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, false, PosFuncTypes::Exp, QuadTypes::ClenshawCurtis), CreateComponentImpl_Prob_CC<mpart::DeviceSpace, Exp>));
-    static auto reg_device_prob_cc_splus = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, false, PosFuncTypes::SoftPlus, QuadTypes::ClenshawCurtis), CreateComponentImpl_Prob_CC<mpart::DeviceSpace, SoftPlus>));
+    static auto reg_device_prob_cc_exp = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, false, PosFuncTypes::Exp, QuadTypes::ClenshawCurtis, false), CreateComponentImpl_Prob_CC<mpart::DeviceSpace, Exp, false>));
+    static auto reg_device_prob_cc_splus = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, false, PosFuncTypes::SoftPlus, QuadTypes::ClenshawCurtis, false), CreateComponentImpl_Prob_CC<mpart::DeviceSpace, SoftPlus, false>));
+#endif
+
+static auto reg_host_prob_cc_exp_compact = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, false, PosFuncTypes::Exp, QuadTypes::ClenshawCurtis, true), CreateComponentImpl_Prob_CC<Kokkos::HostSpace, Exp, true>));
+static auto reg_host_prob_cc_splus_compact = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, false, PosFuncTypes::SoftPlus, QuadTypes::ClenshawCurtis, true), CreateComponentImpl_Prob_CC<Kokkos::HostSpace, SoftPlus, true>));
+#if defined(MPART_ENABLE_GPU)
+    static auto reg_device_prob_cc_exp_compact = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, false, PosFuncTypes::Exp, QuadTypes::ClenshawCurtis, true), CreateComponentImpl_Prob_CC<mpart::DeviceSpace, Exp, true>));
+    static auto reg_device_prob_cc_splus_compact = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::ProbabilistHermite, false, PosFuncTypes::SoftPlus, QuadTypes::ClenshawCurtis, true), CreateComponentImpl_Prob_CC<mpart::DeviceSpace, SoftPlus, true>));
 #endif
 
 #if defined(MPART_HAS_CEREAL)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, Exp, ClenshawCurtisQuadrature, Kokkos::HostSpace)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, SoftPlus, ClenshawCurtisQuadrature, Kokkos::HostSpace)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, Exp, ClenshawCurtisQuadrature, Kokkos::HostSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, SoftPlus, ClenshawCurtisQuadrature, Kokkos::HostSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, Exp, ClenshawCurtisQuadrature, Kokkos::HostSpace, true)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, SoftPlus, ClenshawCurtisQuadrature, Kokkos::HostSpace, true)
 #if defined(MPART_ENABLE_GPU)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, Exp, ClenshawCurtisQuadrature, mpart::DeviceSpace)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, SoftPlus, ClenshawCurtisQuadrature, mpart::DeviceSpace)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, Exp, ClenshawCurtisQuadrature, mpart::DeviceSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, SoftPlus, ClenshawCurtisQuadrature, mpart::DeviceSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, Exp, ClenshawCurtisQuadrature, mpart::DeviceSpace, true)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, SoftPlus, ClenshawCurtisQuadrature, mpart::DeviceSpace, true)
 #endif 
 CEREAL_REGISTER_DYNAMIC_INIT(mpartInitMapFactory5)
 #endif

--- a/src/MapFactoryImpl6.cpp
+++ b/src/MapFactoryImpl6.cpp
@@ -42,15 +42,15 @@ static auto reg_host_prob_as_splus_compact = mpart::MapFactory::CompFactoryImpl<
 #endif
 
 #if defined(MPART_HAS_CEREAL)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, Exp, AdaptiveSimpson, Kokkos::HostSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, SoftPlus, AdaptiveSimpson, Kokkos::HostSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, Exp, AdaptiveSimpson, Kokkos::HostSpace, true)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, SoftPlus, AdaptiveSimpson, Kokkos::HostSpace, true)
+REGISTER_HOMOGENEOUS_MONO_COMP(ProbabilistHermite, Exp, AdaptiveSimpson, Kokkos::HostSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(ProbabilistHermite, SoftPlus, AdaptiveSimpson, Kokkos::HostSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(ProbabilistHermite, Exp, AdaptiveSimpson, Kokkos::HostSpace, true)
+REGISTER_HOMOGENEOUS_MONO_COMP(ProbabilistHermite, SoftPlus, AdaptiveSimpson, Kokkos::HostSpace, true)
 #if defined(MPART_ENABLE_GPU)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, Exp, AdaptiveSimpson, mpart::DeviceSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, SoftPlus, AdaptiveSimpson, mpart::DeviceSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, Exp, AdaptiveSimpson, mpart::DeviceSpace, true)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, ProbabilistHermite, SoftPlus, AdaptiveSimpson, mpart::DeviceSpace, true)
+REGISTER_HOMOGENEOUS_MONO_COMP(ProbabilistHermite, Exp, AdaptiveSimpson, mpart::DeviceSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(ProbabilistHermite, SoftPlus, AdaptiveSimpson, mpart::DeviceSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(ProbabilistHermite, Exp, AdaptiveSimpson, mpart::DeviceSpace, true)
+REGISTER_HOMOGENEOUS_MONO_COMP(ProbabilistHermite, SoftPlus, AdaptiveSimpson, mpart::DeviceSpace, true)
 #endif 
 CEREAL_REGISTER_DYNAMIC_INIT(mpartInitMapFactory6)
 #endif

--- a/src/MapFactoryImpl7.cpp
+++ b/src/MapFactoryImpl7.cpp
@@ -10,7 +10,7 @@
 
 using namespace mpart;
 
-template<typename MemorySpace, typename PosFuncType>
+template<typename MemorySpace, typename PosFuncType, bool isCompact>
 std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_HF_ACC(FixedMultiIndexSet<MemorySpace> const& mset, MapOptions opts)
 {
     BasisEvaluator<BasisHomogeneity::Homogeneous,HermiteFunction> basis1d;
@@ -21,7 +21,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_HF_ACC(Fixe
     MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
     std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
-    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv, opts.nugget);
+    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace, isCompact>>(expansion, quad, opts.contDeriv, opts.nugget);
 
     Kokkos::View<const double*,MemorySpace> coeffs = Kokkos::View<double*,MemorySpace>("Component Coefficients", mset.Size());
     output->SetCoeffs(coeffs);
@@ -29,20 +29,31 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_HF_ACC(Fixe
     return output;
 }
 
-static auto reg_host_hf_acc_exp = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, false, PosFuncTypes::Exp, QuadTypes::AdaptiveClenshawCurtis), CreateComponentImpl_HF_ACC<Kokkos::HostSpace, Exp>));
-static auto reg_host_hf_acc_splus = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, false, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveClenshawCurtis), CreateComponentImpl_HF_ACC<Kokkos::HostSpace, SoftPlus>));
+static auto reg_host_hf_acc_exp = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, false, PosFuncTypes::Exp, QuadTypes::AdaptiveClenshawCurtis, false), CreateComponentImpl_HF_ACC<Kokkos::HostSpace, Exp, false>));
+static auto reg_host_hf_acc_splus = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, false, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveClenshawCurtis, false), CreateComponentImpl_HF_ACC<Kokkos::HostSpace, SoftPlus, false>));
 #if defined(MPART_ENABLE_GPU)
-    static auto reg_device_hf_acc_exp = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, false, PosFuncTypes::Exp, QuadTypes::AdaptiveClenshawCurtis), CreateComponentImpl_HF_ACC<mpart::DeviceSpace, Exp>));
-    static auto reg_device_hf_acc_splus = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, false, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveClenshawCurtis), CreateComponentImpl_HF_ACC<mpart::DeviceSpace, SoftPlus>));
+    static auto reg_device_hf_acc_exp = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, false, PosFuncTypes::Exp, QuadTypes::AdaptiveClenshawCurtis, false), CreateComponentImpl_HF_ACC<mpart::DeviceSpace, Exp, false>));
+    static auto reg_device_hf_acc_splus = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, false, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveClenshawCurtis, false), CreateComponentImpl_HF_ACC<mpart::DeviceSpace, SoftPlus, false>));
 #endif
 
+static auto reg_host_hf_acc_exp_compact = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, false, PosFuncTypes::Exp, QuadTypes::AdaptiveClenshawCurtis, true), CreateComponentImpl_HF_ACC<Kokkos::HostSpace, Exp, true>));
+static auto reg_host_hf_acc_splus_compact = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, false, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveClenshawCurtis, true), CreateComponentImpl_HF_ACC<Kokkos::HostSpace, SoftPlus, true>));
+#if defined(MPART_ENABLE_GPU)
+    static auto reg_device_hf_acc_exp_compact = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, false, PosFuncTypes::Exp, QuadTypes::AdaptiveClenshawCurtis, true), CreateComponentImpl_HF_ACC<mpart::DeviceSpace, Exp, true>));
+    static auto reg_device_hf_acc_splus_compact = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, false, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveClenshawCurtis, true), CreateComponentImpl_HF_ACC<mpart::DeviceSpace, SoftPlus, true>));
+#endif
 
 #if defined(MPART_HAS_CEREAL)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, Exp, AdaptiveClenshawCurtis, Kokkos::HostSpace)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, SoftPlus, AdaptiveClenshawCurtis, Kokkos::HostSpace)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, Exp, AdaptiveClenshawCurtis, Kokkos::HostSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, SoftPlus, AdaptiveClenshawCurtis, Kokkos::HostSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, Exp, AdaptiveClenshawCurtis, Kokkos::HostSpace, true)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, SoftPlus, AdaptiveClenshawCurtis, Kokkos::HostSpace, true)
 #if defined(MPART_ENABLE_GPU)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, Exp, AdaptiveClenshawCurtis, mpart::DeviceSpace)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, SoftPlus, AdaptiveClenshawCurtis, mpart::DeviceSpace)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, Exp, AdaptiveClenshawCurtis, mpart::DeviceSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, SoftPlus, AdaptiveClenshawCurtis, mpart::DeviceSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, Exp, AdaptiveClenshawCurtis, mpart::DeviceSpace, true)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, SoftPlus, AdaptiveClenshawCurtis, mpart::DeviceSpace, true)
 #endif
+
 CEREAL_REGISTER_DYNAMIC_INIT(mpartInitMapFactory7) 
 #endif

--- a/src/MapFactoryImpl7.cpp
+++ b/src/MapFactoryImpl7.cpp
@@ -44,15 +44,15 @@ static auto reg_host_hf_acc_splus_compact = mpart::MapFactory::CompFactoryImpl<K
 #endif
 
 #if defined(MPART_HAS_CEREAL)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, Exp, AdaptiveClenshawCurtis, Kokkos::HostSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, SoftPlus, AdaptiveClenshawCurtis, Kokkos::HostSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, Exp, AdaptiveClenshawCurtis, Kokkos::HostSpace, true)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, SoftPlus, AdaptiveClenshawCurtis, Kokkos::HostSpace, true)
+REGISTER_HOMOGENEOUS_MONO_COMP(HermiteFunction, Exp, AdaptiveClenshawCurtis, Kokkos::HostSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(HermiteFunction, SoftPlus, AdaptiveClenshawCurtis, Kokkos::HostSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(HermiteFunction, Exp, AdaptiveClenshawCurtis, Kokkos::HostSpace, true)
+REGISTER_HOMOGENEOUS_MONO_COMP(HermiteFunction, SoftPlus, AdaptiveClenshawCurtis, Kokkos::HostSpace, true)
 #if defined(MPART_ENABLE_GPU)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, Exp, AdaptiveClenshawCurtis, mpart::DeviceSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, SoftPlus, AdaptiveClenshawCurtis, mpart::DeviceSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, Exp, AdaptiveClenshawCurtis, mpart::DeviceSpace, true)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, SoftPlus, AdaptiveClenshawCurtis, mpart::DeviceSpace, true)
+REGISTER_HOMOGENEOUS_MONO_COMP(HermiteFunction, Exp, AdaptiveClenshawCurtis, mpart::DeviceSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(HermiteFunction, SoftPlus, AdaptiveClenshawCurtis, mpart::DeviceSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(HermiteFunction, Exp, AdaptiveClenshawCurtis, mpart::DeviceSpace, true)
+REGISTER_HOMOGENEOUS_MONO_COMP(HermiteFunction, SoftPlus, AdaptiveClenshawCurtis, mpart::DeviceSpace, true)
 #endif
 
 CEREAL_REGISTER_DYNAMIC_INIT(mpartInitMapFactory7) 

--- a/src/MapFactoryImpl8.cpp
+++ b/src/MapFactoryImpl8.cpp
@@ -42,15 +42,15 @@ static auto reg_host_hf_cc_splus_compact = mpart::MapFactory::CompFactoryImpl<Ko
 #endif
 
 #if defined(MPART_HAS_CEREAL)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, Exp, ClenshawCurtisQuadrature, Kokkos::HostSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, SoftPlus, ClenshawCurtisQuadrature, Kokkos::HostSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, Exp, ClenshawCurtisQuadrature, Kokkos::HostSpace, true)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, SoftPlus, ClenshawCurtisQuadrature, Kokkos::HostSpace, true)
+REGISTER_HOMOGENEOUS_MONO_COMP(HermiteFunction, Exp, ClenshawCurtisQuadrature, Kokkos::HostSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(HermiteFunction, SoftPlus, ClenshawCurtisQuadrature, Kokkos::HostSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(HermiteFunction, Exp, ClenshawCurtisQuadrature, Kokkos::HostSpace, true)
+REGISTER_HOMOGENEOUS_MONO_COMP(HermiteFunction, SoftPlus, ClenshawCurtisQuadrature, Kokkos::HostSpace, true)
 #if defined(MPART_ENABLE_GPU)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, Exp, ClenshawCurtisQuadrature, mpart::DeviceSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, SoftPlus, ClenshawCurtisQuadrature, mpart::DeviceSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, Exp, ClenshawCurtisQuadrature, mpart::DeviceSpace, true)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, SoftPlus, ClenshawCurtisQuadrature, mpart::DeviceSpace, true)
+REGISTER_HOMOGENEOUS_MONO_COMP(HermiteFunction, Exp, ClenshawCurtisQuadrature, mpart::DeviceSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(HermiteFunction, SoftPlus, ClenshawCurtisQuadrature, mpart::DeviceSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(HermiteFunction, Exp, ClenshawCurtisQuadrature, mpart::DeviceSpace, true)
+REGISTER_HOMOGENEOUS_MONO_COMP(HermiteFunction, SoftPlus, ClenshawCurtisQuadrature, mpart::DeviceSpace, true)
 #endif
 CEREAL_REGISTER_DYNAMIC_INIT(mpartInitMapFactory8)
 #endif

--- a/src/MapFactoryImpl8.cpp
+++ b/src/MapFactoryImpl8.cpp
@@ -10,7 +10,7 @@
 
 using namespace mpart;
 
-template<typename MemorySpace, typename PosFuncType>
+template<typename MemorySpace, typename PosFuncType, bool isCompact>
 std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_HF_CC(FixedMultiIndexSet<MemorySpace> const& mset, MapOptions opts)
 {
     BasisEvaluator<BasisHomogeneity::Homogeneous,HermiteFunction> basis1d;
@@ -19,7 +19,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_HF_CC(Fixed
     MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
     std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
-    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv, opts.nugget);
+    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace, isCompact>>(expansion, quad, opts.contDeriv, opts.nugget);
 
     Kokkos::View<const double*,MemorySpace> coeffs = Kokkos::View<double*,MemorySpace>("Component Coefficients", mset.Size());
     output->SetCoeffs(coeffs);
@@ -27,19 +27,30 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_HF_CC(Fixed
     return output;
 }
 
-static auto reg_host_hf_cc_exp = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, false, PosFuncTypes::Exp, QuadTypes::ClenshawCurtis), CreateComponentImpl_HF_CC<Kokkos::HostSpace, Exp>));
-static auto reg_host_hf_cc_splus = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, false, PosFuncTypes::SoftPlus, QuadTypes::ClenshawCurtis), CreateComponentImpl_HF_CC<Kokkos::HostSpace, SoftPlus>));
+static auto reg_host_hf_cc_exp = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, false, PosFuncTypes::Exp, QuadTypes::ClenshawCurtis, false), CreateComponentImpl_HF_CC<Kokkos::HostSpace, Exp, false>));
+static auto reg_host_hf_cc_splus = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, false, PosFuncTypes::SoftPlus, QuadTypes::ClenshawCurtis, false), CreateComponentImpl_HF_CC<Kokkos::HostSpace, SoftPlus, false>));
 #if defined(MPART_ENABLE_GPU)
-    static auto reg_device_hf_cc_exp = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, false, PosFuncTypes::Exp, QuadTypes::ClenshawCurtis), CreateComponentImpl_HF_CC<mpart::DeviceSpace, Exp>));
-    static auto reg_device_hf_cc_splus = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, false, PosFuncTypes::SoftPlus, QuadTypes::ClenshawCurtis), CreateComponentImpl_HF_CC<mpart::DeviceSpace, SoftPlus>));
+    static auto reg_device_hf_cc_exp = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, false, PosFuncTypes::Exp, QuadTypes::ClenshawCurtis, false), CreateComponentImpl_HF_CC<mpart::DeviceSpace, Exp, false>));
+    static auto reg_device_hf_cc_splus = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, false, PosFuncTypes::SoftPlus, QuadTypes::ClenshawCurtis, false), CreateComponentImpl_HF_CC<mpart::DeviceSpace, SoftPlus, false>));
+#endif
+
+static auto reg_host_hf_cc_exp_compact = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, false, PosFuncTypes::Exp, QuadTypes::ClenshawCurtis, true), CreateComponentImpl_HF_CC<Kokkos::HostSpace, Exp, true>));
+static auto reg_host_hf_cc_splus_compact = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, false, PosFuncTypes::SoftPlus, QuadTypes::ClenshawCurtis, true), CreateComponentImpl_HF_CC<Kokkos::HostSpace, SoftPlus, true>));
+#if defined(MPART_ENABLE_GPU)
+    static auto reg_device_hf_cc_exp_compact = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, false, PosFuncTypes::Exp, QuadTypes::ClenshawCurtis, true), CreateComponentImpl_HF_CC<mpart::DeviceSpace, Exp, true>));
+    static auto reg_device_hf_cc_splus_compact = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, false, PosFuncTypes::SoftPlus, QuadTypes::ClenshawCurtis, true), CreateComponentImpl_HF_CC<mpart::DeviceSpace, SoftPlus, true>));
 #endif
 
 #if defined(MPART_HAS_CEREAL)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, Exp, ClenshawCurtisQuadrature, Kokkos::HostSpace)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, SoftPlus, ClenshawCurtisQuadrature, Kokkos::HostSpace)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, Exp, ClenshawCurtisQuadrature, Kokkos::HostSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, SoftPlus, ClenshawCurtisQuadrature, Kokkos::HostSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, Exp, ClenshawCurtisQuadrature, Kokkos::HostSpace, true)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, SoftPlus, ClenshawCurtisQuadrature, Kokkos::HostSpace, true)
 #if defined(MPART_ENABLE_GPU)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, Exp, ClenshawCurtisQuadrature, mpart::DeviceSpace)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, SoftPlus, ClenshawCurtisQuadrature, mpart::DeviceSpace)
-#endif 
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, Exp, ClenshawCurtisQuadrature, mpart::DeviceSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, SoftPlus, ClenshawCurtisQuadrature, mpart::DeviceSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, Exp, ClenshawCurtisQuadrature, mpart::DeviceSpace, true)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, SoftPlus, ClenshawCurtisQuadrature, mpart::DeviceSpace, true)
+#endif
 CEREAL_REGISTER_DYNAMIC_INIT(mpartInitMapFactory8)
 #endif

--- a/src/MapFactoryImpl9.cpp
+++ b/src/MapFactoryImpl9.cpp
@@ -42,15 +42,15 @@ static auto reg_host_hf_as_splus_compact = mpart::MapFactory::CompFactoryImpl<Ko
 #endif
 
 #if defined(MPART_HAS_CEREAL)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, Exp, AdaptiveSimpson, Kokkos::HostSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, SoftPlus, AdaptiveSimpson, Kokkos::HostSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, Exp, AdaptiveSimpson, Kokkos::HostSpace, true)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, SoftPlus, AdaptiveSimpson, Kokkos::HostSpace, true)
+REGISTER_HOMOGENEOUS_MONO_COMP(HermiteFunction, Exp, AdaptiveSimpson, Kokkos::HostSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(HermiteFunction, SoftPlus, AdaptiveSimpson, Kokkos::HostSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(HermiteFunction, Exp, AdaptiveSimpson, Kokkos::HostSpace, true)
+REGISTER_HOMOGENEOUS_MONO_COMP(HermiteFunction, SoftPlus, AdaptiveSimpson, Kokkos::HostSpace, true)
 #if defined(MPART_ENABLE_GPU)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, Exp, AdaptiveSimpson, mpart::DeviceSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, SoftPlus, AdaptiveSimpson, mpart::DeviceSpace, false)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, Exp, AdaptiveSimpson, mpart::DeviceSpace, true)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, SoftPlus, AdaptiveSimpson, mpart::DeviceSpace, true)
+REGISTER_HOMOGENEOUS_MONO_COMP(HermiteFunction, Exp, AdaptiveSimpson, mpart::DeviceSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(HermiteFunction, SoftPlus, AdaptiveSimpson, mpart::DeviceSpace, false)
+REGISTER_HOMOGENEOUS_MONO_COMP(HermiteFunction, Exp, AdaptiveSimpson, mpart::DeviceSpace, true)
+REGISTER_HOMOGENEOUS_MONO_COMP(HermiteFunction, SoftPlus, AdaptiveSimpson, mpart::DeviceSpace, true)
 #endif 
 CEREAL_REGISTER_DYNAMIC_INIT(mpartInitMapFactory9)
 #endif

--- a/src/MapFactoryImpl9.cpp
+++ b/src/MapFactoryImpl9.cpp
@@ -10,7 +10,7 @@
 
 using namespace mpart;
 
-template<typename MemorySpace, typename PosFuncType>
+template<typename MemorySpace, typename PosFuncType, bool isCompact>
 std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_HF_AS(FixedMultiIndexSet<MemorySpace> const& mset, MapOptions opts)
 {
     BasisEvaluator<BasisHomogeneity::Homogeneous,HermiteFunction> basis1d;
@@ -19,7 +19,7 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_HF_AS(Fixed
     MultivariateExpansionWorker<decltype(basis1d),MemorySpace> expansion(mset, basis1d);
     std::shared_ptr<ConditionalMapBase<MemorySpace>> output;
 
-    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace>>(expansion, quad, opts.contDeriv, opts.nugget);
+    output = std::make_shared<MonotoneComponent<decltype(expansion), PosFuncType, decltype(quad), MemorySpace, isCompact>>(expansion, quad, opts.contDeriv, opts.nugget);
 
     Kokkos::View<const double*,MemorySpace> coeffs = Kokkos::View<double*,MemorySpace>("Component Coefficients", mset.Size());
     output->SetCoeffs(coeffs);
@@ -27,19 +27,30 @@ std::shared_ptr<ConditionalMapBase<MemorySpace>> CreateComponentImpl_HF_AS(Fixed
     return output;
 }
 
-static auto reg_host_hf_as_exp = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, false, PosFuncTypes::Exp, QuadTypes::AdaptiveSimpson), CreateComponentImpl_HF_AS<Kokkos::HostSpace, Exp>));
-static auto reg_host_hf_as_splus = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, false, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveSimpson), CreateComponentImpl_HF_AS<Kokkos::HostSpace, SoftPlus>));
+static auto reg_host_hf_as_exp = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, false, PosFuncTypes::Exp, QuadTypes::AdaptiveSimpson, false), CreateComponentImpl_HF_AS<Kokkos::HostSpace, Exp, false>));
+static auto reg_host_hf_as_splus = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, false, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveSimpson, false), CreateComponentImpl_HF_AS<Kokkos::HostSpace, SoftPlus, false>));
 #if defined(MPART_ENABLE_GPU)
-    static auto reg_device_hf_as_exp = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, false, PosFuncTypes::Exp, QuadTypes::AdaptiveSimpson), CreateComponentImpl_HF_AS<mpart::DeviceSpace, Exp>));
-    static auto reg_device_hf_as_splus = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, false, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveSimpson), CreateComponentImpl_HF_AS<mpart::DeviceSpace, SoftPlus>));
+    static auto reg_device_hf_as_exp = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, false, PosFuncTypes::Exp, QuadTypes::AdaptiveSimpson, false), CreateComponentImpl_HF_AS<mpart::DeviceSpace, Exp, false>));
+    static auto reg_device_hf_as_splus = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, false, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveSimpson, false), CreateComponentImpl_HF_AS<mpart::DeviceSpace, SoftPlus, false>));
+#endif
+
+static auto reg_host_hf_as_exp_compact = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, false, PosFuncTypes::Exp, QuadTypes::AdaptiveSimpson, true), CreateComponentImpl_HF_AS<Kokkos::HostSpace, Exp, true>));
+static auto reg_host_hf_as_splus_compact = mpart::MapFactory::CompFactoryImpl<Kokkos::HostSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, false, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveSimpson, true), CreateComponentImpl_HF_AS<Kokkos::HostSpace, SoftPlus, true>));
+#if defined(MPART_ENABLE_GPU)
+    static auto reg_device_hf_as_exp_compact = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, false, PosFuncTypes::Exp, QuadTypes::AdaptiveSimpson, true), CreateComponentImpl_HF_AS<mpart::DeviceSpace, Exp, true>));
+    static auto reg_device_hf_as_splus_compact = mpart::MapFactory::CompFactoryImpl<mpart::DeviceSpace>::GetFactoryMap()->insert(std::make_pair(std::make_tuple(BasisTypes::HermiteFunctions, false, PosFuncTypes::SoftPlus, QuadTypes::AdaptiveSimpson, true), CreateComponentImpl_HF_AS<mpart::DeviceSpace, SoftPlus, true>));
 #endif
 
 #if defined(MPART_HAS_CEREAL)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, Exp, AdaptiveSimpson, Kokkos::HostSpace)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, SoftPlus, AdaptiveSimpson, Kokkos::HostSpace)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, Exp, AdaptiveSimpson, Kokkos::HostSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, SoftPlus, AdaptiveSimpson, Kokkos::HostSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, Exp, AdaptiveSimpson, Kokkos::HostSpace, true)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, SoftPlus, AdaptiveSimpson, Kokkos::HostSpace, true)
 #if defined(MPART_ENABLE_GPU)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, Exp, AdaptiveSimpson, mpart::DeviceSpace)
-REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, SoftPlus, AdaptiveSimpson, mpart::DeviceSpace)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, Exp, AdaptiveSimpson, mpart::DeviceSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, SoftPlus, AdaptiveSimpson, mpart::DeviceSpace, false)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, Exp, AdaptiveSimpson, mpart::DeviceSpace, true)
+REGISTER_MONO_COMP(BasisHomogeneity::Homogeneous, HermiteFunction, SoftPlus, AdaptiveSimpson, mpart::DeviceSpace, true)
 #endif 
 CEREAL_REGISTER_DYNAMIC_INIT(mpartInitMapFactory9)
 #endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ set (TEST_SOURCES
      tests/Distributions/Test_TransportSampler.cpp
 
      tests/Test_OrthogonalPolynomials.cpp
+     tests/Test_UnivariateBases.cpp
      tests/Test_RootFinding.cpp
      tests/Test_HermiteFunctions.cpp
      tests/Test_Sigmoid.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,6 +36,7 @@ set (TEST_SOURCES
      tests/Test_PositiveBijectors.cpp
      tests/Test_Quadrature.cpp
      tests/Test_MonotoneComponent.cpp
+     tests/Test_MonotoneComponent_compact.cpp
      tests/Test_MultivariateExpansion.cpp
      tests/Test_BasisEvaluator.cpp
      tests/Test_MultivariateExpansionWorker.cpp

--- a/tests/Test_MapFactory.cpp
+++ b/tests/Test_MapFactory.cpp
@@ -163,8 +163,6 @@ TEST_CASE( "Testing compact map component factory", "[MapFactoryCompactComponent
         
         Kokkos::View<double**, MemorySpace> evals = map->Evaluate(pts);
 
-        // This is perhaps broken for certain coefficient values when the polynomial p(x,y) does not have p(x,0) = 0.
-        SKIP();
         for(unsigned int i=0; i<numPts; ++i){
             CHECK(evals(0,i) >= 0.);
             CHECK(evals(0,i) <= 1.);
@@ -172,10 +170,10 @@ TEST_CASE( "Testing compact map component factory", "[MapFactoryCompactComponent
     }
 }
 
-TEST_CASE( "Testing compact map component factory, sinusoid-legendre basis", "[MapFactoryCompactComponent_Sinusoid]" ) {
+TEST_CASE( "Testing compact map component factory, legendre basis", "[MapFactoryCompactComponent_Legendre]" ) {
 
     MapOptions options;
-    options.basisType = BasisTypes::SinusoidLegendre;
+    options.basisType = BasisTypes::Legendre;
     options.isCompact = true;
     options.basisNorm = false;
     
@@ -184,15 +182,15 @@ TEST_CASE( "Testing compact map component factory, sinusoid-legendre basis", "[M
     MultiIndexSet mset_h = MultiIndexSet::CreateTotalOrder(dim,maxDegree);
     FixedMultiIndexSet<MemorySpace> mset = mset_h.Fix(true);
 
-    SECTION("AdaptiveSimpson"){
-        options.quadType = QuadTypes::ClenshawCurtis;
+    SECTION("AdaptiveClenshawCurtis"){
+        options.quadType = QuadTypes::AdaptiveClenshawCurtis;
 
         std::shared_ptr<ConditionalMapBase<MemorySpace>> map = MapFactory::CreateComponent<MemorySpace>(mset, options);
         REQUIRE(map!=nullptr);
 
         Kokkos::View<double*,MemorySpace> coeffs("Coefficients", map->numCoeffs);
         for(unsigned int i=0; i<map->numCoeffs; ++i)
-            coeffs(i) = i*cos(i*M_PI*2/map->numCoeffs);
+            coeffs(i) = i*cos(0.5+i*M_PI*2/map->numCoeffs);
         map->SetCoeffs(coeffs);
 
         unsigned int numPts = 5;

--- a/tests/Test_MapFactory.cpp
+++ b/tests/Test_MapFactory.cpp
@@ -14,242 +14,255 @@ using namespace mpart;
 using namespace Catch;
 using MemorySpace = Kokkos::HostSpace;
 
-TEST_CASE( "Testing map component factory", "[MapFactoryComponent]" ) {
+TEST_CASE("Testing map component factory", "[MapFactoryComponent]")
+{
 
-    
     MapOptions options;
     options.basisType = BasisTypes::ProbabilistHermite;
     options.basisNorm = false;
 
     unsigned int dim = 3;
     unsigned int maxDegree = 5;
-    FixedMultiIndexSet<MemorySpace> mset(dim,maxDegree);
+    FixedMultiIndexSet<MemorySpace> mset(dim, maxDegree);
 
-    SECTION("AdaptiveSimpson"){
+    SECTION("AdaptiveSimpson")
+    {
         options.quadType = QuadTypes::AdaptiveSimpson;
 
         std::shared_ptr<ConditionalMapBase<MemorySpace>> map = MapFactory::CreateComponent<MemorySpace>(mset, options);
-        REQUIRE(map!=nullptr);
+        REQUIRE(map != nullptr);
 
         unsigned int numPts = 100;
-        Kokkos::View<double**,MemorySpace> pts("Points", dim, numPts);
-        for(unsigned int i=0; i<numPts; ++i)
-            pts(dim-1,i) = double(i)/double(numPts-1);
+        Kokkos::View<double **, MemorySpace> pts("Points", dim, numPts);
+        for (unsigned int i = 0; i < numPts; ++i)
+            pts(dim - 1, i) = double(i) / double(numPts - 1);
 
-        Kokkos::View<double**, MemorySpace> eval = map->Evaluate(pts);
+        Kokkos::View<double **, MemorySpace> eval = map->Evaluate(pts);
     }
 
-    SECTION("ClenshawCurtis"){
+    SECTION("ClenshawCurtis")
+    {
         options.quadType = QuadTypes::ClenshawCurtis;
-        
+
         std::shared_ptr<ConditionalMapBase<MemorySpace>> map = MapFactory::CreateComponent<MemorySpace>(mset, options);
-        REQUIRE(map!=nullptr);
+        REQUIRE(map != nullptr);
 
         unsigned int numPts = 100;
-        Kokkos::View<double**,MemorySpace> pts("Points", dim, numPts);
-        for(unsigned int i=0; i<numPts; ++i)
-            pts(dim-1,i) = double(i)/double(numPts-1);
+        Kokkos::View<double **, MemorySpace> pts("Points", dim, numPts);
+        for (unsigned int i = 0; i < numPts; ++i)
+            pts(dim - 1, i) = double(i) / double(numPts - 1);
 
-        Kokkos::View<double**, MemorySpace> eval = map->Evaluate(pts);
+        Kokkos::View<double **, MemorySpace> eval = map->Evaluate(pts);
     }
 
-    SECTION("AdaptiveClenshawCurtis"){
+    SECTION("AdaptiveClenshawCurtis")
+    {
         options.quadType = QuadTypes::AdaptiveClenshawCurtis;
-        
+
         std::shared_ptr<ConditionalMapBase<MemorySpace>> map = MapFactory::CreateComponent<MemorySpace>(mset, options);
-        REQUIRE(map!=nullptr);
+        REQUIRE(map != nullptr);
 
         unsigned int numPts = 100;
-        Kokkos::View<double**,MemorySpace> pts("Points", dim, numPts);
-        for(unsigned int i=0; i<numPts; ++i)
-            pts(dim-1,i) = double(i)/double(numPts-1);
+        Kokkos::View<double **, MemorySpace> pts("Points", dim, numPts);
+        for (unsigned int i = 0; i < numPts; ++i)
+            pts(dim - 1, i) = double(i) / double(numPts - 1);
 
-        Kokkos::View<double**, MemorySpace> eval = map->Evaluate(pts);
+        Kokkos::View<double **, MemorySpace> eval = map->Evaluate(pts);
     }
 }
 
+TEST_CASE("Testing map component factory with linearized basis", "[MapFactoryLinearizedComponent]")
+{
 
-TEST_CASE( "Testing map component factory with linearized basis", "[MapFactoryLinearizedComponent]" ) {
-
-    
     MapOptions options;
     options.basisType = BasisTypes::ProbabilistHermite;
     options.basisLB = -5;
     options.basisUB = 4;
     options.basisNorm = false;
-    
-    
+
     MapOptions options2;
     options2.basisType = BasisTypes::ProbabilistHermite;
     options2.basisNorm = false;
-    
+
     unsigned int dim = 1;
     unsigned int maxDegree = 7;
-    FixedMultiIndexSet<MemorySpace> mset(dim,maxDegree);
+    FixedMultiIndexSet<MemorySpace> mset(dim, maxDegree);
 
-    SECTION("AdaptiveSimpson"){
+    SECTION("AdaptiveSimpson")
+    {
         options.quadType = QuadTypes::AdaptiveSimpson;
 
         std::shared_ptr<ConditionalMapBase<MemorySpace>> linearized_map = MapFactory::CreateComponent<MemorySpace>(mset, options);
-        
-        std::shared_ptr<ConditionalMapBase<MemorySpace>> map = MapFactory::CreateComponent<MemorySpace>(mset, options2);
-        REQUIRE(linearized_map!=nullptr);
-        REQUIRE(map!=nullptr);
 
-        Kokkos::View<double*,MemorySpace> coeffs("Coefficients", map->numCoeffs);
-        for(unsigned int i=0; i<map->numCoeffs; ++i)
+        std::shared_ptr<ConditionalMapBase<MemorySpace>> map = MapFactory::CreateComponent<MemorySpace>(mset, options2);
+        REQUIRE(linearized_map != nullptr);
+        REQUIRE(map != nullptr);
+
+        Kokkos::View<double *, MemorySpace> coeffs("Coefficients", map->numCoeffs);
+        for (unsigned int i = 0; i < map->numCoeffs; ++i)
             coeffs(i) = 1.0;
         map->SetCoeffs(coeffs);
         linearized_map->SetCoeffs(coeffs);
 
         unsigned int numPts = 5;
-        Kokkos::View<double**,MemorySpace> pts("Points", dim, numPts);
-        pts(0,0) = -6;
-        pts(0,1) = -4.5;
-        pts(0,2) = 0;
-        pts(0,3) = 3.5;
-        pts(0,4) = 4.5;
-        
-        
-        Kokkos::View<double**, MemorySpace> linearized_evals = linearized_map->Evaluate(pts);
-        Kokkos::View<double**, MemorySpace> evals = map->Evaluate(pts);
+        Kokkos::View<double **, MemorySpace> pts("Points", dim, numPts);
+        pts(0, 0) = -6;
+        pts(0, 1) = -4.5;
+        pts(0, 2) = 0;
+        pts(0, 3) = 3.5;
+        pts(0, 4) = 4.5;
 
-        for(unsigned int i=0; i<numPts; ++i){
-            if((pts(0,i)<options.basisLB)||(pts(0,i)>options.basisUB)){
-                CHECK( std::abs(linearized_evals(0,i) - evals(0,i))>1e-13);
-            }else{
-                CHECK( linearized_evals(0,i) == Approx(evals(0,i)).epsilon(1e-15));
+        Kokkos::View<double **, MemorySpace> linearized_evals = linearized_map->Evaluate(pts);
+        Kokkos::View<double **, MemorySpace> evals = map->Evaluate(pts);
+
+        for (unsigned int i = 0; i < numPts; ++i)
+        {
+            if ((pts(0, i) < options.basisLB) || (pts(0, i) > options.basisUB))
+            {
+                CHECK(std::abs(linearized_evals(0, i) - evals(0, i)) > 1e-13);
+            }
+            else
+            {
+                CHECK(linearized_evals(0, i) == Approx(evals(0, i)).epsilon(1e-15));
             }
         }
     }
-
 }
 
-TEST_CASE( "Testing compact map component factory", "[MapFactoryCompactComponent]" ) {
+TEST_CASE("Testing compact map component factory", "[MapFactoryCompactComponent]")
+{
 
     MapOptions options;
     options.basisType = BasisTypes::ProbabilistHermite;
     options.isCompact = true;
     options.basisNorm = false;
-    
+
     unsigned int dim = 2;
     unsigned int maxDegree = 7;
-    MultiIndexSet mset_h = MultiIndexSet::CreateTotalOrder(dim,maxDegree, [](MultiIndex m){return m.HasNonzeroEnd() || m.Max() == 0;});
+    MultiIndexSet mset_h = MultiIndexSet::CreateTotalOrder(dim, maxDegree, [](MultiIndex m)
+                                                           { return m.HasNonzeroEnd() || m.Max() == 0; });
     FixedMultiIndexSet<MemorySpace> mset = mset_h.Fix(true);
 
-    SECTION("AdaptiveSimpson"){
+    SECTION("AdaptiveSimpson")
+    {
         options.quadType = QuadTypes::AdaptiveSimpson;
 
         std::shared_ptr<ConditionalMapBase<MemorySpace>> map = MapFactory::CreateComponent<MemorySpace>(mset, options);
-        REQUIRE(map!=nullptr);
+        REQUIRE(map != nullptr);
 
-        Kokkos::View<double*,MemorySpace> coeffs("Coefficients", map->numCoeffs);
-        for(unsigned int i=0; i<map->numCoeffs; ++i)
+        Kokkos::View<double *, MemorySpace> coeffs("Coefficients", map->numCoeffs);
+        for (unsigned int i = 0; i < map->numCoeffs; ++i)
             coeffs(i) = 1.0;
         map->SetCoeffs(coeffs);
 
         unsigned int numPts = 5;
-        Kokkos::View<double**,MemorySpace> pts("Points", dim, numPts);
-        pts(0,0) = 0.0;
-        pts(0,1) = 0.2;
-        pts(0,2) = 0.5;
-        pts(0,3) = 0.94;
-        pts(0,4) = 1.0;
-        pts(1,0) = 0.0;
-        pts(1,1) = 0.0;
-        pts(1,2) = 0.4;
-        pts(1,3) = 1.0;
-        pts(1,4) = 1.0;
-        
-        Kokkos::View<double**, MemorySpace> evals = map->Evaluate(pts);
+        Kokkos::View<double **, MemorySpace> pts("Points", dim, numPts);
+        pts(0, 0) = 0.0;
+        pts(0, 1) = 0.2;
+        pts(0, 2) = 0.5;
+        pts(0, 3) = 0.94;
+        pts(0, 4) = 1.0;
+        pts(1, 0) = 0.0;
+        pts(1, 1) = 0.0;
+        pts(1, 2) = 0.4;
+        pts(1, 3) = 1.0;
+        pts(1, 4) = 1.0;
 
-        for(unsigned int i=0; i<numPts; ++i){
-            CHECK(evals(0,i) >= 0.);
-            CHECK(evals(0,i) <= 1.);
+        Kokkos::View<double **, MemorySpace> evals = map->Evaluate(pts);
+
+        for (unsigned int i = 0; i < numPts; ++i)
+        {
+            CHECK(evals(0, i) >= 0.);
+            CHECK(evals(0, i) <= 1.);
         }
     }
 }
 
-TEST_CASE( "Testing compact map component factory, legendre basis", "[MapFactoryCompactComponent_Legendre]" ) {
+TEST_CASE("Testing compact map component factory, legendre basis", "[MapFactoryCompactComponent_Legendre]")
+{
 
     MapOptions options;
     options.basisType = BasisTypes::Legendre;
     options.isCompact = true;
     options.basisNorm = false;
-    
+
     unsigned int dim = 2;
     unsigned int maxDegree = 7;
-    MultiIndexSet mset_h = MultiIndexSet::CreateTotalOrder(dim,maxDegree);
+    MultiIndexSet mset_h = MultiIndexSet::CreateTotalOrder(dim, maxDegree);
     FixedMultiIndexSet<MemorySpace> mset = mset_h.Fix(true);
 
-    SECTION("AdaptiveClenshawCurtis"){
+    SECTION("AdaptiveClenshawCurtis")
+    {
         options.quadType = QuadTypes::AdaptiveClenshawCurtis;
 
         std::shared_ptr<ConditionalMapBase<MemorySpace>> map = MapFactory::CreateComponent<MemorySpace>(mset, options);
-        REQUIRE(map!=nullptr);
+        REQUIRE(map != nullptr);
 
-        Kokkos::View<double*,MemorySpace> coeffs("Coefficients", map->numCoeffs);
-        for(unsigned int i=0; i<map->numCoeffs; ++i)
-            coeffs(i) = i*cos(0.5+i*M_PI*2/map->numCoeffs);
+        Kokkos::View<double *, MemorySpace> coeffs("Coefficients", map->numCoeffs);
+        for (unsigned int i = 0; i < map->numCoeffs; ++i)
+            coeffs(i) = i * cos(0.5 + i * M_PI * 2 / map->numCoeffs);
         map->SetCoeffs(coeffs);
 
         unsigned int numPts = 5;
-        Kokkos::View<double**,MemorySpace> pts("Points", dim, numPts);
-        pts(0,0) = 0.0;
-        pts(0,1) = 0.2;
-        pts(0,2) = 0.5;
-        pts(0,3) = 0.94;
-        pts(0,4) = 1.0;
-        pts(1,0) = 0.0;
-        pts(1,1) = 0.0;
-        pts(1,2) = 0.4;
-        pts(1,3) = 1.0;
-        pts(1,4) = 1.0;
-        
-        Kokkos::View<double**, MemorySpace> evals = map->Evaluate(pts);
+        Kokkos::View<double **, MemorySpace> pts("Points", dim, numPts);
+        pts(0, 0) = 0.0;
+        pts(0, 1) = 0.2;
+        pts(0, 2) = 0.5;
+        pts(0, 3) = 0.94;
+        pts(0, 4) = 1.0;
+        pts(1, 0) = 0.0;
+        pts(1, 1) = 0.0;
+        pts(1, 2) = 0.4;
+        pts(1, 3) = 1.0;
+        pts(1, 4) = 1.0;
 
-        for(unsigned int i=0; i<numPts; ++i){
-            CHECK(evals(0,i) >= 0.);
-            CHECK(evals(0,i) <= 1.);
+        Kokkos::View<double **, MemorySpace> evals = map->Evaluate(pts);
+
+        for (unsigned int i = 0; i < numPts; ++i)
+        {
+            CHECK(evals(0, i) >= 0.);
+            CHECK(evals(0, i) <= 1.);
         }
     }
 }
 
-TEST_CASE( "Testing multivariate expansion factory", "[MapFactoryExpansion]" ) {
+TEST_CASE("Testing multivariate expansion factory", "[MapFactoryExpansion]")
+{
 
     MapOptions options;
     options.basisType = BasisTypes::ProbabilistHermite;
-    
+
     unsigned int outDim = 5;
     unsigned int inDim = 3;
     unsigned int maxDegree = 5;
-    FixedMultiIndexSet<MemorySpace> mset(inDim,maxDegree);
+    FixedMultiIndexSet<MemorySpace> mset(inDim, maxDegree);
 
     std::shared_ptr<ParameterizedFunctionBase<MemorySpace>> func = MapFactory::CreateExpansion<MemorySpace>(outDim, mset, options);
-    REQUIRE(func!=nullptr);
+    REQUIRE(func != nullptr);
 
     unsigned int numPts = 100;
-    Kokkos::View<double**,MemorySpace> pts("Points", inDim, numPts);
-    for(unsigned int i=0; i<numPts; ++i)
-        pts(inDim-1,i) = double(i)/double(numPts-1);
+    Kokkos::View<double **, MemorySpace> pts("Points", inDim, numPts);
+    for (unsigned int i = 0; i < numPts; ++i)
+        pts(inDim - 1, i) = double(i) / double(numPts - 1);
 
-    Kokkos::View<double**, MemorySpace> eval = func->Evaluate(pts);
-    CHECK(eval.extent(0)==outDim);
-    CHECK(eval.extent(1)==numPts);
+    Kokkos::View<double **, MemorySpace> eval = func->Evaluate(pts);
+    CHECK(eval.extent(0) == outDim);
+    CHECK(eval.extent(1) == numPts);
 }
 
-
-TEST_CASE( "Testing factory method for triangular map", "[MapFactoryTriangular]" ) {
+TEST_CASE("Testing factory method for triangular map", "[MapFactoryTriangular]")
+{
 
     MapOptions options;
     options.basisType = BasisTypes::ProbabilistHermite;
 
-    std::shared_ptr<ConditionalMapBase<MemorySpace>> map = MapFactory::CreateTriangular<MemorySpace>(4,3,5, options);
+    std::shared_ptr<ConditionalMapBase<MemorySpace>> map = MapFactory::CreateTriangular<MemorySpace>(4, 3, 5, options);
 
     REQUIRE(map != nullptr);
 }
 
-TEST_CASE( "Testing factory method for single entry map, activeInd = 1", "[MapFactorySingleEntryMap 1]" ) {
+TEST_CASE("Testing factory method for single entry map, activeInd = 1", "[MapFactorySingleEntryMap 1]")
+{
 
     MapOptions options;
     options.basisType = BasisTypes::ProbabilistHermite;
@@ -264,7 +277,8 @@ TEST_CASE( "Testing factory method for single entry map, activeInd = 1", "[MapFa
     REQUIRE(map != nullptr);
 }
 
-TEST_CASE( "Testing factory method for single entry map, activeInd = dim", "[MapFactorySingleEntryMap 2]" ) {
+TEST_CASE("Testing factory method for single entry map, activeInd = dim", "[MapFactorySingleEntryMap 2]")
+{
 
     MapOptions options;
     options.basisType = BasisTypes::ProbabilistHermite;
@@ -279,7 +293,8 @@ TEST_CASE( "Testing factory method for single entry map, activeInd = dim", "[Map
     REQUIRE(map != nullptr);
 }
 
-TEST_CASE( "Testing factory method for single entry map, 1 < activeInd < dim", "[MapFactorySingleEntryMap 3]" ) {
+TEST_CASE("Testing factory method for single entry map, 1 < activeInd < dim", "[MapFactorySingleEntryMap 3]")
+{
 
     MapOptions options;
     options.basisType = BasisTypes::ProbabilistHermite;
@@ -293,83 +308,91 @@ TEST_CASE( "Testing factory method for single entry map, 1 < activeInd < dim", "
 
     REQUIRE(map != nullptr);
 }
-TEST_CASE( "Testing factory method for Sigmoid Component", "[MapFactorySigmoidComponent]" ) {
+TEST_CASE("Testing factory method for Sigmoid Component", "[MapFactorySigmoidComponent]")
+{
 
     MapOptions options;
     unsigned int inputDim = 7;
     unsigned int maxDegree = 3;
     unsigned int num_sigmoids = 5;
-    unsigned int numCenters = 2 + num_sigmoids*(num_sigmoids+1)/2;
+    unsigned int numCenters = 2 + num_sigmoids * (num_sigmoids + 1) / 2;
     options.basisType = BasisTypes::HermiteFunctions;
-    Kokkos::View<double*, MemorySpace> centers("Centers", numCenters);
+    Kokkos::View<double *, MemorySpace> centers("Centers", numCenters);
     double bound = 3.;
-    centers(0) = -bound; centers(1) = bound;
+    centers(0) = -bound;
+    centers(1) = bound;
     unsigned int center_idx = 2;
-    for(int j = 0; j < num_sigmoids; j++){
-        for(int i = 0; i <= j; i++){
-            centers(center_idx) = -bound + (2*bound)*(i+1)/(j+2);
+    for (int j = 0; j < num_sigmoids; j++)
+    {
+        for (int i = 0; i <= j; i++)
+        {
+            centers(center_idx) = -bound + (2 * bound) * (i + 1) / (j + 2);
             center_idx++;
         }
     }
     std::shared_ptr<ParameterizedFunctionBase<MemorySpace>> func = MapFactory::CreateSigmoidComponent<MemorySpace>(inputDim, maxDegree, centers, options);
     REQUIRE(func != nullptr);
     unsigned int numPts = 100;
-    Kokkos::View<double**,MemorySpace> pts("Points", inputDim, numPts);
-    Kokkos::MDRangePolicy<Kokkos::Rank<2>, typename MemoryToExecution<MemorySpace>::Space> policy({0,0}, {inputDim, numPts});
-    Kokkos::parallel_for("Fill points", policy, KOKKOS_LAMBDA(const int i, const int j){
-        pts(i,j) = double(j*i)/double((inputDim)*(numPts-1));
-    });
+    Kokkos::View<double **, MemorySpace> pts("Points", inputDim, numPts);
+    Kokkos::MDRangePolicy<Kokkos::Rank<2>, typename MemoryToExecution<MemorySpace>::Space> policy({0, 0}, {inputDim, numPts});
+    Kokkos::parallel_for("Fill points", policy, KOKKOS_LAMBDA(const int i, const int j) { pts(i, j) = double(j * i) / double((inputDim) * (numPts - 1)); });
     Kokkos::fence();
     // Checking example of Gradient
     StridedVector<double, MemorySpace> coeffs = func->Coeffs();
     Kokkos::deep_copy(coeffs, 1.0);
-    Kokkos::View<double**, MemorySpace> eval = func->Evaluate(pts);
-    CHECK(eval.extent(0)==1);
-    SECTION("Check Gradient") {
-        Kokkos::View<double**, MemorySpace> sens ( "Sensitivities", 1, numPts);
-        Kokkos::RangePolicy<typename MemoryToExecution<MemorySpace>::Space> policy_pts {0, numPts};
-        Kokkos::parallel_for("fill sensitivities", policy_pts, KOKKOS_LAMBDA(const int i){
-            sens(0,i) = 1.0;
-        });
-        Kokkos::View<double**, MemorySpace> grad = func->Gradient(pts, sens);
-        CHECK(grad.extent(0)==inputDim);
-        CHECK(grad.extent(1)==numPts);
+    Kokkos::View<double **, MemorySpace> eval = func->Evaluate(pts);
+    CHECK(eval.extent(0) == 1);
+    SECTION("Check Gradient")
+    {
+        Kokkos::View<double **, MemorySpace> sens("Sensitivities", 1, numPts);
+        Kokkos::RangePolicy<typename MemoryToExecution<MemorySpace>::Space> policy_pts{0, numPts};
+        Kokkos::parallel_for("fill sensitivities", policy_pts, KOKKOS_LAMBDA(const int i) { sens(0, i) = 1.0; });
+        Kokkos::View<double **, MemorySpace> grad = func->Gradient(pts, sens);
+        CHECK(grad.extent(0) == inputDim);
+        CHECK(grad.extent(1) == numPts);
         double fd_step = 1e-6;
-        for(int i = 0; i < inputDim; i++){
-            Kokkos::parallel_for(policy_pts, KOKKOS_LAMBDA(const int j){
+        for (int i = 0; i < inputDim; i++)
+        {
+            Kokkos::parallel_for(policy_pts, KOKKOS_LAMBDA(const int j) {
                 if(i > 0) pts(i-1,j) -= fd_step;
-                pts(i,j) += fd_step;
-            });
+                pts(i,j) += fd_step; });
             Kokkos::fence();
-            Kokkos::View<double**, MemorySpace> eval2 = func->Evaluate(pts);
-            for(int j = 0; j < numPts; j++){
-                double fd = (eval2(0,j) - eval(0,j))/(fd_step);
-                CHECK(grad(i,j) == Approx(fd).epsilon(20*fd_step));
+            Kokkos::View<double **, MemorySpace> eval2 = func->Evaluate(pts);
+            for (int j = 0; j < numPts; j++)
+            {
+                double fd = (eval2(0, j) - eval(0, j)) / (fd_step);
+                CHECK(grad(i, j) == Approx(fd).epsilon(20 * fd_step));
             }
         }
     }
-    SECTION("Create Sigmoid Component from fixed msets") {
+    SECTION("Create Sigmoid Component from fixed msets")
+    {
         // Make some arbitrary limiter
-        auto limiter = [maxDegree](MultiIndex const& index){
-            return index.Get(index.Length()-1) != 0 && index.Sum() == maxDegree;
+        auto limiter = [maxDegree](MultiIndex const &index)
+        {
+            return index.Get(index.Length() - 1) != 0 && index.Sum() == maxDegree;
         };
-        FixedMultiIndexSet<MemorySpace> mset= MultiIndexSet::CreateTotalOrder(inputDim, maxDegree, limiter).Fix(true);
+        FixedMultiIndexSet<MemorySpace> mset = MultiIndexSet::CreateTotalOrder(inputDim, maxDegree, limiter).Fix(true);
         std::shared_ptr<ConditionalMapBase<MemorySpace>> map = MapFactory::CreateSigmoidComponent<MemorySpace>(mset, centers, options);
         REQUIRE(map != nullptr);
         REQUIRE(map->numCoeffs == mset.Size());
     }
-    SECTION("Create Triangular Sigmoid Map From Components") {
+    SECTION("Create Triangular Sigmoid Map From Components")
+    {
         std::vector<std::shared_ptr<ConditionalMapBase<MemorySpace>>> maps;
-        for(int i = 1; i <= inputDim; i++){
+        for (int i = 1; i <= inputDim; i++)
+        {
             maps.push_back(MapFactory::CreateSigmoidComponent<MemorySpace>(i, 0, centers, options));
         }
         auto map = std::make_shared<TriangularMap<MemorySpace>>(maps);
         REQUIRE(map != nullptr);
     }
-    SECTION("CreateSigmoidTriangular") {
+    SECTION("CreateSigmoidTriangular")
+    {
         std::vector<StridedVector<const double, MemorySpace>> centers_vec;
         unsigned int outputDim = 3;
-        for(int i = 0; i < outputDim; i++){
+        for (int i = 0; i < outputDim; i++)
+        {
             centers_vec.push_back(centers);
         }
         std::shared_ptr<ConditionalMapBase<MemorySpace>> map = MapFactory::CreateSigmoidTriangular<MemorySpace>(inputDim, outputDim, 0, centers_vec, options);

--- a/tests/Test_MonotoneComponent.cpp
+++ b/tests/Test_MonotoneComponent.cpp
@@ -11,10 +11,6 @@
 
 #include <Eigen/Dense>
 
-// TO REMOVE
-#include <iostream>
-#include <chrono>
-
 using namespace mpart;
 using namespace Catch;
 using HostSpace = Kokkos::HostSpace;
@@ -107,8 +103,6 @@ TEST_CASE( "MonotoneIntegrand1d", "[MonotoneIntegrand1d]") {
         }
     }
 }
-
-
 
 TEST_CASE( "MonotoneIntegrand1d With Nugget", "[MonotoneIntegrand1d]") {
 
@@ -355,8 +349,6 @@ TEST_CASE( "MonotoneIntegrand2d", "[MonotoneIntegrand2d]") {
     }
 }
 
-
-
 TEST_CASE( "Testing monotone component evaluation in 1d", "[MonotoneComponent1d]" ) {
 
     const double testTol = 1e-7;
@@ -438,7 +430,6 @@ TEST_CASE( "Testing monotone component evaluation in 1d", "[MonotoneComponent1d]
 
     }
 }
-
 
 TEST_CASE( "Testing bracket-based inversion of monotone component", "[MonotoneBracketInverse]" ) {
 
@@ -555,8 +546,6 @@ TEST_CASE( "Testing bracket-based inversion of monotone component", "[MonotoneBr
         }
     }
 }
-
-
 
 TEST_CASE( "Testing monotone component derivative", "[MonotoneComponentDerivative]" ) {
 

--- a/tests/Test_MonotoneComponent_compact.cpp
+++ b/tests/Test_MonotoneComponent_compact.cpp
@@ -56,8 +56,8 @@ TEST_CASE("Testing compact monotone component evaluation in 1d", "[MonotoneCompo
 
         for (unsigned int i = 0; i < numPts; ++i)
         {
-            CHECK_THAT(output(i), WithinRel(1 + exp(-1) * evalPts(0, i), testTol));
-            bool isInbounds = output(i) < 1. && output(i) > 0.;
+            CHECK_THAT(output(i), WithinRel(evalPts(0, i), testTol));
+            bool isInbounds = output(i) <= 1. && output(i) >= 0.;
             CHECK(isInbounds);
         }
     }

--- a/tests/Test_MonotoneComponent_compact.cpp
+++ b/tests/Test_MonotoneComponent_compact.cpp
@@ -1,0 +1,801 @@
+#include <catch2/catch_all.hpp>
+
+#include "MParT/MonotoneComponent.h"
+#include "MParT/PositiveBijectors.h"
+#include "MParT/Quadrature.h"
+#include "MParT/OrthogonalPolynomial.h"
+#include "MParT/MultivariateExpansionWorker.h"
+#include "MParT/MonotoneIntegrand.h"
+
+#include "MParT/Utilities/ArrayConversions.h"
+
+#include <Eigen/Dense>
+
+using namespace mpart;
+using namespace Catch::Matchers;
+using HostSpace = Kokkos::HostSpace;
+
+TEST_CASE( "Testing compact monotone component evaluation in 1d", "[MonotoneComponentCompact1d]" ) {
+
+    const double testTol = 1e-7;
+    unsigned int dim = 1;
+
+    // Create points evently space on [lb,ub]
+    unsigned int numPts = 20;
+
+    Kokkos::View<double**,HostSpace> evalPts("Evaluate Points", dim, numPts);
+    for(unsigned int i=0; i<numPts; ++i)
+        evalPts(0,i) = (i/double(numPts-0.5));
+
+    /* Create and evaluate an affine map
+       - Set coefficients so that f(x) = 1.0 + x
+       - (f(0) + int_0^x exp( d f(t) ) dt)/(f(0) + int_0^1 exp( d f(t) ) dt ) =  (1 + |x| * exp(1))/(1 + exp(1))
+    */
+    SECTION("Affine Map"){
+        unsigned int maxDegree = 1;
+        // This only will be okay for compact map since dim = 1
+        MultiIndexSet mset = MultiIndexSet::CreateTotalOrder(dim, maxDegree);
+
+        MultivariateExpansionWorker<BasisEvaluator<BasisHomogeneity::Homogeneous,ProbabilistHermite>,HostSpace> expansion(mset);
+
+        Kokkos::View<double*,HostSpace> coeffs("Expansion coefficients", mset.Size());
+        coeffs(0) = 1.0; // Constant term
+        coeffs(1) = 1.0; // Linear term
+
+        unsigned int maxSub = 3;
+        double relTol = 1e-7;
+        double absTol = 1e-7;
+        AdaptiveSimpson quad(maxSub, 1, nullptr, absTol, relTol, QuadError::First);
+
+        MonotoneComponent<MultivariateExpansionWorker<BasisEvaluator<BasisHomogeneity::Homogeneous,ProbabilistHermite>,HostSpace>, Exp, AdaptiveSimpson<HostSpace>, HostSpace, true> comp(expansion, quad);
+
+        Kokkos::View<double*,HostSpace> output("output", numPts);
+        comp.EvaluateImpl(evalPts, coeffs, output);
+
+        for(unsigned int i=0; i<numPts; ++i){
+            CHECK_THAT(output(i), WithinRel( (1+exp(1)*evalPts(0,i))/(1 + exp(1)), testTol));
+            bool isInbounds = output(i) < 1. && output(i) > 0.;
+            CHECK(isInbounds);
+        }
+    }
+
+    /* Create and evaluate a quadratic map
+       - Set coefficients so that f(x) = 1.0 + x + 0.5*x^2
+       - df/dt = 1.0 + t
+       - f(0) + int_0^x exp( df/dt ) dt = ( 1.0 + int_0^x exp(1+t) dt )/( 1.0 + int_0^1 exp(1+t) dt) = (1+exp(1+x)-exp(1))/(1+exp(2)-exp(1))
+    */
+    SECTION("Quadratic Map"){
+        unsigned int maxDegree = 2;
+        MultiIndexSet mset = MultiIndexSet::CreateTotalOrder(dim, maxDegree);
+
+        MultivariateExpansionWorker<BasisEvaluator<BasisHomogeneity::Homogeneous,ProbabilistHermite>,HostSpace> expansion(mset);
+
+        Kokkos::View<double*,HostSpace> coeffs("Expansion coefficients", mset.Size());
+        coeffs(1) = 1.0; // Linear term = x ^1
+        coeffs(2) = 0.5; // Quadratic term = x^2 - 1.0
+        coeffs(0) = 1.0 + coeffs(2); // Constant term = x^0
+
+        unsigned int maxSub = 30;
+        double relTol = 1e-7;
+        double absTol = 1e-7;
+        AdaptiveSimpson quad(maxSub, 1, nullptr, absTol, relTol,QuadError::First);
+
+        MonotoneComponent<MultivariateExpansionWorker<BasisEvaluator<BasisHomogeneity::Homogeneous,ProbabilistHermite>,HostSpace>, Exp, AdaptiveSimpson<HostSpace>, HostSpace, true> comp(expansion, quad);
+
+        Kokkos::View<double*,HostSpace> output("Output", numPts);
+        comp.EvaluateImpl(evalPts, coeffs, output);
+
+        for(unsigned int i=0; i<numPts; ++i){
+            double x = evalPts(0,i);
+            CHECK_THAT(output(i), WithinRel( (1 + exp(1+x) - exp(1))/(1 + exp(2) - exp(1)) , testTol));
+        }
+    }
+}
+
+TEST_CASE( "Testing bracket-based inversion of compact monotone component", "[CompactMonotoneBracketInverse]" ) {
+
+    const double testTol = 1e-6;
+    unsigned int dim = 1;
+
+    // Create points evently space on [lb,ub]
+    unsigned int numPts = 20;
+
+    Kokkos::View<double**, HostSpace> evalPts("Evaluate Points", dim, numPts);
+    for(unsigned int i=0; i<numPts; ++i)
+        evalPts(0,i) = (i/double(numPts-1));
+
+    /* Create and evaluate an affine map
+       - Set coefficients so that f(x) = 1.0 + x
+       - ( f(0) + int_0^x exp( d f(t) ) dt ) / ( f(0) + int_0^1 exp( d f(t) ) dt )=  (1 + x * exp(1))/(1 + exp(1))
+    */
+    SECTION("Affine Map"){
+        unsigned int maxDegree = 1;
+        MultiIndexSet mset = MultiIndexSet::CreateTotalOrder(dim, maxDegree);
+
+        MultivariateExpansionWorker<BasisEvaluator<BasisHomogeneity::Homogeneous,ProbabilistHermite>,HostSpace> expansion(mset);
+
+        Kokkos::View<double*, HostSpace> coeffs("Expansion coefficients", mset.Size());
+        coeffs(0) = 1.0; // Constant term
+        coeffs(1) = 1.0; // Linear term
+
+        unsigned int maxSub = 30;
+        double relTol = 1e-7;
+        double absTol = 1e-7;
+        AdaptiveSimpson quad(maxSub, 1, nullptr, absTol, relTol, QuadError::First);
+
+        MonotoneComponent<decltype(expansion), Exp, AdaptiveSimpson<HostSpace>, HostSpace, true> comp(expansion, quad);
+
+        Kokkos::View<double*, HostSpace> ys("ys", numPts);
+        comp.EvaluateImpl(evalPts, coeffs, ys);
+
+        Kokkos::View<double*, HostSpace> testInverse("Test output", numPts);
+        for(int i = 0; i < 100; i++)
+            comp.InverseImpl(evalPts, ys, coeffs, testInverse);
+
+        for(unsigned int i=0; i<numPts; ++i){
+            CHECK_THAT(testInverse(i), WithinRel(evalPts(0,i), testTol));
+        }
+    }
+
+    /* Create and evaluate a quadratic map
+       - Set coefficients so that f(x) = 1.0 + x + 0.5*x^2
+       - df/dt = 1.0 + t
+       - f(0) + int_0^x exp( df/dt ) dt =  1.0 + int_0^x exp(1+t) dt = 1+exp(1+x)
+    */
+    SECTION("Quadratic Map"){
+        unsigned int maxDegree = 2;
+        MultiIndexSet mset = MultiIndexSet::CreateTotalOrder(dim, maxDegree);
+
+        MultivariateExpansionWorker<BasisEvaluator<BasisHomogeneity::Homogeneous,ProbabilistHermite>,HostSpace> expansion(mset);
+
+        Kokkos::View<double*, HostSpace> coeffs("Expansion coefficients", mset.Size());
+        coeffs(1) = 1.0; // Linear term = x ^1
+        coeffs(2) = 0.5; // Quadratic term = x^2 - 1.0
+        coeffs(0) = 1.0 + coeffs(2); // Constant term = x^0
+
+        unsigned int maxSub = 30;
+        double relTol = 1e-7;
+        double absTol = 1e-7;
+        AdaptiveSimpson quad(maxSub, 1, nullptr, absTol, relTol,QuadError::First);
+
+        MonotoneComponent<decltype(expansion), Exp, AdaptiveSimpson<HostSpace>, HostSpace, true> comp(expansion, quad);
+
+        Kokkos::View<double*, HostSpace> ys("ys",numPts);
+        comp.EvaluateImpl(evalPts, coeffs,ys);
+
+        Kokkos::View<double*, HostSpace> testInverse("inverse", numPts);
+        comp.InverseImpl(evalPts, ys, coeffs, testInverse);
+
+        for(unsigned int i=0; i<numPts; ++i){
+            CHECK_THAT(testInverse(i), WithinAbs(evalPts(0,i), testTol));
+        }
+    }
+
+    SECTION("Same x, multiple ys"){
+
+        Kokkos::View<double**, HostSpace> x("Evaluate Points", dim, 1);
+        x(0,0) = 0.5;
+
+        unsigned int maxDegree = 2;
+        MultiIndexSet mset = MultiIndexSet::CreateTotalOrder(dim, maxDegree);
+        MultivariateExpansionWorker<BasisEvaluator<BasisHomogeneity::Homogeneous,ProbabilistHermite>,HostSpace> expansion(mset);
+
+        Kokkos::View<double*, HostSpace> coeffs("Expansion coefficients", mset.Size());
+        coeffs(1) = 1.0; // Linear term = x ^1
+        coeffs(2) = 0.5; // Quadratic term = x^2 - 1.0
+        coeffs(0) = 1.0 + coeffs(2); // Constant term = x^0
+
+        unsigned int maxSub = 30;
+        double relTol = 1e-7;
+        double absTol = 1e-7;
+        AdaptiveSimpson quad(maxSub, 1, nullptr, absTol, relTol,QuadError::First);
+
+        MonotoneComponent<decltype(expansion), Exp, AdaptiveSimpson<HostSpace>, HostSpace, true> comp(expansion, quad);
+
+        Kokkos::View<double*, HostSpace> ys("ys", numPts);
+        comp.EvaluateImpl(evalPts, coeffs, ys);
+
+        Kokkos::View<double*, HostSpace> testInverse("inverse", numPts);
+        comp.InverseImpl(x, ys, coeffs,testInverse);
+
+        for(unsigned int i=0; i<numPts; ++i){
+            CHECK_THAT(testInverse(i), WithinAbs(evalPts(0,i), testTol));
+        }
+    }
+}
+
+TEST_CASE( "Testing compact monotone component derivative", "[CompactMonotoneComponentDerivative]" ) {
+
+    const double testTol = 1e-4;
+    unsigned int dim = 2;
+    const double fdStep = 1e-4;
+
+    // Create points evently spaced on [lb,ub]
+    unsigned int numPts = 20;
+    double lb = 1e-3;
+    double ub = 1.- 1e-3;
+
+    Kokkos::View<double**, HostSpace> evalPts("Evaluate Points", dim, numPts);
+    for(unsigned int i=0; i<numPts; ++i){
+        evalPts(0,i) = (i/double(numPts-1))*(ub-lb) + lb;
+        evalPts(1,i) = evalPts(0,i);
+    }
+
+    Kokkos::View<double**, HostSpace> rightEvalPts("Finite difference points", dim, numPts);
+    for(unsigned int i=0; i<numPts; ++i){
+        rightEvalPts(0,i) = evalPts(0,i);
+        rightEvalPts(1,i) = evalPts(1,i) + fdStep;
+    }
+
+    unsigned int maxDegree = 2;
+
+    // Need nonzero end to midx's for compact since we need 0 to map to 0
+    // i.e. T(x,y) = (f(x,0) + int_0^y g(d_y f(x,t)) dt )/(f(x,0) + int_0^1 g(d_y f(x,t)) dt )
+    // so T(x,0) = f(x,0)/(f(x,0) + int_0^1 g(d_y f(x,t)) dt)
+    // Since we assume support on the entire domain, then we must have f(x,0) == 0
+    MultiIndexSet mset = MultiIndexSet::CreateTotalOrder(dim, maxDegree, [](MultiIndex m){return m.HasNonzeroEnd();});
+    MultivariateExpansionWorker<BasisEvaluator<BasisHomogeneity::Homogeneous,ProbabilistHermite>,HostSpace> expansion(mset);
+
+    unsigned int numTerms = mset.Size();
+
+    unsigned int maxSub = 30;
+    double relTol = 1e-7;
+    double absTol = 1e-7;
+    AdaptiveSimpson quad(maxSub, 1, nullptr, absTol, relTol,QuadError::First);
+
+    MonotoneComponent<decltype(expansion), Exp, AdaptiveSimpson<HostSpace>, HostSpace, true> comp(expansion, quad);
+
+    // Create some arbitrary coefficients
+    Kokkos::View<double*, HostSpace> coeffs("Expansion coefficients", mset.Size());
+    for(unsigned int i=0; i<coeffs.extent(0); ++i)
+        coeffs(i) = 0.1*std::cos( 0.01*i );
+
+    Kokkos::View<double*, HostSpace> evals("evals",numPts);
+    comp.EvaluateImpl(evalPts, coeffs, evals);
+    Kokkos::View<double*, HostSpace> rightEvals("revals", numPts);
+    comp.EvaluateImpl(rightEvalPts, coeffs, rightEvals);
+    Kokkos::View<double*, HostSpace> contDerivs = comp.ContinuousDerivative(evalPts, coeffs);
+
+    for(unsigned int i=0; i<numPts; ++i){
+        double fdDeriv = (rightEvals(i)-evals(i))/fdStep;
+        CHECK_THAT( contDerivs(i), WithinRel(fdDeriv, testTol) );
+    }
+}
+//     SECTION("Coefficient Jacobian"){
+
+//         Kokkos::View<double*, HostSpace> evals2("FD Evals", numPts);
+//         Kokkos::View<double**, HostSpace> jac("Jacobian", numTerms, numPts);
+
+//         comp.CoeffJacobian(evalPts, coeffs, evals2, jac);
+
+//         for(unsigned int i=0; i<numPts; ++i)
+//             CHECK(evals2(i) == Approx(evals(i)).epsilon(1e-12));
+
+//         const double fdStep = 1e-4;
+
+//         for(unsigned j=0; j<numTerms; ++j){
+//             coeffs(j) += fdStep;
+//             comp.EvaluateImpl(evalPts, coeffs, evals2);
+
+//             for(unsigned int i=0; i<numPts; ++i)
+//                 CHECK(jac(j,i) == Approx((evals2(i)-evals(i))/fdStep).epsilon(5e-4).margin(1e-4));
+
+//             coeffs(j) -= fdStep;
+//         }
+//     }
+
+
+//      SECTION("Mixed Discrete Jacobian"){
+
+//         const double fdStep = 1e-4;
+
+//         Kokkos::View<double*, HostSpace> derivs("Derivatives", numPts);
+//         Kokkos::View<double*, HostSpace> derivs2("Derivatives2", numPts);
+
+//         Kokkos::View<double**, HostSpace> jac("Jacobian", numTerms,numPts);
+
+//         comp.DiscreteMixedJacobian(evalPts, coeffs, jac);
+//         derivs = comp.DiscreteDerivative(evalPts, coeffs);
+
+//         // Perturb the coefficients and recompute
+//         Kokkos::View<double*, HostSpace> coeffs2("Coefficients2", numTerms);
+//         Kokkos::deep_copy(coeffs2, coeffs);
+
+//         for(unsigned int j=0; j<coeffs.extent(0); ++j){
+//             coeffs2(j) += fdStep;
+//             derivs2 = comp.DiscreteDerivative(evalPts, coeffs2);
+
+//             for(unsigned int i=0; i<derivs2.extent(0); ++i){
+//                 CHECK(jac(j,i)==Approx((derivs2(i) - derivs(i))/fdStep).epsilon(1e-4).margin(1e-3));
+//             }
+
+//             coeffs2(j) = coeffs(j);
+//         }
+
+//     }
+
+//     SECTION("Mixed Continuous Jacobian"){
+
+//         const double fdStep = 1e-4;
+
+//         Kokkos::View<double*, HostSpace> derivs("Derivatives", numPts);
+//         Kokkos::View<double*, HostSpace> derivs2("Derivatives2", numPts);
+
+//         Kokkos::View<double**, HostSpace> jac("Jacobian", numTerms,numPts);
+
+//         comp.ContinuousMixedJacobian(evalPts, coeffs, jac);
+//         derivs = comp.ContinuousDerivative(evalPts, coeffs);
+
+//         // Perturb the coefficients and recompute
+//         Kokkos::View<double*, HostSpace> coeffs2("Coefficients2", numTerms);
+//         Kokkos::deep_copy(coeffs2, coeffs);
+
+//         for(unsigned int j=0; j<coeffs.extent(0); ++j){
+//             coeffs2(j) += fdStep;
+//             derivs2 = comp.ContinuousDerivative(evalPts, coeffs2);
+
+//             for(unsigned int i=0; i<derivs2.extent(0); ++i){
+//                 CHECK(jac(j,i)==Approx((derivs2(i) - derivs(i))/fdStep).epsilon(1e-4).margin(1e-3));
+//             }
+
+//             coeffs2(j) = coeffs(j);
+//         }
+
+//     }
+
+//     SECTION("Input Jacobian"){
+
+//         const double fdStep = 1e-4;
+
+//         Kokkos::View<double*, HostSpace> evals("Evaluations", numPts);
+//         Kokkos::View<double*, HostSpace> evals2("Evaluations 2", numPts);
+
+//         Kokkos::View<double**, HostSpace> jac("Jacobian", dim, numPts);
+
+//         comp.InputJacobian(evalPts, coeffs, evals, jac);
+
+//         Kokkos::View<double**, HostSpace> evalPts2("Points2", evalPts.extent(0), evalPts.extent(1));
+//         Kokkos::deep_copy(evalPts2, evalPts);
+
+//         for(unsigned int j=0; j<dim; ++j){
+//             for(unsigned int ptInd=0; ptInd<numPts; ++ptInd)
+//                 evalPts2(j,ptInd) += fdStep;
+
+//             comp.EvaluateImpl(evalPts2, coeffs, evals2);
+
+//             for(unsigned int ptInd=0; ptInd<numPts; ++ptInd)
+//                 CHECK(jac(j,ptInd)==Approx((evals2(ptInd) - evals(ptInd))/fdStep).epsilon(1e-4).margin(1e-3));
+
+//             for(unsigned int ptInd=0; ptInd<numPts; ++ptInd)
+//                 evalPts2(j,ptInd) = evalPts(j,ptInd);
+//         }
+
+//     }
+
+//     SECTION("GradientImpl") {
+
+//             Kokkos::View<double**, HostSpace> evals("Evaluations", 1, numPts);
+
+//             Kokkos::View<double**, HostSpace> sens("Jacobian", dim+1, numPts);
+//             REQUIRE_THROWS_AS(comp.GradientImpl(evalPts, sens, evals), std::invalid_argument);
+
+//     }
+// }
+
+
+// TEST_CASE( "Least squares test", "[MonotoneComponentRegression]" ) {
+
+//     unsigned int numPts = 100;
+//     Kokkos::View<double**,HostSpace> pts("Training Points", 1,numPts);
+//     for(unsigned int i=0; i<numPts; ++i)
+//         pts(0,i) = i/(numPts-1.0);
+
+
+//     Kokkos::View<double*,HostSpace> fvals("Training Vales", numPts);
+//     for(unsigned int i=0; i<numPts; ++i)
+//         fvals(i) = pts(0,i)*pts(0,i) + pts(0,i);
+
+
+//     MultiIndexSet mset = MultiIndexSet::CreateTotalOrder(1, 6);
+//     MultivariateExpansionWorker<BasisEvaluator<BasisHomogeneity::Homogeneous,ProbabilistHermite>,HostSpace> expansion(mset);
+
+//     unsigned int maxSub = 30;
+//     double relTol = 1e-3;
+//     double absTol = 1e-3;
+//     AdaptiveSimpson quad(maxSub, 1, nullptr, absTol, relTol, QuadError::First);
+
+//     MonotoneComponent<decltype(expansion), SoftPlus, AdaptiveSimpson<HostSpace>, HostSpace> comp(expansion, quad);
+
+//     unsigned int numTerms = mset.Size();
+//     Kokkos::View<double*,HostSpace> coeffs("Coefficients", numTerms);
+//     Kokkos::View<double**,HostSpace> jac("Gradient", numTerms,numPts);
+//     Kokkos::View<double*,HostSpace> preds("Predictions", numPts);
+
+
+//     double objective;
+
+//     Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic,Eigen::Dynamic, Eigen::RowMajor>> jacMat(&jac(0,0), numTerms,numPts);
+
+//     Eigen::Map<Eigen::VectorXd> predVec(&preds(0), numPts);
+//     Eigen::Map<Eigen::VectorXd> obsVec(&fvals(0), numPts);
+//     Eigen::Map<Eigen::VectorXd> coeffVec(&coeffs(0), numTerms);
+
+//     Eigen::VectorXd objGrad;
+
+//     for(unsigned int optIt=0; optIt<5; ++optIt){
+
+//         comp.CoeffJacobian(pts, coeffs, preds, jac);
+
+//         objGrad = predVec-obsVec;
+
+//         objective = 0.5*objGrad.squaredNorm();
+//         coeffVec -= jacMat.transpose().colPivHouseholderQr().solve(objGrad);
+//     }
+
+//     CHECK(objective<1e-3);
+
+// }
+
+
+// TEST_CASE("Testing MonotoneComponent CoeffGrad and LogDeterminantCoeffGrad", "[MonotoneComponent_CoeffGrad]")
+// {
+//     //const double testTol = 1e-4;
+//     unsigned int dim = 2;
+
+//     // Create points evently spaced on [lb,ub]
+//     unsigned int numPts = 20;
+//     //double lb = -0.5;
+//     //double ub = 0.5;
+
+//     Kokkos::View<double**, HostSpace> evalPts("Evaluate Points", dim, numPts);
+//     for(unsigned int i=0; i<numPts; ++i){
+//         evalPts(0,i) = 0.3;
+//         evalPts(1,i) = 0.5;
+//     }
+
+//     unsigned int maxDegree = 3;
+//     MultiIndexSet mset = MultiIndexSet::CreateTotalOrder(dim, maxDegree);
+//     MultivariateExpansionWorker<BasisEvaluator<BasisHomogeneity::Homogeneous,ProbabilistHermite>,HostSpace> expansion(mset);
+
+//     unsigned int maxSub = 20;
+//     double relTol = 1e-7;
+//     double absTol = 1e-7;
+//     AdaptiveSimpson quad(maxSub, 1, nullptr, absTol, relTol, QuadError::First);
+
+//     MonotoneComponent<decltype(expansion), Exp, AdaptiveSimpson<HostSpace>, HostSpace> comp(expansion, quad);
+
+//     Kokkos::View<double*, HostSpace> coeffs("Expansion coefficients", mset.Size());
+//     for(unsigned int i=0; i<coeffs.extent(0); ++i)
+//         coeffs(i) = 0.1*std::cos( 0.01*i );
+
+//     comp.SetCoeffs(coeffs);
+
+//     SECTION("CoeffGrad"){
+
+//         Kokkos::View<double**, HostSpace> sens("Sensitivity", 1, numPts);
+//         for(unsigned int i=0; i<numPts; ++i)
+//             sens(0,i) = 0.25*(i+1);
+
+//         Kokkos::View<double**, HostSpace> grads = comp.CoeffGrad(evalPts, sens);
+//         REQUIRE(grads.extent(0)==comp.numCoeffs);
+//         REQUIRE(grads.extent(1)==numPts);
+
+//         for(unsigned int j=1; j<numPts; ++j){
+//             for(unsigned int i=0; i<comp.numCoeffs; ++i){
+//                 CHECK(grads(i,j) == (j+1.0)*grads(i,0));
+//             }
+//         }
+//     }
+
+//     SECTION("LogDeterminantCoeffGrad"){
+
+//         for(unsigned int i=0; i<numPts; ++i){
+//             evalPts(0,i) = 0.03*i;
+//             evalPts(1,i) = -0.05*i;
+//         }
+
+//         Kokkos::View<double*, HostSpace> logDets = comp.LogDeterminant(evalPts);
+//         Kokkos::View<double*, HostSpace> logDets2;
+//         Kokkos::View<double**, HostSpace> grads = comp.LogDeterminantCoeffGrad(evalPts);
+//         REQUIRE(grads.extent(0)==comp.numCoeffs);
+//         REQUIRE(grads.extent(1)==numPts);
+
+//         // Compare with finite difference derivatives
+//         const double fdstep = 1e-4;
+
+//         for(unsigned int i=0; i<coeffs.extent(0); ++i){
+//             coeffs(i) += fdstep;
+
+//             comp.SetCoeffs(coeffs);
+//             logDets2 = comp.LogDeterminant(evalPts);
+//             for(unsigned int ptInd=0; ptInd<numPts; ++ptInd)
+//                 CHECK( grads(i,ptInd) == Approx((logDets2(ptInd)-logDets(ptInd))/fdstep).epsilon(1e-5));
+
+//             coeffs(i) -= fdstep;
+//         }
+
+//     }
+
+//     SECTION("DiagonalCoeffIndices") {
+//         std::vector<unsigned int> indices = comp.DiagonalCoeffIndices();
+//         std::vector<unsigned int> indices_ref = expansion.NonzeroDiagonalEntries();
+//         bool same_indices = indices == indices_ref;
+//         REQUIRE(same_indices);
+//     }
+// }
+
+// #if defined(KOKKOS_ENABLE_CUDA ) || defined(KOKKOS_ENABLE_SYCL)
+
+// TEST_CASE( "MonotoneIntegrand1d on device", "[MonotoneIntegrandDevice]") {
+
+//     typedef Kokkos::DefaultExecutionSpace::memory_space DeviceSpace;
+
+//     const double testTol = 1e-7;
+
+//     unsigned int dim = 1;
+//     unsigned int maxDegree = 1;
+//     FixedMultiIndexSet<HostSpace> hset(dim, maxDegree);
+//     FixedMultiIndexSet<DeviceSpace> mset = hset.ToDevice<DeviceSpace>(); // Create a total order limited fixed multindex set
+
+//     MultivariateExpansionWorker<BasisEvaluator<BasisHomogeneity::Homogeneous,ProbabilistHermite>,DeviceSpace> expansion(mset);
+
+//     MultivariateExpansionWorker<BasisEvaluator<BasisHomogeneity::Homogeneous,ProbabilistHermite>,HostSpace> hexpansion(hset);
+
+//     // Make room for the cache
+//     unsigned int cacheSize = hexpansion.CacheSize();
+//     Kokkos::View<double*, DeviceSpace> dcache("device cache", cacheSize);
+
+//     Kokkos::View<double*, HostSpace> hcoeffs("Expansion coefficients", mset.Size());
+//     hcoeffs(0) = 1.0; // Constant term
+//     hcoeffs(1) = 1.0; // Linear term
+
+//     Kokkos::View<double*, DeviceSpace> dcoeffs = ToDevice<DeviceSpace>(hcoeffs);
+
+//     Kokkos::View<double*, HostSpace> hpt("evaluation point", dim);
+//     hpt(0) = 1.0;
+
+//     Kokkos::View<double*, DeviceSpace> dpt = ToDevice<DeviceSpace>(hpt);
+
+//     SECTION("Integrand Only") {
+//         Kokkos::View<double*, DeviceSpace> dres("result", 1);
+
+//     	Kokkos::RangePolicy<typename MemoryToExecution<DeviceSpace>::Space> policy(0,1);
+//         Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const int i){
+//             MonotoneIntegrand<decltype(expansion), Exp, decltype(dpt), decltype(dcoeffs), DeviceSpace> integrand(dcache.data(), expansion, dpt, dcoeffs, DerivativeFlags::None, 0.0);
+//             integrand(0.5, &dres(0));
+//         });
+
+//         Kokkos::View<double*, HostSpace> hres = ToHost(dres);
+
+//         CHECK(hres(0) == Approx(exp(1)).epsilon(testTol));
+//     }
+
+//     SECTION("Integrand Derivative") {
+//         Kokkos::View<double*, DeviceSpace> dres("result", 2);
+
+//     	Kokkos::RangePolicy<typename MemoryToExecution<DeviceSpace>::Space> policy(0,1);
+//         Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const int i){
+//             MonotoneIntegrand<decltype(expansion), Exp, decltype(dpt), decltype(dcoeffs), DeviceSpace> integrand(dcache.data(), expansion, dpt, dcoeffs, DerivativeFlags::Diagonal, 0.0);
+//             integrand(0.5, dres.data());
+//         });
+
+//         Kokkos::View<double*, HostSpace> hres = ToHost(dres);
+
+//         CHECK(hres(0) == Approx(exp(1)).epsilon(testTol));
+//     }
+
+//     SECTION("Integrand Parameters Gradient") {
+
+//         Kokkos::View<double*, DeviceSpace> dres("result", hset.Size());
+//         Kokkos::View<double*, DeviceSpace> dres_fd("result_fd", hset.Size());
+//         Kokkos::View<double*, DeviceSpace> testVal("integrand", 1+hset.Size());
+
+//     	Kokkos::RangePolicy<typename MemoryToExecution<DeviceSpace>::Space> policy(0,1);
+//         Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const int i){
+
+//             MonotoneIntegrand<decltype(expansion), Exp, decltype(dpt), decltype(dcoeffs), DeviceSpace> integrand(dcache.data(), expansion, dpt, dcoeffs, DerivativeFlags::Parameters, 0.0);
+//             MonotoneIntegrand<decltype(expansion), Exp, decltype(dpt), decltype(dcoeffs), DeviceSpace> integrand2(dcache.data(), expansion, dpt, dcoeffs, DerivativeFlags::None, 0.0);
+
+//             integrand(0.5, testVal.data());
+
+//             const double fdStep = 1e-4;
+//             double testVal2;
+//             for(unsigned int termInd=0; termInd<dres.extent(0); ++termInd){
+//                 dcoeffs(termInd) += fdStep;
+//                 integrand2(0.5, &testVal2);
+//                 dres_fd(termInd) = (testVal2 - testVal(0))/fdStep;
+
+//                 dres(termInd) = testVal(1 + termInd);
+//                 dcoeffs(termInd) -= fdStep;
+//             }
+
+//         });
+
+//         Kokkos::View<double*, HostSpace> hres = ToHost(dres);
+//         Kokkos::View<double*, HostSpace> hres_fd = ToHost(dres_fd);
+
+//         for(unsigned int termInd=0; termInd<hres.extent(0); ++termInd)
+//             CHECK(hres(termInd) == Approx(hres_fd(termInd)).epsilon(1e-4));
+//     }
+
+
+//     SECTION("Integrand Mixed Gradient") {
+
+//         Kokkos::View<double*, DeviceSpace> dres("result", hset.Size());
+//         Kokkos::View<double*, DeviceSpace> dres_fd("result_fd", hset.Size());
+//         Kokkos::View<double*, DeviceSpace> testVal("integrand", 1+hset.Size());
+//         Kokkos::View<double*, DeviceSpace> workspace("workspace", hset.Size());
+	
+// 	Kokkos::RangePolicy<typename MemoryToExecution<DeviceSpace>::Space> policy(0,1);
+//         Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const int i){
+
+//             MonotoneIntegrand<decltype(expansion), Exp, decltype(dpt), decltype(dcoeffs), DeviceSpace> integrand(dcache.data(), expansion, dpt, dcoeffs, DerivativeFlags::MixedCoeff, 0.0, workspace);
+//             MonotoneIntegrand<decltype(expansion), Exp, decltype(dpt), decltype(dcoeffs), DeviceSpace> integrand2(dcache.data(), expansion, dpt, dcoeffs, DerivativeFlags::Diagonal, 0.0);
+
+//             integrand(0.5, testVal.data());
+
+//             const double fdStep = 1e-4;
+//             double testVal2[2];
+//             for(unsigned int termInd=0; termInd<dres.extent(0); ++termInd){
+//                 dcoeffs(termInd) += fdStep;
+//                 integrand2(0.5, testVal2);
+//                 dres_fd(termInd) = (testVal2[0] - testVal(0))/fdStep;
+//                 dres(termInd) = testVal(1 + termInd);
+//             }
+//         });
+
+//         Kokkos::View<double*, HostSpace> hres = ToHost(dres);
+//         Kokkos::View<double*, HostSpace> hres_fd = ToHost(dres_fd);
+
+//         for(unsigned int termInd=0; termInd<hres.extent(0); ++termInd)
+//             CHECK(hres(termInd) == Approx(hres_fd(termInd)).epsilon(1e-4));
+
+//     }
+// }
+
+
+
+// TEST_CASE( "Testing MonotoneComponent::EvaluateSingle on Device", "[MonotoneComponentSingle_Device]") {
+
+//     typedef Kokkos::DefaultExecutionSpace::memory_space DeviceSpace;
+
+//     unsigned int dim = 2;
+//     unsigned int maxDegree = 1;
+//     FixedMultiIndexSet<HostSpace> hset(dim,maxDegree);
+//     FixedMultiIndexSet<DeviceSpace> dset = hset.ToDevice<DeviceSpace>(); // Create a total order limited fixed multindex set
+
+//     MultivariateExpansionWorker<BasisEvaluator<BasisHomogeneity::Homogeneous,ProbabilistHermite>,DeviceSpace> dexpansion(dset);
+
+//     // define f(x1,x2) = c0 + c1*x1 + c2*x2
+//     Kokkos::View<double*,HostSpace> hcoeffs("Expansion coefficients", hset.Size());
+//     hcoeffs(0) = 1.0; // Constant term
+//     hcoeffs(1) = 1.0; // Linear term in x1
+//     hcoeffs(2) = 1.0; // Linear in x2
+
+//     Kokkos::View<double*,DeviceSpace> dcoeffs = ToDevice<DeviceSpace>(hcoeffs);
+
+//     unsigned int cacheSize = dexpansion.CacheSize();
+//     CHECK(cacheSize == (maxDegree+1)*(2*dim+1));
+
+//     // Allocate some memory for the cache
+//     Kokkos::View<double*, DeviceSpace> dcache("device cache", cacheSize);
+
+//     Kokkos::View<double*,HostSpace> hpt("host point", dim);
+//     hpt(0) = 0.5;
+//     hpt(1) = 0.5;
+//     Kokkos::View<double*,DeviceSpace> dpt = ToDevice<DeviceSpace>(hpt);
+
+//     unsigned int maxSub = 20;
+//     double relTol = 1e-5;
+//     double absTol = 1e-5;
+//     AdaptiveSimpson quad(maxSub, 1, nullptr, absTol, relTol, QuadError::First);
+
+//     Kokkos::View<double*,DeviceSpace> workspace("quadrature workspace", quad.WorkspaceSize());
+
+//     Kokkos::View<double*, DeviceSpace> dres("Device Evaluation", 1);
+//     // Run the fill cache funciton, using a parallel_for loop to ensure it's run on the device
+//     Kokkos::RangePolicy<typename MemoryToExecution<DeviceSpace>::Space> policy(0,1);
+//     Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const int i){
+//         dexpansion.FillCache1(dcache.data(), dpt, DerivativeFlags::None);
+//         dres(0) = MonotoneComponent<decltype(dexpansion),Exp, decltype(quad), DeviceSpace>::EvaluateSingle(dcache.data(), workspace.data(), dpt, dpt(dim-1), dcoeffs, quad, dexpansion);
+//     });
+
+//     Kokkos::fence();
+
+//     CHECK(ToHost(dres)(0) == Approx(hcoeffs(0) + hcoeffs(1)*hpt(0) + hpt(1)*exp(hcoeffs(2))).epsilon(1e-4));
+
+// }
+
+
+// TEST_CASE( "Testing 1d monotone component evaluation on device", "[MonotoneComponent1d_Device]" ) {
+
+//     typedef Kokkos::DefaultExecutionSpace::memory_space DeviceSpace;
+
+//     const double testTol = 1e-7;
+//     unsigned int dim = 1;
+
+//     // Create points evently space on [lb,ub]
+//     unsigned int numPts = 3;
+//     double lb = -2.0;
+//     double ub = 2.0;
+
+//     Kokkos::View<double**,DeviceSpace>::HostMirror hevalPts("Evaluation Points", dim, numPts);
+//     for(unsigned int i=0; i<numPts; ++i)
+//         hevalPts(0,i) = (i/double(numPts-1))*(ub-lb) - lb;
+
+//     Kokkos::View<double**,DeviceSpace> devalPts = ToDevice<DeviceSpace>(hevalPts);
+
+
+//     /* Create and evaluate an affine map
+//        - Set coefficients so that f(x) = 1.0 + x
+//        - f(0) + int_0^x exp( d f(t) ) dt =  1.0 + int_0^x exp(1) dt = 1 + |x| * exp(1)
+//     */
+//     SECTION("Affine Map"){
+//         unsigned int maxDegree = 1;
+//         FixedMultiIndexSet<HostSpace> hset(dim, maxDegree);
+//         FixedMultiIndexSet<DeviceSpace> mset = hset.ToDevice<DeviceSpace>();
+
+//         MultivariateExpansionWorker<BasisEvaluator<BasisHomogeneity::Homogeneous,ProbabilistHermite>,DeviceSpace> expansion(mset);
+
+//         Kokkos::View<double*,HostSpace> hcoeffs("Expansion coefficients", mset.Size());
+//         hcoeffs(0) = 1.0; // Constant term
+//         hcoeffs(1) = 1.0; // Linear term
+
+//         Kokkos::View<double*,DeviceSpace> dcoeffs = ToDevice<DeviceSpace>(hcoeffs);
+
+//         unsigned int maxSub = 10;
+//         double relTol = 1e-6;
+//         double absTol = 1e-6;
+//         AdaptiveSimpson<DeviceSpace> quad(maxSub, 1, nullptr, absTol, relTol, QuadError::First);
+
+//         MonotoneComponent<decltype(expansion),Exp, decltype(quad),DeviceSpace> comp(expansion, quad);
+
+//         Kokkos::View<double*,DeviceSpace> doutput("dout", numPts);
+//         comp.EvaluateImpl(devalPts, dcoeffs, doutput);
+//         auto houtput = ToHost(doutput);
+
+//         for(unsigned int i=0; i<numPts; ++i){
+//             CHECK(houtput(i) == Approx(1+exp(1)*std::abs(hevalPts(0,i))).epsilon(testTol));
+//         }
+//     }
+
+
+//     /* Create and evaluate a quadratic map
+//        - Set coefficients so that f(x) = 1.0 + x + 0.5*x^2
+//        - df/dt = 1.0 + t
+//        - f(0) + int_0^x exp( df/dt ) dt =  1.0 + int_0^x exp(1+t) dt = 1+exp(1+x)
+//     */
+//     SECTION("Quadratic Map"){
+//         unsigned int maxDegree = 2;
+
+//         FixedMultiIndexSet<HostSpace> hset(dim, maxDegree);
+//         FixedMultiIndexSet<DeviceSpace> mset = hset.ToDevice<DeviceSpace>();
+
+//         MultivariateExpansionWorker<BasisEvaluator<BasisHomogeneity::Homogeneous,ProbabilistHermite>,DeviceSpace> expansion(mset);
+
+//         Kokkos::View<double*,HostSpace> hcoeffs("Expansion coefficients", mset.Size());
+//         hcoeffs(1) = 1.0; // Linear term = x ^1
+//         hcoeffs(2) = 0.5; // Quadratic term = x^2 - 1.0
+//         hcoeffs(0) = 1.0 + hcoeffs(2); // Constant term = x^0
+
+//         Kokkos::View<double*,DeviceSpace> dcoeffs = ToDevice<DeviceSpace>(hcoeffs);
+
+//         unsigned int maxSub = 10;
+//         double relTol = 1e-6;
+//         double absTol = 1e-6;
+//         AdaptiveSimpson<DeviceSpace> quad(maxSub, 1, nullptr, absTol, relTol, QuadError::First);
+
+//         MonotoneComponent<decltype(expansion), Exp, decltype(quad), DeviceSpace> comp(expansion, quad);
+
+//         Kokkos::View<double*,DeviceSpace> doutput("dout",numPts);
+//         comp.EvaluateImpl(devalPts, dcoeffs, doutput);
+//         auto houtput = ToHost(doutput);
+
+//         for(unsigned int i=0; i<numPts; ++i){
+//             CHECK(houtput(i) == Approx(1+exp(1)*(exp(hevalPts(0,i))-1)).epsilon(testTol));
+//         }
+//     }
+
+// }
+
+// #endif

--- a/tests/Test_MonotoneComponent_compact.cpp
+++ b/tests/Test_MonotoneComponent_compact.cpp
@@ -15,7 +15,8 @@ using namespace mpart;
 using namespace Catch::Matchers;
 using HostSpace = Kokkos::HostSpace;
 
-TEST_CASE( "Testing compact monotone component evaluation in 1d", "[MonotoneComponentCompact1d]" ) {
+TEST_CASE("Testing compact monotone component evaluation in 1d", "[MonotoneComponentCompact1d]")
+{
 
     const double testTol = 1e-7;
     unsigned int dim = 1;
@@ -23,22 +24,23 @@ TEST_CASE( "Testing compact monotone component evaluation in 1d", "[MonotoneComp
     // Create points evently space on [lb,ub]
     unsigned int numPts = 20;
 
-    Kokkos::View<double**,HostSpace> evalPts("Evaluate Points", dim, numPts);
-    for(unsigned int i=0; i<numPts; ++i)
-        evalPts(0,i) = (i/double(numPts-0.5));
+    Kokkos::View<double **, HostSpace> evalPts("Evaluate Points", dim, numPts);
+    for (unsigned int i = 0; i < numPts; ++i)
+        evalPts(0, i) = (i / double(numPts - 0.5));
 
     /* Create and evaluate an affine map
        - Set coefficients so that f(x) = 1.0 + x
        - (int_0^x exp( d f(t) ) dt)/(int_0^1 exp( d f(t) ) dt ) =  x*exp(-1) + 1
     */
-    SECTION("Affine Map"){
+    SECTION("Affine Map")
+    {
         unsigned int maxDegree = 1;
         // This only will be okay for compact map since dim = 1
         MultiIndexSet mset = MultiIndexSet::CreateTotalOrder(dim, maxDegree);
 
-        MultivariateExpansionWorker<BasisEvaluator<BasisHomogeneity::Homogeneous,ProbabilistHermite>,HostSpace> expansion(mset);
+        MultivariateExpansionWorker<BasisEvaluator<BasisHomogeneity::Homogeneous, ProbabilistHermite>, HostSpace> expansion(mset);
 
-        Kokkos::View<double*,HostSpace> coeffs("Expansion coefficients", mset.Size());
+        Kokkos::View<double *, HostSpace> coeffs("Expansion coefficients", mset.Size());
         coeffs(0) = 1.0; // Constant term
         coeffs(1) = 1.0; // Linear term
 
@@ -47,13 +49,14 @@ TEST_CASE( "Testing compact monotone component evaluation in 1d", "[MonotoneComp
         double absTol = 1e-7;
         AdaptiveSimpson quad(maxSub, 1, nullptr, absTol, relTol, QuadError::First);
 
-        MonotoneComponent<MultivariateExpansionWorker<BasisEvaluator<BasisHomogeneity::Homogeneous,ProbabilistHermite>,HostSpace>, Exp, AdaptiveSimpson<HostSpace>, HostSpace, true> comp(expansion, quad);
+        MonotoneComponent<MultivariateExpansionWorker<BasisEvaluator<BasisHomogeneity::Homogeneous, ProbabilistHermite>, HostSpace>, Exp, AdaptiveSimpson<HostSpace>, HostSpace, true> comp(expansion, quad);
 
-        Kokkos::View<double*,HostSpace> output("output", numPts);
+        Kokkos::View<double *, HostSpace> output("output", numPts);
         comp.EvaluateImpl(evalPts, coeffs, output);
 
-        for(unsigned int i=0; i<numPts; ++i){
-            CHECK_THAT(output(i), WithinRel( 1+exp(-1)*evalPts(0,i), testTol));
+        for (unsigned int i = 0; i < numPts; ++i)
+        {
+            CHECK_THAT(output(i), WithinRel(1 + exp(-1) * evalPts(0, i), testTol));
             bool isInbounds = output(i) < 1. && output(i) > 0.;
             CHECK(isInbounds);
         }
@@ -64,35 +67,38 @@ TEST_CASE( "Testing compact monotone component evaluation in 1d", "[MonotoneComp
        - df/dt = 1.0 + t
        - int_0^x exp( df/dt ) dt = int_0^x exp(1+t) = exp(1+x)-exp(1) => (exp(1+x)-exp(1))/(exp(2)-exp(1))
     */
-    SECTION("Quadratic Map"){
+    SECTION("Quadratic Map")
+    {
         unsigned int maxDegree = 2;
         MultiIndexSet mset = MultiIndexSet::CreateTotalOrder(dim, maxDegree);
 
-        MultivariateExpansionWorker<BasisEvaluator<BasisHomogeneity::Homogeneous,ProbabilistHermite>,HostSpace> expansion(mset);
+        MultivariateExpansionWorker<BasisEvaluator<BasisHomogeneity::Homogeneous, ProbabilistHermite>, HostSpace> expansion(mset);
 
-        Kokkos::View<double*,HostSpace> coeffs("Expansion coefficients", mset.Size());
-        coeffs(1) = 1.0; // Linear term = x ^1
-        coeffs(2) = 0.5; // Quadratic term = x^2 - 1.0
+        Kokkos::View<double *, HostSpace> coeffs("Expansion coefficients", mset.Size());
+        coeffs(1) = 1.0;             // Linear term = x ^1
+        coeffs(2) = 0.5;             // Quadratic term = x^2 - 1.0
         coeffs(0) = 1.0 + coeffs(2); // Constant term = x^0
 
         unsigned int maxSub = 30;
         double relTol = 1e-7;
         double absTol = 1e-7;
-        AdaptiveSimpson quad(maxSub, 1, nullptr, absTol, relTol,QuadError::First);
+        AdaptiveSimpson quad(maxSub, 1, nullptr, absTol, relTol, QuadError::First);
 
-        MonotoneComponent<MultivariateExpansionWorker<BasisEvaluator<BasisHomogeneity::Homogeneous,ProbabilistHermite>,HostSpace>, Exp, AdaptiveSimpson<HostSpace>, HostSpace, true> comp(expansion, quad);
+        MonotoneComponent<MultivariateExpansionWorker<BasisEvaluator<BasisHomogeneity::Homogeneous, ProbabilistHermite>, HostSpace>, Exp, AdaptiveSimpson<HostSpace>, HostSpace, true> comp(expansion, quad);
 
-        Kokkos::View<double*,HostSpace> output("Output", numPts);
+        Kokkos::View<double *, HostSpace> output("Output", numPts);
         comp.EvaluateImpl(evalPts, coeffs, output);
 
-        for(unsigned int i=0; i<numPts; ++i){
-            double x = evalPts(0,i);
-            CHECK_THAT(output(i), WithinRel( (exp(1+x) - exp(1))/(exp(2) - exp(1)) , testTol));
+        for (unsigned int i = 0; i < numPts; ++i)
+        {
+            double x = evalPts(0, i);
+            CHECK_THAT(output(i), WithinRel((exp(1 + x) - exp(1)) / (exp(2) - exp(1)), testTol));
         }
     }
 }
 
-TEST_CASE( "Testing bracket-based inversion of compact monotone component", "[CompactMonotoneBracketInverse]" ) {
+TEST_CASE("Testing bracket-based inversion of compact monotone component", "[CompactMonotoneBracketInverse]")
+{
 
     const double testTol = 2e-6;
     unsigned int dim = 1;
@@ -100,21 +106,22 @@ TEST_CASE( "Testing bracket-based inversion of compact monotone component", "[Co
     // Create points evently space on [lb,ub]
     unsigned int numPts = 20;
 
-    Kokkos::View<double**, HostSpace> evalPts("Evaluate Points", dim, numPts);
-    for(unsigned int i=0; i<numPts; ++i)
-        evalPts(0,i) = (i/double(numPts-1));
+    Kokkos::View<double **, HostSpace> evalPts("Evaluate Points", dim, numPts);
+    for (unsigned int i = 0; i < numPts; ++i)
+        evalPts(0, i) = (i / double(numPts - 1));
 
     /* Create and evaluate an affine map
        - Set coefficients so that f(x) = 1.0 + x
        - ( f(0) + int_0^x exp( d f(t) ) dt ) / ( f(0) + int_0^1 exp( d f(t) ) dt )=  (1 + x * exp(1))/(1 + exp(1))
     */
-    SECTION("Affine Map"){
+    SECTION("Affine Map")
+    {
         unsigned int maxDegree = 1;
         MultiIndexSet mset = MultiIndexSet::CreateTotalOrder(dim, maxDegree);
 
-        MultivariateExpansionWorker<BasisEvaluator<BasisHomogeneity::Homogeneous,ProbabilistHermite>,HostSpace> expansion(mset);
+        MultivariateExpansionWorker<BasisEvaluator<BasisHomogeneity::Homogeneous, ProbabilistHermite>, HostSpace> expansion(mset);
 
-        Kokkos::View<double*, HostSpace> coeffs("Expansion coefficients", mset.Size());
+        Kokkos::View<double *, HostSpace> coeffs("Expansion coefficients", mset.Size());
         coeffs(0) = 1.0; // Constant term
         coeffs(1) = 1.0; // Linear term
 
@@ -125,15 +132,16 @@ TEST_CASE( "Testing bracket-based inversion of compact monotone component", "[Co
 
         MonotoneComponent<decltype(expansion), Exp, AdaptiveSimpson<HostSpace>, HostSpace, true> comp(expansion, quad);
 
-        Kokkos::View<double*, HostSpace> ys("ys", numPts);
+        Kokkos::View<double *, HostSpace> ys("ys", numPts);
         comp.EvaluateImpl(evalPts, coeffs, ys);
 
-        Kokkos::View<double*, HostSpace> testInverse("Test output", numPts);
-        for(int i = 0; i < 100; i++)
+        Kokkos::View<double *, HostSpace> testInverse("Test output", numPts);
+        for (int i = 0; i < 100; i++)
             comp.InverseImpl(evalPts, ys, coeffs, testInverse);
 
-        for(unsigned int i=0; i<numPts; ++i){
-            CHECK_THAT(testInverse(i), WithinRel(evalPts(0,i), testTol));
+        for (unsigned int i = 0; i < numPts; ++i)
+        {
+            CHECK_THAT(testInverse(i), WithinRel(evalPts(0, i), testTol));
         }
     }
 
@@ -142,69 +150,74 @@ TEST_CASE( "Testing bracket-based inversion of compact monotone component", "[Co
        - df/dt = 1.0 + t
        - f(0) + int_0^x exp( df/dt ) dt =  1.0 + int_0^x exp(1+t) dt = 1+exp(1+x)
     */
-    SECTION("Quadratic Map"){
+    SECTION("Quadratic Map")
+    {
         unsigned int maxDegree = 2;
         MultiIndexSet mset = MultiIndexSet::CreateTotalOrder(dim, maxDegree);
 
-        MultivariateExpansionWorker<BasisEvaluator<BasisHomogeneity::Homogeneous,ProbabilistHermite>,HostSpace> expansion(mset);
+        MultivariateExpansionWorker<BasisEvaluator<BasisHomogeneity::Homogeneous, ProbabilistHermite>, HostSpace> expansion(mset);
 
-        Kokkos::View<double*, HostSpace> coeffs("Expansion coefficients", mset.Size());
-        coeffs(1) = 1.0; // Linear term = x ^1
-        coeffs(2) = 0.5; // Quadratic term = x^2 - 1.0
+        Kokkos::View<double *, HostSpace> coeffs("Expansion coefficients", mset.Size());
+        coeffs(1) = 1.0;             // Linear term = x ^1
+        coeffs(2) = 0.5;             // Quadratic term = x^2 - 1.0
         coeffs(0) = 1.0 + coeffs(2); // Constant term = x^0
 
         unsigned int maxSub = 30;
         double relTol = 1e-7;
         double absTol = 1e-7;
-        AdaptiveSimpson quad(maxSub, 1, nullptr, absTol, relTol,QuadError::First);
+        AdaptiveSimpson quad(maxSub, 1, nullptr, absTol, relTol, QuadError::First);
 
         MonotoneComponent<decltype(expansion), Exp, AdaptiveSimpson<HostSpace>, HostSpace, true> comp(expansion, quad);
 
-        Kokkos::View<double*, HostSpace> ys("ys",numPts);
-        comp.EvaluateImpl(evalPts, coeffs,ys);
+        Kokkos::View<double *, HostSpace> ys("ys", numPts);
+        comp.EvaluateImpl(evalPts, coeffs, ys);
 
-        Kokkos::View<double*, HostSpace> testInverse("inverse", numPts);
+        Kokkos::View<double *, HostSpace> testInverse("inverse", numPts);
         comp.InverseImpl(evalPts, ys, coeffs, testInverse);
 
-        for(unsigned int i=0; i<numPts; ++i){
-            CHECK_THAT(testInverse(i), WithinAbs(evalPts(0,i), testTol));
+        for (unsigned int i = 0; i < numPts; ++i)
+        {
+            CHECK_THAT(testInverse(i), WithinAbs(evalPts(0, i), testTol));
         }
     }
 
-    SECTION("Same x, multiple ys"){
+    SECTION("Same x, multiple ys")
+    {
 
-        Kokkos::View<double**, HostSpace> x("Evaluate Points", dim, 1);
-        x(0,0) = 0.5;
+        Kokkos::View<double **, HostSpace> x("Evaluate Points", dim, 1);
+        x(0, 0) = 0.5;
 
         unsigned int maxDegree = 2;
         MultiIndexSet mset = MultiIndexSet::CreateTotalOrder(dim, maxDegree);
-        MultivariateExpansionWorker<BasisEvaluator<BasisHomogeneity::Homogeneous,ProbabilistHermite>,HostSpace> expansion(mset);
+        MultivariateExpansionWorker<BasisEvaluator<BasisHomogeneity::Homogeneous, ProbabilistHermite>, HostSpace> expansion(mset);
 
-        Kokkos::View<double*, HostSpace> coeffs("Expansion coefficients", mset.Size());
-        coeffs(1) = 1.0; // Linear term = x ^1
-        coeffs(2) = 0.5; // Quadratic term = x^2 - 1.0
+        Kokkos::View<double *, HostSpace> coeffs("Expansion coefficients", mset.Size());
+        coeffs(1) = 1.0;             // Linear term = x ^1
+        coeffs(2) = 0.5;             // Quadratic term = x^2 - 1.0
         coeffs(0) = 1.0 + coeffs(2); // Constant term = x^0
 
         unsigned int maxSub = 30;
         double relTol = 1e-7;
         double absTol = 1e-7;
-        AdaptiveSimpson quad(maxSub, 1, nullptr, absTol, relTol,QuadError::First);
+        AdaptiveSimpson quad(maxSub, 1, nullptr, absTol, relTol, QuadError::First);
 
         MonotoneComponent<decltype(expansion), Exp, AdaptiveSimpson<HostSpace>, HostSpace, true> comp(expansion, quad);
 
-        Kokkos::View<double*, HostSpace> ys("ys", numPts);
+        Kokkos::View<double *, HostSpace> ys("ys", numPts);
         comp.EvaluateImpl(evalPts, coeffs, ys);
 
-        Kokkos::View<double*, HostSpace> testInverse("inverse", numPts);
-        comp.InverseImpl(x, ys, coeffs,testInverse);
+        Kokkos::View<double *, HostSpace> testInverse("inverse", numPts);
+        comp.InverseImpl(x, ys, coeffs, testInverse);
 
-        for(unsigned int i=0; i<numPts; ++i){
-            CHECK_THAT(testInverse(i), WithinAbs(evalPts(0,i), testTol));
+        for (unsigned int i = 0; i < numPts; ++i)
+        {
+            CHECK_THAT(testInverse(i), WithinAbs(evalPts(0, i), testTol));
         }
     }
 }
 
-TEST_CASE( "Testing compact monotone component derivative", "[CompactMonotoneComponentDerivative]" ) {
+TEST_CASE("Testing compact monotone component derivative", "[CompactMonotoneComponentDerivative]")
+{
 
     const double testTol = 1e-4;
     unsigned int dim = 2;
@@ -213,169 +226,180 @@ TEST_CASE( "Testing compact monotone component derivative", "[CompactMonotoneCom
     // Create points evently spaced on [lb,ub]
     unsigned int numPts = 20;
     double lb = 0.;
-    double ub = 1.- fdStep;
+    double ub = 1. - fdStep;
 
-    Kokkos::View<double**, HostSpace> evalPts("Evaluate Points", dim, numPts);
-    for(unsigned int i=0; i<numPts; ++i){
-        evalPts(0,i) = (i/double(numPts-1))*(ub-lb) + lb;
-        evalPts(1,i) = evalPts(0,i);
+    Kokkos::View<double **, HostSpace> evalPts("Evaluate Points", dim, numPts);
+    for (unsigned int i = 0; i < numPts; ++i)
+    {
+        evalPts(0, i) = (i / double(numPts - 1)) * (ub - lb) + lb;
+        evalPts(1, i) = evalPts(0, i);
     }
 
-    Kokkos::View<double**, HostSpace> rightEvalPts("Finite difference points", dim, numPts);
-    for(unsigned int i=0; i<numPts; ++i){
-        rightEvalPts(0,i) = evalPts(0,i);
-        rightEvalPts(1,i) = evalPts(1,i) + fdStep;
+    Kokkos::View<double **, HostSpace> rightEvalPts("Finite difference points", dim, numPts);
+    for (unsigned int i = 0; i < numPts; ++i)
+    {
+        rightEvalPts(0, i) = evalPts(0, i);
+        rightEvalPts(1, i) = evalPts(1, i) + fdStep;
     }
 
     unsigned int maxDegree = 4;
 
     MultiIndexSet mset = MultiIndexSet::CreateTotalOrder(dim, maxDegree);
-    MultivariateExpansionWorker<BasisEvaluator<BasisHomogeneity::Homogeneous,ProbabilistHermite>,HostSpace> expansion(mset);
+    MultivariateExpansionWorker<BasisEvaluator<BasisHomogeneity::Homogeneous, ProbabilistHermite>, HostSpace> expansion(mset);
 
     unsigned int numTerms = mset.Size();
 
     unsigned int maxSub = 30;
     double relTol = 1e-7;
     double absTol = 1e-7;
-    AdaptiveSimpson quad(maxSub, 1, nullptr, absTol, relTol,QuadError::First);
+    AdaptiveSimpson quad(maxSub, 1, nullptr, absTol, relTol, QuadError::First);
 
     MonotoneComponent<decltype(expansion), Exp, AdaptiveSimpson<HostSpace>, HostSpace, true> comp(expansion, quad);
 
     // Create some arbitrary coefficients
-    Kokkos::View<double*, HostSpace> coeffs("Expansion coefficients", mset.Size());
-    for(unsigned int i=0; i<coeffs.extent(0); ++i)
-        coeffs(i) = 0.1*std::cos( 2*i + 0.5);
+    Kokkos::View<double *, HostSpace> coeffs("Expansion coefficients", mset.Size());
+    for (unsigned int i = 0; i < coeffs.extent(0); ++i)
+        coeffs(i) = 0.1 * std::cos(2 * i + 0.5);
 
-    Kokkos::View<double*, HostSpace> evals("evals",numPts);
+    Kokkos::View<double *, HostSpace> evals("evals", numPts);
     comp.EvaluateImpl(evalPts, coeffs, evals);
-    Kokkos::View<double*, HostSpace> rightEvals("revals", numPts);
+    Kokkos::View<double *, HostSpace> rightEvals("revals", numPts);
     comp.EvaluateImpl(rightEvalPts, coeffs, rightEvals);
-    Kokkos::View<double*, HostSpace> contDerivs = comp.ContinuousDerivative(evalPts, coeffs);
+    Kokkos::View<double *, HostSpace> contDerivs = comp.ContinuousDerivative(evalPts, coeffs);
 
-    SECTION("Continuous derivatives") {
-        for(unsigned int i=0; i<numPts; ++i){
-            double fdDeriv = (rightEvals(i)-evals(i))/fdStep;
-            CHECK_THAT( contDerivs(i), WithinRel(fdDeriv, testTol) );
+    SECTION("Continuous derivatives")
+    {
+        for (unsigned int i = 0; i < numPts; ++i)
+        {
+            double fdDeriv = (rightEvals(i) - evals(i)) / fdStep;
+            CHECK_THAT(contDerivs(i), WithinRel(fdDeriv, testTol));
         }
     }
 
-    SECTION("Coefficient Jacobian"){
+    SECTION("Coefficient Jacobian")
+    {
 
-        Kokkos::View<double*, HostSpace> evals2("FD Evals", numPts);
-        Kokkos::View<double**, HostSpace> jac("Jacobian", numTerms, numPts);
+        Kokkos::View<double *, HostSpace> evals2("FD Evals", numPts);
+        Kokkos::View<double **, HostSpace> jac("Jacobian", numTerms, numPts);
 
         comp.CoeffJacobian(evalPts, coeffs, evals2, jac);
 
-        for(unsigned int i=0; i<numPts; ++i)
+        for (unsigned int i = 0; i < numPts; ++i)
             CHECK_THAT(evals2(i), WithinAbs(evals(i), 1e-12));
 
         const double fdStep = 1e-4;
 
-        for(unsigned j=0; j<numTerms; ++j){
+        for (unsigned j = 0; j < numTerms; ++j)
+        {
             coeffs(j) += fdStep;
             comp.EvaluateImpl(evalPts, coeffs, evals2);
 
-            for(unsigned int i=0; i<numPts; ++i) {
+            for (unsigned int i = 0; i < numPts; ++i)
+            {
                 // TODO: Why is jacobian zero for midx (k_1,k_2) k_2<=1 ??
-                double fd_deriv = (evals2(i)-evals(i))/fdStep;
-                CHECK_THAT(jac(j,i), WithinRel(fd_deriv, 5*fdStep) || WithinAbs(fd_deriv, 1e-10));
+                double fd_deriv = (evals2(i) - evals(i)) / fdStep;
+                CHECK_THAT(jac(j, i), WithinRel(fd_deriv, 5 * fdStep) || WithinAbs(fd_deriv, 1e-10));
             }
 
             coeffs(j) -= fdStep;
         }
     }
 
-    SECTION("Mixed Continuous Jacobian"){
+    SECTION("Mixed Continuous Jacobian")
+    {
 
         const double fdStep = 1e-5;
 
-        Kokkos::View<double*, HostSpace> derivs("Derivatives", numPts);
-        Kokkos::View<double*, HostSpace> derivs2("Derivatives2", numPts);
+        Kokkos::View<double *, HostSpace> derivs("Derivatives", numPts);
+        Kokkos::View<double *, HostSpace> derivs2("Derivatives2", numPts);
 
-        Kokkos::View<double**, HostSpace> jac("Jacobian", numTerms,numPts);
+        Kokkos::View<double **, HostSpace> jac("Jacobian", numTerms, numPts);
 
         comp.ContinuousMixedJacobian(evalPts, coeffs, jac);
         derivs = comp.ContinuousDerivative(evalPts, coeffs);
 
         // Perturb the coefficients and recompute
-        Kokkos::View<double*, HostSpace> coeffs2("Coefficients2", numTerms);
+        Kokkos::View<double *, HostSpace> coeffs2("Coefficients2", numTerms);
         Kokkos::deep_copy(coeffs2, coeffs);
 
-        for(unsigned int j=0; j<coeffs.extent(0); ++j){
+        for (unsigned int j = 0; j < coeffs.extent(0); ++j)
+        {
             coeffs2(j) += fdStep;
             derivs2 = comp.ContinuousDerivative(evalPts, coeffs2);
 
-            for(unsigned int i=0; i<derivs2.extent(0); ++i){
+            for (unsigned int i = 0; i < derivs2.extent(0); ++i)
+            {
                 // TODO: Why is jacobian zero for midx (k_1,k_2) k_2<=1 ??
-                double fd_deriv = (derivs2(i) - derivs(i))/fdStep;
-                CHECK_THAT(jac(j,i), WithinRel(fd_deriv, 20*fdStep) || WithinAbs(fd_deriv, 1e-10));
+                double fd_deriv = (derivs2(i) - derivs(i)) / fdStep;
+                CHECK_THAT(jac(j, i), WithinRel(fd_deriv, 20 * fdStep) || WithinAbs(fd_deriv, 1e-10));
             }
 
             coeffs2(j) = coeffs(j);
         }
     }
 
-    SECTION("Input Jacobian"){
+    SECTION("Input Jacobian")
+    {
 
         const double fdStep = 1e-4;
 
-        Kokkos::View<double*, HostSpace> evals("Evaluations", numPts);
-        Kokkos::View<double*, HostSpace> evals2("Evaluations 2", numPts);
+        Kokkos::View<double *, HostSpace> evals("Evaluations", numPts);
+        Kokkos::View<double *, HostSpace> evals2("Evaluations 2", numPts);
 
-        Kokkos::View<double**, HostSpace> jac("Jacobian", dim, numPts);
+        Kokkos::View<double **, HostSpace> jac("Jacobian", dim, numPts);
 
         comp.InputJacobian(evalPts, coeffs, evals, jac);
 
-        Kokkos::View<double**, HostSpace> evalPts2("Points2", evalPts.extent(0), evalPts.extent(1));
+        Kokkos::View<double **, HostSpace> evalPts2("Points2", evalPts.extent(0), evalPts.extent(1));
         Kokkos::deep_copy(evalPts2, evalPts);
 
-        for(unsigned int j=0; j<dim; ++j){
-            for(unsigned int ptInd=0; ptInd<numPts; ++ptInd)
-                evalPts2(j,ptInd) += fdStep;
+        for (unsigned int j = 0; j < dim; ++j)
+        {
+            for (unsigned int ptInd = 0; ptInd < numPts; ++ptInd)
+                evalPts2(j, ptInd) += fdStep;
 
             comp.EvaluateImpl(evalPts2, coeffs, evals2);
 
-            for(unsigned int ptInd=0; ptInd<numPts; ++ptInd) {
-                double fd_deriv = (evals2(ptInd) - evals(ptInd))/fdStep;
-                CHECK_THAT(jac(j,ptInd), WithinRel(fd_deriv, 10*fdStep) || WithinAbs(fd_deriv, 1e-10));
+            for (unsigned int ptInd = 0; ptInd < numPts; ++ptInd)
+            {
+                double fd_deriv = (evals2(ptInd) - evals(ptInd)) / fdStep;
+                CHECK_THAT(jac(j, ptInd), WithinRel(fd_deriv, 10 * fdStep) || WithinAbs(fd_deriv, 1e-10));
             }
 
-            for(unsigned int ptInd=0; ptInd<numPts; ++ptInd)
-                evalPts2(j,ptInd) = evalPts(j,ptInd);
+            for (unsigned int ptInd = 0; ptInd < numPts; ++ptInd)
+                evalPts2(j, ptInd) = evalPts(j, ptInd);
         }
-
     }
 
-    SECTION("DiscreteDerivative") {
-            REQUIRE_THROWS_AS(comp.DiscreteDerivative(evalPts, coeffs), std::invalid_argument);
+    SECTION("DiscreteDerivative")
+    {
+        REQUIRE_THROWS_AS(comp.DiscreteDerivative(evalPts, coeffs), std::invalid_argument);
     }
-    SECTION("GradientImpl") {
+    SECTION("GradientImpl")
+    {
 
-            Kokkos::View<double**, HostSpace> evals("Evaluations", 1, numPts);
+        Kokkos::View<double **, HostSpace> evals("Evaluations", 1, numPts);
 
-            Kokkos::View<double**, HostSpace> sens("Jacobian", dim+1, numPts);
-            REQUIRE_THROWS_AS(comp.GradientImpl(evalPts, sens, evals), std::invalid_argument);
-
+        Kokkos::View<double **, HostSpace> sens("Jacobian", dim + 1, numPts);
+        REQUIRE_THROWS_AS(comp.GradientImpl(evalPts, sens, evals), std::invalid_argument);
     }
 }
 
-
-TEST_CASE( "Compact least squares test", "[CompactMonotoneComponentRegression]" ) {
+TEST_CASE("Compact least squares test", "[CompactMonotoneComponentRegression]")
+{
 
     unsigned int numPts = 100;
-    Kokkos::View<double**,HostSpace> pts("Training Points", 1,numPts);
-    for(unsigned int i=0; i<numPts; ++i)
-        pts(0,i) = i/(numPts-1.0);
+    Kokkos::View<double **, HostSpace> pts("Training Points", 1, numPts);
+    for (unsigned int i = 0; i < numPts; ++i)
+        pts(0, i) = i / (numPts - 1.0);
 
-
-    Kokkos::View<double*,HostSpace> fvals("Training Values", numPts);
-    for(unsigned int i=0; i<numPts; ++i)
-        fvals(i) = (pts(0,i)*pts(0,i) + pts(0,i))/2; // Bijection on [0,1]
-
+    Kokkos::View<double *, HostSpace> fvals("Training Values", numPts);
+    for (unsigned int i = 0; i < numPts; ++i)
+        fvals(i) = (pts(0, i) * pts(0, i) + pts(0, i)) / 2; // Bijection on [0,1]
 
     // Don't need limiter for compact in one dimension
     MultiIndexSet mset = MultiIndexSet::CreateTotalOrder(1, 6);
-    MultivariateExpansionWorker<BasisEvaluator<BasisHomogeneity::Homogeneous,ProbabilistHermite>,HostSpace> expansion(mset);
+    MultivariateExpansionWorker<BasisEvaluator<BasisHomogeneity::Homogeneous, ProbabilistHermite>, HostSpace> expansion(mset);
 
     unsigned int maxSub = 30;
     double relTol = 1e-3;
@@ -385,14 +409,13 @@ TEST_CASE( "Compact least squares test", "[CompactMonotoneComponentRegression]" 
     MonotoneComponent<decltype(expansion), SoftPlus, AdaptiveSimpson<HostSpace>, HostSpace, true> comp(expansion, quad);
 
     unsigned int numTerms = mset.Size();
-    Kokkos::View<double*,HostSpace> coeffs("Coefficients", numTerms);
-    Kokkos::View<double**,HostSpace> jac("Gradient", numTerms,numPts);
-    Kokkos::View<double*,HostSpace> preds("Predictions", numPts);
-
+    Kokkos::View<double *, HostSpace> coeffs("Coefficients", numTerms);
+    Kokkos::View<double **, HostSpace> jac("Gradient", numTerms, numPts);
+    Kokkos::View<double *, HostSpace> preds("Predictions", numPts);
 
     double objective;
 
-    Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic,Eigen::Dynamic, Eigen::RowMajor>> jacMat(&jac(0,0), numTerms,numPts);
+    Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>> jacMat(&jac(0, 0), numTerms, numPts);
 
     Eigen::Map<Eigen::VectorXd> predVec(&preds(0), numPts);
     Eigen::Map<Eigen::VectorXd> obsVec(&fvals(0), numPts);
@@ -400,40 +423,40 @@ TEST_CASE( "Compact least squares test", "[CompactMonotoneComponentRegression]" 
 
     Eigen::VectorXd objGrad;
 
-    for(unsigned int optIt=0; optIt<5; ++optIt){
+    for (unsigned int optIt = 0; optIt < 5; ++optIt)
+    {
 
         comp.CoeffJacobian(pts, coeffs, preds, jac);
 
-        objGrad = predVec-obsVec;
+        objGrad = predVec - obsVec;
 
-        objective = 0.5*objGrad.squaredNorm();
+        objective = 0.5 * objGrad.squaredNorm();
         coeffVec -= jacMat.transpose().colPivHouseholderQr().solve(objGrad);
     }
 
-    CHECK(objective<1e-3);
-
+    CHECK(objective < 1e-3);
 }
-
 
 TEST_CASE("Testing CompactMonotoneComponent CoeffGrad and LogDeterminantCoeffGrad", "[CompactMonotoneComponent_CoeffGrad]")
 {
-    //const double testTol = 1e-4;
+    // const double testTol = 1e-4;
     unsigned int dim = 2;
 
     // Create points evently spaced on [lb,ub]
     unsigned int numPts = 20;
-    //double lb = -0.5;
-    //double ub = 0.5;
+    // double lb = -0.5;
+    // double ub = 0.5;
 
-    Kokkos::View<double**, HostSpace> evalPts("Evaluate Points", dim, numPts);
-    for(unsigned int i=0; i<numPts; ++i){
-        evalPts(0,i) = i / double(numPts + 2);
-        evalPts(1,i) = i / double(numPts);
+    Kokkos::View<double **, HostSpace> evalPts("Evaluate Points", dim, numPts);
+    for (unsigned int i = 0; i < numPts; ++i)
+    {
+        evalPts(0, i) = i / double(numPts + 2);
+        evalPts(1, i) = i / double(numPts);
     }
 
     unsigned int maxDegree = 3;
     MultiIndexSet mset = MultiIndexSet::CreateTotalOrder(dim, maxDegree);
-    MultivariateExpansionWorker<BasisEvaluator<BasisHomogeneity::Homogeneous,ShiftedLegendre>,HostSpace> expansion(mset);
+    MultivariateExpansionWorker<BasisEvaluator<BasisHomogeneity::Homogeneous, ShiftedLegendre>, HostSpace> expansion(mset);
 
     unsigned int maxSub = 20;
     double relTol = 1e-7;
@@ -442,66 +465,75 @@ TEST_CASE("Testing CompactMonotoneComponent CoeffGrad and LogDeterminantCoeffGra
 
     MonotoneComponent<decltype(expansion), SoftPlus, AdaptiveSimpson<HostSpace>, HostSpace, true> comp(expansion, quad);
 
-    Kokkos::View<double*, HostSpace> coeffs("Expansion coefficients", mset.Size());
-    for(unsigned int i=0; i<coeffs.extent(0); ++i)
-        coeffs(i) = 1. + 0.1*std::cos( 2*i + 0.5);
+    Kokkos::View<double *, HostSpace> coeffs("Expansion coefficients", mset.Size());
+    for (unsigned int i = 0; i < coeffs.extent(0); ++i)
+        coeffs(i) = 1. + 0.1 * std::cos(2 * i + 0.5);
 
     comp.SetCoeffs(coeffs);
 
-    SECTION("CoeffGrad") {
-        Kokkos::View<double**, HostSpace> sens ("sensitivities", 1, numPts);
+    SECTION("CoeffGrad")
+    {
+        Kokkos::View<double **, HostSpace> sens("sensitivities", 1, numPts);
         Kokkos::deep_copy(sens, 1.);
-        Kokkos::View<double**, HostSpace> evals = comp.Evaluate(evalPts);
-        Kokkos::View<double**, HostSpace> evals2;
-        Kokkos::View<double**, HostSpace> grads = comp.CoeffGrad(evalPts, sens);
-        REQUIRE(grads.extent(0)==comp.numCoeffs);
-        REQUIRE(grads.extent(1)==numPts);
+        Kokkos::View<double **, HostSpace> evals = comp.Evaluate(evalPts);
+        Kokkos::View<double **, HostSpace> evals2;
+        Kokkos::View<double **, HostSpace> grads = comp.CoeffGrad(evalPts, sens);
+        REQUIRE(grads.extent(0) == comp.numCoeffs);
+        REQUIRE(grads.extent(1) == numPts);
 
         // Compare with finite difference derivatives
         const double fdstep = 1e-5;
 
-        for(unsigned int i=0; i<coeffs.extent(0); ++i){
+        for (unsigned int i = 0; i < coeffs.extent(0); ++i)
+        {
             coeffs(i) += fdstep;
 
             comp.SetCoeffs(coeffs);
             evals2 = comp.Evaluate(evalPts);
-            for(unsigned int ptInd=0; ptInd<numPts; ++ptInd) {
-                double fd_grad = (evals2(0,ptInd)-evals(0,ptInd))/fdstep;
-                if(i == 0 || (ptInd == 0 && !mset[i].HasNonzeroEnd())) {
-                    CHECK_THAT( grads(i,ptInd), WithinAbs(0., 1e-10));
+            for (unsigned int ptInd = 0; ptInd < numPts; ++ptInd)
+            {
+                double fd_grad = (evals2(0, ptInd) - evals(0, ptInd)) / fdstep;
+                if (i == 0 || (ptInd == 0 && !mset[i].HasNonzeroEnd()))
+                {
+                    CHECK_THAT(grads(i, ptInd), WithinAbs(0., 1e-10));
                 }
-                else CHECK_THAT( grads(i,ptInd), WithinRel(fd_grad, 1e-3) || WithinAbs(fd_grad, 1e-5));
+                else
+                    CHECK_THAT(grads(i, ptInd), WithinRel(fd_grad, 1e-3) || WithinAbs(fd_grad, 1e-5));
             }
 
             coeffs(i) -= fdstep;
         }
     }
 
-    SECTION("LogDeterminantCoeffGrad"){
+    SECTION("LogDeterminantCoeffGrad")
+    {
 
-        Kokkos::View<double*, HostSpace> logDets = comp.LogDeterminant(evalPts);
-        Kokkos::View<double*, HostSpace> logDets2;
-        Kokkos::View<double**, HostSpace> grads = comp.LogDeterminantCoeffGrad(evalPts);
-        REQUIRE(grads.extent(0)==comp.numCoeffs);
-        REQUIRE(grads.extent(1)==numPts);
+        Kokkos::View<double *, HostSpace> logDets = comp.LogDeterminant(evalPts);
+        Kokkos::View<double *, HostSpace> logDets2;
+        Kokkos::View<double **, HostSpace> grads = comp.LogDeterminantCoeffGrad(evalPts);
+        REQUIRE(grads.extent(0) == comp.numCoeffs);
+        REQUIRE(grads.extent(1) == numPts);
 
         // Compare with finite difference derivatives
         const double fdstep = 1e-5;
 
-        for(unsigned int i=0; i<coeffs.extent(0); ++i){
+        for (unsigned int i = 0; i < coeffs.extent(0); ++i)
+        {
             coeffs(i) += fdstep;
 
             comp.SetCoeffs(coeffs);
             logDets2 = comp.LogDeterminant(evalPts);
-            for(unsigned int ptInd=0; ptInd<numPts; ++ptInd) {
-                if(i == 0 || (ptInd == 0 && !mset[i].HasNonzeroEnd())) {
-                    CHECK_THAT( grads(i,ptInd), WithinAbs(0., 1e-10));
+            for (unsigned int ptInd = 0; ptInd < numPts; ++ptInd)
+            {
+                if (i == 0 || (ptInd == 0 && !mset[i].HasNonzeroEnd()))
+                {
+                    CHECK_THAT(grads(i, ptInd), WithinAbs(0., 1e-10));
                 }
-                else CHECK_THAT( grads(i,ptInd), WithinRel((logDets2(ptInd)-logDets(ptInd))/fdstep, 1e-3));
+                else
+                    CHECK_THAT(grads(i, ptInd), WithinRel((logDets2(ptInd) - logDets(ptInd)) / fdstep, 1e-3));
             }
 
             coeffs(i) -= fdstep;
         }
-
     }
 }

--- a/tests/Test_MonotoneComponent_compact.cpp
+++ b/tests/Test_MonotoneComponent_compact.cpp
@@ -212,8 +212,8 @@ TEST_CASE( "Testing compact monotone component derivative", "[CompactMonotoneCom
 
     // Create points evently spaced on [lb,ub]
     unsigned int numPts = 20;
-    double lb = 1e-3;
-    double ub = 1.- 1e-3;
+    double lb = 0.;
+    double ub = 1.- fdStep;
 
     Kokkos::View<double**, HostSpace> evalPts("Evaluate Points", dim, numPts);
     for(unsigned int i=0; i<numPts; ++i){
@@ -260,542 +260,234 @@ TEST_CASE( "Testing compact monotone component derivative", "[CompactMonotoneCom
         double fdDeriv = (rightEvals(i)-evals(i))/fdStep;
         CHECK_THAT( contDerivs(i), WithinRel(fdDeriv, testTol) );
     }
+
+    SECTION("Coefficient Jacobian"){
+
+        Kokkos::View<double*, HostSpace> evals2("FD Evals", numPts);
+        Kokkos::View<double**, HostSpace> jac("Jacobian", numTerms, numPts);
+
+        comp.CoeffJacobian(evalPts, coeffs, evals2, jac);
+
+        for(unsigned int i=0; i<numPts; ++i)
+            CHECK_THAT(evals2(i), WithinAbs(evals(i), 1e-12));
+
+        const double fdStep = 1e-4;
+
+        for(unsigned j=0; j<numTerms; ++j){
+            coeffs(j) += fdStep;
+            comp.EvaluateImpl(evalPts, coeffs, evals2);
+
+            for(unsigned int i=0; i<numPts; ++i)
+                CHECK_THAT(jac(j,i), WithinRel((evals2(i)-evals(i))/fdStep, 1e-4));
+
+            coeffs(j) -= fdStep;
+        }
+    }
+
+    SECTION("Mixed Continuous Jacobian"){
+
+        const double fdStep = 1e-5;
+
+        Kokkos::View<double*, HostSpace> derivs("Derivatives", numPts);
+        Kokkos::View<double*, HostSpace> derivs2("Derivatives2", numPts);
+
+        Kokkos::View<double**, HostSpace> jac("Jacobian", numTerms,numPts);
+
+        comp.ContinuousMixedJacobian(evalPts, coeffs, jac);
+        derivs = comp.ContinuousDerivative(evalPts, coeffs);
+
+        // Perturb the coefficients and recompute
+        Kokkos::View<double*, HostSpace> coeffs2("Coefficients2", numTerms);
+        Kokkos::deep_copy(coeffs2, coeffs);
+
+        for(unsigned int j=0; j<coeffs.extent(0); ++j){
+            coeffs2(j) += fdStep;
+            derivs2 = comp.ContinuousDerivative(evalPts, coeffs2);
+
+            for(unsigned int i=0; i<derivs2.extent(0); ++i){
+                CHECK_THAT(jac(j,i), WithinRel((derivs2(i) - derivs(i))/fdStep, 25*fdStep));
+            }
+
+            coeffs2(j) = coeffs(j);
+        }
+
+    }
+
+    SECTION("Input Jacobian"){
+
+        const double fdStep = 1e-4;
+
+        Kokkos::View<double*, HostSpace> evals("Evaluations", numPts);
+        Kokkos::View<double*, HostSpace> evals2("Evaluations 2", numPts);
+
+        Kokkos::View<double**, HostSpace> jac("Jacobian", dim, numPts);
+
+        comp.InputJacobian(evalPts, coeffs, evals, jac);
+
+        Kokkos::View<double**, HostSpace> evalPts2("Points2", evalPts.extent(0), evalPts.extent(1));
+        Kokkos::deep_copy(evalPts2, evalPts);
+
+        for(unsigned int j=0; j<dim; ++j){
+            for(unsigned int ptInd=0; ptInd<numPts; ++ptInd)
+                evalPts2(j,ptInd) += fdStep;
+
+            comp.EvaluateImpl(evalPts2, coeffs, evals2);
+
+            for(unsigned int ptInd=0; ptInd<numPts; ++ptInd) {
+                CHECK_THAT(jac(j,ptInd), WithinRel((evals2(ptInd) - evals(ptInd))/fdStep, 20*fdStep));
+            }
+
+            for(unsigned int ptInd=0; ptInd<numPts; ++ptInd)
+                evalPts2(j,ptInd) = evalPts(j,ptInd);
+        }
+
+    }
+
+    SECTION("DiscreteDerivative") {
+            REQUIRE_THROWS_AS(comp.DiscreteDerivative(evalPts, coeffs), std::invalid_argument);
+    }
+    SECTION("GradientImpl") {
+
+            Kokkos::View<double**, HostSpace> evals("Evaluations", 1, numPts);
+
+            Kokkos::View<double**, HostSpace> sens("Jacobian", dim+1, numPts);
+            REQUIRE_THROWS_AS(comp.GradientImpl(evalPts, sens, evals), std::invalid_argument);
+
+    }
 }
-//     SECTION("Coefficient Jacobian"){
 
-//         Kokkos::View<double*, HostSpace> evals2("FD Evals", numPts);
-//         Kokkos::View<double**, HostSpace> jac("Jacobian", numTerms, numPts);
 
-//         comp.CoeffJacobian(evalPts, coeffs, evals2, jac);
+TEST_CASE( "Compact least squares test", "[CompactMonotoneComponentRegression]" ) {
 
-//         for(unsigned int i=0; i<numPts; ++i)
-//             CHECK(evals2(i) == Approx(evals(i)).epsilon(1e-12));
+    unsigned int numPts = 100;
+    Kokkos::View<double**,HostSpace> pts("Training Points", 1,numPts);
+    for(unsigned int i=0; i<numPts; ++i)
+        pts(0,i) = i/(numPts-1.0);
 
-//         const double fdStep = 1e-4;
 
-//         for(unsigned j=0; j<numTerms; ++j){
-//             coeffs(j) += fdStep;
-//             comp.EvaluateImpl(evalPts, coeffs, evals2);
+    Kokkos::View<double*,HostSpace> fvals("Training Values", numPts);
+    for(unsigned int i=0; i<numPts; ++i)
+        fvals(i) = (pts(0,i)*pts(0,i) + pts(0,i))/2; // Bijection on [0,1]
 
-//             for(unsigned int i=0; i<numPts; ++i)
-//                 CHECK(jac(j,i) == Approx((evals2(i)-evals(i))/fdStep).epsilon(5e-4).margin(1e-4));
 
-//             coeffs(j) -= fdStep;
-//         }
-//     }
+    // Don't need limiter for compact in one dimension
+    MultiIndexSet mset = MultiIndexSet::CreateTotalOrder(1, 6);
+    MultivariateExpansionWorker<BasisEvaluator<BasisHomogeneity::Homogeneous,ProbabilistHermite>,HostSpace> expansion(mset);
 
+    unsigned int maxSub = 30;
+    double relTol = 1e-3;
+    double absTol = 1e-3;
+    AdaptiveSimpson quad(maxSub, 1, nullptr, absTol, relTol, QuadError::First);
 
-//      SECTION("Mixed Discrete Jacobian"){
+    MonotoneComponent<decltype(expansion), SoftPlus, AdaptiveSimpson<HostSpace>, HostSpace, true> comp(expansion, quad);
 
-//         const double fdStep = 1e-4;
+    unsigned int numTerms = mset.Size();
+    Kokkos::View<double*,HostSpace> coeffs("Coefficients", numTerms);
+    Kokkos::View<double**,HostSpace> jac("Gradient", numTerms,numPts);
+    Kokkos::View<double*,HostSpace> preds("Predictions", numPts);
 
-//         Kokkos::View<double*, HostSpace> derivs("Derivatives", numPts);
-//         Kokkos::View<double*, HostSpace> derivs2("Derivatives2", numPts);
 
-//         Kokkos::View<double**, HostSpace> jac("Jacobian", numTerms,numPts);
+    double objective;
 
-//         comp.DiscreteMixedJacobian(evalPts, coeffs, jac);
-//         derivs = comp.DiscreteDerivative(evalPts, coeffs);
+    Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic,Eigen::Dynamic, Eigen::RowMajor>> jacMat(&jac(0,0), numTerms,numPts);
 
-//         // Perturb the coefficients and recompute
-//         Kokkos::View<double*, HostSpace> coeffs2("Coefficients2", numTerms);
-//         Kokkos::deep_copy(coeffs2, coeffs);
+    Eigen::Map<Eigen::VectorXd> predVec(&preds(0), numPts);
+    Eigen::Map<Eigen::VectorXd> obsVec(&fvals(0), numPts);
+    Eigen::Map<Eigen::VectorXd> coeffVec(&coeffs(0), numTerms);
 
-//         for(unsigned int j=0; j<coeffs.extent(0); ++j){
-//             coeffs2(j) += fdStep;
-//             derivs2 = comp.DiscreteDerivative(evalPts, coeffs2);
+    Eigen::VectorXd objGrad;
 
-//             for(unsigned int i=0; i<derivs2.extent(0); ++i){
-//                 CHECK(jac(j,i)==Approx((derivs2(i) - derivs(i))/fdStep).epsilon(1e-4).margin(1e-3));
-//             }
+    for(unsigned int optIt=0; optIt<5; ++optIt){
 
-//             coeffs2(j) = coeffs(j);
-//         }
+        comp.CoeffJacobian(pts, coeffs, preds, jac);
 
-//     }
+        objGrad = predVec-obsVec;
 
-//     SECTION("Mixed Continuous Jacobian"){
+        objective = 0.5*objGrad.squaredNorm();
+        coeffVec -= jacMat.transpose().colPivHouseholderQr().solve(objGrad);
+    }
 
-//         const double fdStep = 1e-4;
+    CHECK(objective<1e-3);
 
-//         Kokkos::View<double*, HostSpace> derivs("Derivatives", numPts);
-//         Kokkos::View<double*, HostSpace> derivs2("Derivatives2", numPts);
+}
 
-//         Kokkos::View<double**, HostSpace> jac("Jacobian", numTerms,numPts);
 
-//         comp.ContinuousMixedJacobian(evalPts, coeffs, jac);
-//         derivs = comp.ContinuousDerivative(evalPts, coeffs);
+TEST_CASE("Testing CompactMonotoneComponent CoeffGrad and LogDeterminantCoeffGrad", "[CompactMonotoneComponent_CoeffGrad]")
+{
+    //const double testTol = 1e-4;
+    unsigned int dim = 2;
 
-//         // Perturb the coefficients and recompute
-//         Kokkos::View<double*, HostSpace> coeffs2("Coefficients2", numTerms);
-//         Kokkos::deep_copy(coeffs2, coeffs);
+    // Create points evently spaced on [lb,ub]
+    unsigned int numPts = 20;
+    //double lb = -0.5;
+    //double ub = 0.5;
 
-//         for(unsigned int j=0; j<coeffs.extent(0); ++j){
-//             coeffs2(j) += fdStep;
-//             derivs2 = comp.ContinuousDerivative(evalPts, coeffs2);
+    Kokkos::View<double**, HostSpace> evalPts("Evaluate Points", dim, numPts);
+    for(unsigned int i=0; i<numPts; ++i){
+        evalPts(0,i) = 0.3;
+        evalPts(1,i) = 0.5;
+    }
 
-//             for(unsigned int i=0; i<derivs2.extent(0); ++i){
-//                 CHECK(jac(j,i)==Approx((derivs2(i) - derivs(i))/fdStep).epsilon(1e-4).margin(1e-3));
-//             }
+    unsigned int maxDegree = 3;
+    MultiIndexSet mset = MultiIndexSet::CreateTotalOrder(dim, maxDegree, [](MultiIndex m){return m.HasNonzeroEnd() || m.Max() == 0;});
+    MultivariateExpansionWorker<BasisEvaluator<BasisHomogeneity::Homogeneous,ProbabilistHermite>,HostSpace> expansion(mset);
 
-//             coeffs2(j) = coeffs(j);
-//         }
+    unsigned int maxSub = 20;
+    double relTol = 1e-7;
+    double absTol = 1e-7;
+    AdaptiveSimpson quad(maxSub, 1, nullptr, absTol, relTol, QuadError::First);
 
-//     }
+    MonotoneComponent<decltype(expansion), Exp, AdaptiveSimpson<HostSpace>, HostSpace, true> comp(expansion, quad);
 
-//     SECTION("Input Jacobian"){
+    Kokkos::View<double*, HostSpace> coeffs("Expansion coefficients", mset.Size());
+    for(unsigned int i=0; i<coeffs.extent(0); ++i)
+        coeffs(i) = 0.1*std::cos( 0.01*i );
 
-//         const double fdStep = 1e-4;
+    comp.SetCoeffs(coeffs);
 
-//         Kokkos::View<double*, HostSpace> evals("Evaluations", numPts);
-//         Kokkos::View<double*, HostSpace> evals2("Evaluations 2", numPts);
+    SECTION("CoeffGrad"){
 
-//         Kokkos::View<double**, HostSpace> jac("Jacobian", dim, numPts);
+        Kokkos::View<double**, HostSpace> sens("Sensitivity", 1, numPts);
+        for(unsigned int i=0; i<numPts; ++i)
+            sens(0,i) = 0.25*(i+1);
 
-//         comp.InputJacobian(evalPts, coeffs, evals, jac);
+        Kokkos::View<double**, HostSpace> grads = comp.CoeffGrad(evalPts, sens);
+        REQUIRE(grads.extent(0)==comp.numCoeffs);
+        REQUIRE(grads.extent(1)==numPts);
 
-//         Kokkos::View<double**, HostSpace> evalPts2("Points2", evalPts.extent(0), evalPts.extent(1));
-//         Kokkos::deep_copy(evalPts2, evalPts);
-
-//         for(unsigned int j=0; j<dim; ++j){
-//             for(unsigned int ptInd=0; ptInd<numPts; ++ptInd)
-//                 evalPts2(j,ptInd) += fdStep;
-
-//             comp.EvaluateImpl(evalPts2, coeffs, evals2);
-
-//             for(unsigned int ptInd=0; ptInd<numPts; ++ptInd)
-//                 CHECK(jac(j,ptInd)==Approx((evals2(ptInd) - evals(ptInd))/fdStep).epsilon(1e-4).margin(1e-3));
-
-//             for(unsigned int ptInd=0; ptInd<numPts; ++ptInd)
-//                 evalPts2(j,ptInd) = evalPts(j,ptInd);
-//         }
-
-//     }
-
-//     SECTION("GradientImpl") {
-
-//             Kokkos::View<double**, HostSpace> evals("Evaluations", 1, numPts);
-
-//             Kokkos::View<double**, HostSpace> sens("Jacobian", dim+1, numPts);
-//             REQUIRE_THROWS_AS(comp.GradientImpl(evalPts, sens, evals), std::invalid_argument);
-
-//     }
-// }
-
-
-// TEST_CASE( "Least squares test", "[MonotoneComponentRegression]" ) {
-
-//     unsigned int numPts = 100;
-//     Kokkos::View<double**,HostSpace> pts("Training Points", 1,numPts);
-//     for(unsigned int i=0; i<numPts; ++i)
-//         pts(0,i) = i/(numPts-1.0);
-
-
-//     Kokkos::View<double*,HostSpace> fvals("Training Vales", numPts);
-//     for(unsigned int i=0; i<numPts; ++i)
-//         fvals(i) = pts(0,i)*pts(0,i) + pts(0,i);
-
-
-//     MultiIndexSet mset = MultiIndexSet::CreateTotalOrder(1, 6);
-//     MultivariateExpansionWorker<BasisEvaluator<BasisHomogeneity::Homogeneous,ProbabilistHermite>,HostSpace> expansion(mset);
-
-//     unsigned int maxSub = 30;
-//     double relTol = 1e-3;
-//     double absTol = 1e-3;
-//     AdaptiveSimpson quad(maxSub, 1, nullptr, absTol, relTol, QuadError::First);
-
-//     MonotoneComponent<decltype(expansion), SoftPlus, AdaptiveSimpson<HostSpace>, HostSpace> comp(expansion, quad);
-
-//     unsigned int numTerms = mset.Size();
-//     Kokkos::View<double*,HostSpace> coeffs("Coefficients", numTerms);
-//     Kokkos::View<double**,HostSpace> jac("Gradient", numTerms,numPts);
-//     Kokkos::View<double*,HostSpace> preds("Predictions", numPts);
-
-
-//     double objective;
-
-//     Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic,Eigen::Dynamic, Eigen::RowMajor>> jacMat(&jac(0,0), numTerms,numPts);
-
-//     Eigen::Map<Eigen::VectorXd> predVec(&preds(0), numPts);
-//     Eigen::Map<Eigen::VectorXd> obsVec(&fvals(0), numPts);
-//     Eigen::Map<Eigen::VectorXd> coeffVec(&coeffs(0), numTerms);
-
-//     Eigen::VectorXd objGrad;
-
-//     for(unsigned int optIt=0; optIt<5; ++optIt){
-
-//         comp.CoeffJacobian(pts, coeffs, preds, jac);
-
-//         objGrad = predVec-obsVec;
-
-//         objective = 0.5*objGrad.squaredNorm();
-//         coeffVec -= jacMat.transpose().colPivHouseholderQr().solve(objGrad);
-//     }
-
-//     CHECK(objective<1e-3);
-
-// }
-
-
-// TEST_CASE("Testing MonotoneComponent CoeffGrad and LogDeterminantCoeffGrad", "[MonotoneComponent_CoeffGrad]")
-// {
-//     //const double testTol = 1e-4;
-//     unsigned int dim = 2;
-
-//     // Create points evently spaced on [lb,ub]
-//     unsigned int numPts = 20;
-//     //double lb = -0.5;
-//     //double ub = 0.5;
-
-//     Kokkos::View<double**, HostSpace> evalPts("Evaluate Points", dim, numPts);
-//     for(unsigned int i=0; i<numPts; ++i){
-//         evalPts(0,i) = 0.3;
-//         evalPts(1,i) = 0.5;
-//     }
-
-//     unsigned int maxDegree = 3;
-//     MultiIndexSet mset = MultiIndexSet::CreateTotalOrder(dim, maxDegree);
-//     MultivariateExpansionWorker<BasisEvaluator<BasisHomogeneity::Homogeneous,ProbabilistHermite>,HostSpace> expansion(mset);
-
-//     unsigned int maxSub = 20;
-//     double relTol = 1e-7;
-//     double absTol = 1e-7;
-//     AdaptiveSimpson quad(maxSub, 1, nullptr, absTol, relTol, QuadError::First);
-
-//     MonotoneComponent<decltype(expansion), Exp, AdaptiveSimpson<HostSpace>, HostSpace> comp(expansion, quad);
-
-//     Kokkos::View<double*, HostSpace> coeffs("Expansion coefficients", mset.Size());
-//     for(unsigned int i=0; i<coeffs.extent(0); ++i)
-//         coeffs(i) = 0.1*std::cos( 0.01*i );
-
-//     comp.SetCoeffs(coeffs);
-
-//     SECTION("CoeffGrad"){
-
-//         Kokkos::View<double**, HostSpace> sens("Sensitivity", 1, numPts);
-//         for(unsigned int i=0; i<numPts; ++i)
-//             sens(0,i) = 0.25*(i+1);
-
-//         Kokkos::View<double**, HostSpace> grads = comp.CoeffGrad(evalPts, sens);
-//         REQUIRE(grads.extent(0)==comp.numCoeffs);
-//         REQUIRE(grads.extent(1)==numPts);
-
-//         for(unsigned int j=1; j<numPts; ++j){
-//             for(unsigned int i=0; i<comp.numCoeffs; ++i){
-//                 CHECK(grads(i,j) == (j+1.0)*grads(i,0));
-//             }
-//         }
-//     }
-
-//     SECTION("LogDeterminantCoeffGrad"){
-
-//         for(unsigned int i=0; i<numPts; ++i){
-//             evalPts(0,i) = 0.03*i;
-//             evalPts(1,i) = -0.05*i;
-//         }
-
-//         Kokkos::View<double*, HostSpace> logDets = comp.LogDeterminant(evalPts);
-//         Kokkos::View<double*, HostSpace> logDets2;
-//         Kokkos::View<double**, HostSpace> grads = comp.LogDeterminantCoeffGrad(evalPts);
-//         REQUIRE(grads.extent(0)==comp.numCoeffs);
-//         REQUIRE(grads.extent(1)==numPts);
-
-//         // Compare with finite difference derivatives
-//         const double fdstep = 1e-4;
-
-//         for(unsigned int i=0; i<coeffs.extent(0); ++i){
-//             coeffs(i) += fdstep;
-
-//             comp.SetCoeffs(coeffs);
-//             logDets2 = comp.LogDeterminant(evalPts);
-//             for(unsigned int ptInd=0; ptInd<numPts; ++ptInd)
-//                 CHECK( grads(i,ptInd) == Approx((logDets2(ptInd)-logDets(ptInd))/fdstep).epsilon(1e-5));
-
-//             coeffs(i) -= fdstep;
-//         }
-
-//     }
-
-//     SECTION("DiagonalCoeffIndices") {
-//         std::vector<unsigned int> indices = comp.DiagonalCoeffIndices();
-//         std::vector<unsigned int> indices_ref = expansion.NonzeroDiagonalEntries();
-//         bool same_indices = indices == indices_ref;
-//         REQUIRE(same_indices);
-//     }
-// }
-
-// #if defined(KOKKOS_ENABLE_CUDA ) || defined(KOKKOS_ENABLE_SYCL)
-
-// TEST_CASE( "MonotoneIntegrand1d on device", "[MonotoneIntegrandDevice]") {
-
-//     typedef Kokkos::DefaultExecutionSpace::memory_space DeviceSpace;
-
-//     const double testTol = 1e-7;
-
-//     unsigned int dim = 1;
-//     unsigned int maxDegree = 1;
-//     FixedMultiIndexSet<HostSpace> hset(dim, maxDegree);
-//     FixedMultiIndexSet<DeviceSpace> mset = hset.ToDevice<DeviceSpace>(); // Create a total order limited fixed multindex set
-
-//     MultivariateExpansionWorker<BasisEvaluator<BasisHomogeneity::Homogeneous,ProbabilistHermite>,DeviceSpace> expansion(mset);
-
-//     MultivariateExpansionWorker<BasisEvaluator<BasisHomogeneity::Homogeneous,ProbabilistHermite>,HostSpace> hexpansion(hset);
-
-//     // Make room for the cache
-//     unsigned int cacheSize = hexpansion.CacheSize();
-//     Kokkos::View<double*, DeviceSpace> dcache("device cache", cacheSize);
-
-//     Kokkos::View<double*, HostSpace> hcoeffs("Expansion coefficients", mset.Size());
-//     hcoeffs(0) = 1.0; // Constant term
-//     hcoeffs(1) = 1.0; // Linear term
-
-//     Kokkos::View<double*, DeviceSpace> dcoeffs = ToDevice<DeviceSpace>(hcoeffs);
-
-//     Kokkos::View<double*, HostSpace> hpt("evaluation point", dim);
-//     hpt(0) = 1.0;
-
-//     Kokkos::View<double*, DeviceSpace> dpt = ToDevice<DeviceSpace>(hpt);
-
-//     SECTION("Integrand Only") {
-//         Kokkos::View<double*, DeviceSpace> dres("result", 1);
-
-//     	Kokkos::RangePolicy<typename MemoryToExecution<DeviceSpace>::Space> policy(0,1);
-//         Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const int i){
-//             MonotoneIntegrand<decltype(expansion), Exp, decltype(dpt), decltype(dcoeffs), DeviceSpace> integrand(dcache.data(), expansion, dpt, dcoeffs, DerivativeFlags::None, 0.0);
-//             integrand(0.5, &dres(0));
-//         });
-
-//         Kokkos::View<double*, HostSpace> hres = ToHost(dres);
-
-//         CHECK(hres(0) == Approx(exp(1)).epsilon(testTol));
-//     }
-
-//     SECTION("Integrand Derivative") {
-//         Kokkos::View<double*, DeviceSpace> dres("result", 2);
-
-//     	Kokkos::RangePolicy<typename MemoryToExecution<DeviceSpace>::Space> policy(0,1);
-//         Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const int i){
-//             MonotoneIntegrand<decltype(expansion), Exp, decltype(dpt), decltype(dcoeffs), DeviceSpace> integrand(dcache.data(), expansion, dpt, dcoeffs, DerivativeFlags::Diagonal, 0.0);
-//             integrand(0.5, dres.data());
-//         });
-
-//         Kokkos::View<double*, HostSpace> hres = ToHost(dres);
-
-//         CHECK(hres(0) == Approx(exp(1)).epsilon(testTol));
-//     }
-
-//     SECTION("Integrand Parameters Gradient") {
-
-//         Kokkos::View<double*, DeviceSpace> dres("result", hset.Size());
-//         Kokkos::View<double*, DeviceSpace> dres_fd("result_fd", hset.Size());
-//         Kokkos::View<double*, DeviceSpace> testVal("integrand", 1+hset.Size());
-
-//     	Kokkos::RangePolicy<typename MemoryToExecution<DeviceSpace>::Space> policy(0,1);
-//         Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const int i){
-
-//             MonotoneIntegrand<decltype(expansion), Exp, decltype(dpt), decltype(dcoeffs), DeviceSpace> integrand(dcache.data(), expansion, dpt, dcoeffs, DerivativeFlags::Parameters, 0.0);
-//             MonotoneIntegrand<decltype(expansion), Exp, decltype(dpt), decltype(dcoeffs), DeviceSpace> integrand2(dcache.data(), expansion, dpt, dcoeffs, DerivativeFlags::None, 0.0);
-
-//             integrand(0.5, testVal.data());
-
-//             const double fdStep = 1e-4;
-//             double testVal2;
-//             for(unsigned int termInd=0; termInd<dres.extent(0); ++termInd){
-//                 dcoeffs(termInd) += fdStep;
-//                 integrand2(0.5, &testVal2);
-//                 dres_fd(termInd) = (testVal2 - testVal(0))/fdStep;
-
-//                 dres(termInd) = testVal(1 + termInd);
-//                 dcoeffs(termInd) -= fdStep;
-//             }
-
-//         });
-
-//         Kokkos::View<double*, HostSpace> hres = ToHost(dres);
-//         Kokkos::View<double*, HostSpace> hres_fd = ToHost(dres_fd);
-
-//         for(unsigned int termInd=0; termInd<hres.extent(0); ++termInd)
-//             CHECK(hres(termInd) == Approx(hres_fd(termInd)).epsilon(1e-4));
-//     }
-
-
-//     SECTION("Integrand Mixed Gradient") {
-
-//         Kokkos::View<double*, DeviceSpace> dres("result", hset.Size());
-//         Kokkos::View<double*, DeviceSpace> dres_fd("result_fd", hset.Size());
-//         Kokkos::View<double*, DeviceSpace> testVal("integrand", 1+hset.Size());
-//         Kokkos::View<double*, DeviceSpace> workspace("workspace", hset.Size());
-	
-// 	Kokkos::RangePolicy<typename MemoryToExecution<DeviceSpace>::Space> policy(0,1);
-//         Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const int i){
-
-//             MonotoneIntegrand<decltype(expansion), Exp, decltype(dpt), decltype(dcoeffs), DeviceSpace> integrand(dcache.data(), expansion, dpt, dcoeffs, DerivativeFlags::MixedCoeff, 0.0, workspace);
-//             MonotoneIntegrand<decltype(expansion), Exp, decltype(dpt), decltype(dcoeffs), DeviceSpace> integrand2(dcache.data(), expansion, dpt, dcoeffs, DerivativeFlags::Diagonal, 0.0);
-
-//             integrand(0.5, testVal.data());
-
-//             const double fdStep = 1e-4;
-//             double testVal2[2];
-//             for(unsigned int termInd=0; termInd<dres.extent(0); ++termInd){
-//                 dcoeffs(termInd) += fdStep;
-//                 integrand2(0.5, testVal2);
-//                 dres_fd(termInd) = (testVal2[0] - testVal(0))/fdStep;
-//                 dres(termInd) = testVal(1 + termInd);
-//             }
-//         });
-
-//         Kokkos::View<double*, HostSpace> hres = ToHost(dres);
-//         Kokkos::View<double*, HostSpace> hres_fd = ToHost(dres_fd);
-
-//         for(unsigned int termInd=0; termInd<hres.extent(0); ++termInd)
-//             CHECK(hres(termInd) == Approx(hres_fd(termInd)).epsilon(1e-4));
-
-//     }
-// }
-
-
-
-// TEST_CASE( "Testing MonotoneComponent::EvaluateSingle on Device", "[MonotoneComponentSingle_Device]") {
-
-//     typedef Kokkos::DefaultExecutionSpace::memory_space DeviceSpace;
-
-//     unsigned int dim = 2;
-//     unsigned int maxDegree = 1;
-//     FixedMultiIndexSet<HostSpace> hset(dim,maxDegree);
-//     FixedMultiIndexSet<DeviceSpace> dset = hset.ToDevice<DeviceSpace>(); // Create a total order limited fixed multindex set
-
-//     MultivariateExpansionWorker<BasisEvaluator<BasisHomogeneity::Homogeneous,ProbabilistHermite>,DeviceSpace> dexpansion(dset);
-
-//     // define f(x1,x2) = c0 + c1*x1 + c2*x2
-//     Kokkos::View<double*,HostSpace> hcoeffs("Expansion coefficients", hset.Size());
-//     hcoeffs(0) = 1.0; // Constant term
-//     hcoeffs(1) = 1.0; // Linear term in x1
-//     hcoeffs(2) = 1.0; // Linear in x2
-
-//     Kokkos::View<double*,DeviceSpace> dcoeffs = ToDevice<DeviceSpace>(hcoeffs);
-
-//     unsigned int cacheSize = dexpansion.CacheSize();
-//     CHECK(cacheSize == (maxDegree+1)*(2*dim+1));
-
-//     // Allocate some memory for the cache
-//     Kokkos::View<double*, DeviceSpace> dcache("device cache", cacheSize);
-
-//     Kokkos::View<double*,HostSpace> hpt("host point", dim);
-//     hpt(0) = 0.5;
-//     hpt(1) = 0.5;
-//     Kokkos::View<double*,DeviceSpace> dpt = ToDevice<DeviceSpace>(hpt);
-
-//     unsigned int maxSub = 20;
-//     double relTol = 1e-5;
-//     double absTol = 1e-5;
-//     AdaptiveSimpson quad(maxSub, 1, nullptr, absTol, relTol, QuadError::First);
-
-//     Kokkos::View<double*,DeviceSpace> workspace("quadrature workspace", quad.WorkspaceSize());
-
-//     Kokkos::View<double*, DeviceSpace> dres("Device Evaluation", 1);
-//     // Run the fill cache funciton, using a parallel_for loop to ensure it's run on the device
-//     Kokkos::RangePolicy<typename MemoryToExecution<DeviceSpace>::Space> policy(0,1);
-//     Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const int i){
-//         dexpansion.FillCache1(dcache.data(), dpt, DerivativeFlags::None);
-//         dres(0) = MonotoneComponent<decltype(dexpansion),Exp, decltype(quad), DeviceSpace>::EvaluateSingle(dcache.data(), workspace.data(), dpt, dpt(dim-1), dcoeffs, quad, dexpansion);
-//     });
-
-//     Kokkos::fence();
-
-//     CHECK(ToHost(dres)(0) == Approx(hcoeffs(0) + hcoeffs(1)*hpt(0) + hpt(1)*exp(hcoeffs(2))).epsilon(1e-4));
-
-// }
-
-
-// TEST_CASE( "Testing 1d monotone component evaluation on device", "[MonotoneComponent1d_Device]" ) {
-
-//     typedef Kokkos::DefaultExecutionSpace::memory_space DeviceSpace;
-
-//     const double testTol = 1e-7;
-//     unsigned int dim = 1;
-
-//     // Create points evently space on [lb,ub]
-//     unsigned int numPts = 3;
-//     double lb = -2.0;
-//     double ub = 2.0;
-
-//     Kokkos::View<double**,DeviceSpace>::HostMirror hevalPts("Evaluation Points", dim, numPts);
-//     for(unsigned int i=0; i<numPts; ++i)
-//         hevalPts(0,i) = (i/double(numPts-1))*(ub-lb) - lb;
-
-//     Kokkos::View<double**,DeviceSpace> devalPts = ToDevice<DeviceSpace>(hevalPts);
-
-
-//     /* Create and evaluate an affine map
-//        - Set coefficients so that f(x) = 1.0 + x
-//        - f(0) + int_0^x exp( d f(t) ) dt =  1.0 + int_0^x exp(1) dt = 1 + |x| * exp(1)
-//     */
-//     SECTION("Affine Map"){
-//         unsigned int maxDegree = 1;
-//         FixedMultiIndexSet<HostSpace> hset(dim, maxDegree);
-//         FixedMultiIndexSet<DeviceSpace> mset = hset.ToDevice<DeviceSpace>();
-
-//         MultivariateExpansionWorker<BasisEvaluator<BasisHomogeneity::Homogeneous,ProbabilistHermite>,DeviceSpace> expansion(mset);
-
-//         Kokkos::View<double*,HostSpace> hcoeffs("Expansion coefficients", mset.Size());
-//         hcoeffs(0) = 1.0; // Constant term
-//         hcoeffs(1) = 1.0; // Linear term
-
-//         Kokkos::View<double*,DeviceSpace> dcoeffs = ToDevice<DeviceSpace>(hcoeffs);
-
-//         unsigned int maxSub = 10;
-//         double relTol = 1e-6;
-//         double absTol = 1e-6;
-//         AdaptiveSimpson<DeviceSpace> quad(maxSub, 1, nullptr, absTol, relTol, QuadError::First);
-
-//         MonotoneComponent<decltype(expansion),Exp, decltype(quad),DeviceSpace> comp(expansion, quad);
-
-//         Kokkos::View<double*,DeviceSpace> doutput("dout", numPts);
-//         comp.EvaluateImpl(devalPts, dcoeffs, doutput);
-//         auto houtput = ToHost(doutput);
-
-//         for(unsigned int i=0; i<numPts; ++i){
-//             CHECK(houtput(i) == Approx(1+exp(1)*std::abs(hevalPts(0,i))).epsilon(testTol));
-//         }
-//     }
-
-
-//     /* Create and evaluate a quadratic map
-//        - Set coefficients so that f(x) = 1.0 + x + 0.5*x^2
-//        - df/dt = 1.0 + t
-//        - f(0) + int_0^x exp( df/dt ) dt =  1.0 + int_0^x exp(1+t) dt = 1+exp(1+x)
-//     */
-//     SECTION("Quadratic Map"){
-//         unsigned int maxDegree = 2;
-
-//         FixedMultiIndexSet<HostSpace> hset(dim, maxDegree);
-//         FixedMultiIndexSet<DeviceSpace> mset = hset.ToDevice<DeviceSpace>();
-
-//         MultivariateExpansionWorker<BasisEvaluator<BasisHomogeneity::Homogeneous,ProbabilistHermite>,DeviceSpace> expansion(mset);
-
-//         Kokkos::View<double*,HostSpace> hcoeffs("Expansion coefficients", mset.Size());
-//         hcoeffs(1) = 1.0; // Linear term = x ^1
-//         hcoeffs(2) = 0.5; // Quadratic term = x^2 - 1.0
-//         hcoeffs(0) = 1.0 + hcoeffs(2); // Constant term = x^0
-
-//         Kokkos::View<double*,DeviceSpace> dcoeffs = ToDevice<DeviceSpace>(hcoeffs);
-
-//         unsigned int maxSub = 10;
-//         double relTol = 1e-6;
-//         double absTol = 1e-6;
-//         AdaptiveSimpson<DeviceSpace> quad(maxSub, 1, nullptr, absTol, relTol, QuadError::First);
-
-//         MonotoneComponent<decltype(expansion), Exp, decltype(quad), DeviceSpace> comp(expansion, quad);
-
-//         Kokkos::View<double*,DeviceSpace> doutput("dout",numPts);
-//         comp.EvaluateImpl(devalPts, dcoeffs, doutput);
-//         auto houtput = ToHost(doutput);
-
-//         for(unsigned int i=0; i<numPts; ++i){
-//             CHECK(houtput(i) == Approx(1+exp(1)*(exp(hevalPts(0,i))-1)).epsilon(testTol));
-//         }
-//     }
-
-// }
-
-// #endif
+        for(unsigned int j=1; j<numPts; ++j){
+            for(unsigned int i=0; i<comp.numCoeffs; ++i){
+                CHECK(grads(i,j) == (j+1.0)*grads(i,0));
+            }
+        }
+    }
+
+    SECTION("LogDeterminantCoeffGrad"){
+
+        for(unsigned int i=0; i<numPts; ++i){
+            evalPts(0,i) = 0.03*i;
+            evalPts(1,i) = -0.05*i;
+        }
+
+        Kokkos::View<double*, HostSpace> logDets = comp.LogDeterminant(evalPts);
+        Kokkos::View<double*, HostSpace> logDets2;
+        Kokkos::View<double**, HostSpace> grads = comp.LogDeterminantCoeffGrad(evalPts);
+        REQUIRE(grads.extent(0)==comp.numCoeffs);
+        REQUIRE(grads.extent(1)==numPts);
+
+        // Compare with finite difference derivatives
+        const double fdstep = 1e-5;
+
+        for(unsigned int i=0; i<coeffs.extent(0); ++i){
+            coeffs(i) += fdstep;
+
+            comp.SetCoeffs(coeffs);
+            logDets2 = comp.LogDeterminant(evalPts);
+            for(unsigned int ptInd=0; ptInd<numPts; ++ptInd)
+                CHECK_THAT( grads(i,ptInd), WithinRel((logDets2(ptInd)-logDets(ptInd))/fdstep, 1e-3));
+
+            coeffs(i) -= fdstep;
+        }
+
+    }
+}

--- a/tests/Test_OrthogonalPolynomials.cpp
+++ b/tests/Test_OrthogonalPolynomials.cpp
@@ -146,8 +146,6 @@ TEST_CASE( "Testing Probabilist Hermite polynomials", "[ProbabilistHermite]" ) {
 
 }
 
-
-
 TEST_CASE( "Testing Physicist Hermite normalization", "[PhysicistHermiteNorm]" ) {
 
     PhysicistHermite poly(false);
@@ -202,7 +200,6 @@ TEST_CASE( "Testing Physicist Hermite normalization", "[PhysicistHermiteNorm]" )
 
 }
 
-
 TEST_CASE( "Testing Physicist Hermite polynomials", "[PhysicistHermite]" ) {
 
     const double floatTol = 1e-15;
@@ -229,6 +226,116 @@ TEST_CASE( "Testing Physicist Hermite polynomials", "[PhysicistHermite]" ) {
     }
 }
 
+TEST_CASE( "Testing Shifted Legendre polynomials", "[ShiftedLegendre]" ) {
+
+    const double floatTol = 1e-14;
+
+    ShiftedLegendre poly;
+
+    std::vector<double> xs{0.0, 0.1, 0.5, 0.75, 1.0};
+    std::vector<double> allvals(5);
+    std::vector<double> allderivs(5);
+    std::vector<double> allderivs2(5);
+    auto shifted_legendre_eval = [](double x){return std::vector<double> {
+            1.0,
+            2.0*x-1.0,
+            6.0*x*x - 6.0*x + 1.0,
+            20.0*x*x*x - 30.0*x*x + 12.0*x - 1.0,
+            70.0*x*x*x*x - 140.0*x*x*x + 90.0*x*x - 20.0*x + 1.0
+        };
+    };
+    // Check the evaluation
+    for(auto& x : xs){
+        auto shifted_eval = shifted_legendre_eval(x);
+        CHECK( poly.Evaluate(0, x) ==        shifted_eval[0] ); 
+        CHECK( poly.Evaluate(1, x) == Approx(shifted_eval[1]).epsilon(floatTol) );
+        CHECK( poly.Evaluate(2, x) == Approx(shifted_eval[2]).epsilon(floatTol) );
+        CHECK( poly.Evaluate(3, x) == Approx(shifted_eval[3]).epsilon(floatTol) );
+        CHECK( poly.Evaluate(4, x) == Approx(shifted_eval[4]).epsilon(floatTol) );
+
+        poly.EvaluateAll(&allvals[0], 4, x);
+        CHECK( allvals[0] ==        shifted_eval[0]);
+        CHECK( allvals[1] == Approx(shifted_eval[1]).epsilon(floatTol) );
+        CHECK( allvals[2] == Approx(shifted_eval[2]).epsilon(floatTol) );
+        CHECK( allvals[3] == Approx(shifted_eval[3]).epsilon(floatTol) );
+        CHECK( allvals[4] == Approx(shifted_eval[4]).epsilon(floatTol) );
+    }
+    
+    auto shifted_legendre_deriv = [](double x){return std::vector<double> {
+            0.0,
+            2.0,
+            12.0*x - 6.0,
+            60.0*x*x - 60.0*x + 12.0,
+            280.0*x*x*x - 420.0*x*x + 180.0*x - 20.0
+        };
+    };
+    // Check the derivative
+    for(auto& x : xs){
+        auto shifted_deriv = shifted_legendre_deriv(x);
+        CHECK( poly.Derivative(0, x) ==        shifted_deriv[0] ); 
+        CHECK( poly.Derivative(1, x) ==        shifted_deriv[1] );
+        CHECK( poly.Derivative(2, x) == Approx(shifted_deriv[2]).epsilon(floatTol) );
+        CHECK( poly.Derivative(3, x) == Approx(shifted_deriv[3]).epsilon(floatTol) );
+        CHECK( poly.Derivative(4, x) == Approx(shifted_deriv[4]).epsilon(floatTol) );
+
+        auto shifted_eval = shifted_legendre_eval(x);
+        poly.EvaluateDerivatives(&allvals[0], &allderivs[0], 4, x);
+        CHECK( allvals[0] ==        shifted_eval[0] );
+        CHECK( allvals[1] == Approx(shifted_eval[1]).epsilon(floatTol) );
+        CHECK( allvals[2] == Approx(shifted_eval[2]).epsilon(floatTol) );
+        CHECK( allvals[3] == Approx(shifted_eval[3]).epsilon(floatTol) );
+        CHECK( allvals[4] == Approx(shifted_eval[4]).epsilon(floatTol) );
+        CHECK( allderivs[0] ==        shifted_deriv[0] ); 
+        CHECK( allderivs[1] ==        shifted_deriv[1] );
+        CHECK( allderivs[2] == Approx(shifted_deriv[2]).epsilon(floatTol) );
+        CHECK( allderivs[3] == Approx(shifted_deriv[3]).epsilon(floatTol) );
+        CHECK( allderivs[4] == Approx(shifted_deriv[4]).epsilon(floatTol) );
+
+        poly.EvaluateDerivatives(&allderivs[0], 4, x);
+        CHECK( allderivs[0] ==        shifted_deriv[0] ); 
+        CHECK( allderivs[1] ==        shifted_deriv[1] );
+        CHECK( allderivs[2] == Approx(shifted_deriv[2]).epsilon(floatTol) );
+        CHECK( allderivs[3] == Approx(shifted_deriv[3]).epsilon(floatTol) );
+        CHECK( allderivs[4] == Approx(shifted_deriv[4]).epsilon(floatTol) );
+    }
+    
+    auto shifted_legendre_deriv2 = [](double x){return std::vector<double> {
+            0.0,
+            0.0,
+            12.0,
+            120.0*x - 60.0,
+            840.0*x*x - 840.0*x + 180.0
+        };
+    };
+    // Check the second derivatives
+    for(auto& x : xs){
+        auto shifted_deriv2 = shifted_legendre_deriv2(x);
+        CHECK( poly.SecondDerivative(0, x) == shifted_deriv2[0] ); 
+        CHECK( poly.SecondDerivative(1, x) == shifted_deriv2[1] );
+        CHECK( poly.SecondDerivative(2, x) == Approx(shifted_deriv2[2]).epsilon(floatTol) );
+        CHECK( poly.SecondDerivative(3, x) == Approx(shifted_deriv2[3]).epsilon(floatTol) );
+        CHECK( poly.SecondDerivative(4, x) == Approx(shifted_deriv2[4]).epsilon(floatTol) );
+
+        auto shifted_eval = shifted_legendre_eval(x);
+        auto shifted_deriv = shifted_legendre_deriv(x);
+        poly.EvaluateSecondDerivatives(&allvals[0], &allderivs[0], &allderivs2[0], 4, x);
+        CHECK( allvals[0] == shifted_eval[0] );
+        CHECK( allvals[1] == Approx(shifted_eval[1]).epsilon(floatTol) );
+        CHECK( allvals[2] == Approx(shifted_eval[2]).epsilon(floatTol) );
+        CHECK( allvals[3] == Approx(shifted_eval[3]).epsilon(floatTol) );
+        CHECK( allvals[4] == Approx(shifted_eval[4]).epsilon(floatTol) );
+        CHECK( allderivs[0] == shifted_deriv[0]);
+        CHECK( allderivs[1] == shifted_deriv[1]);
+        CHECK( allderivs[2] == Approx(shifted_deriv[2]).epsilon(floatTol) );
+        CHECK( allderivs[3] == Approx(shifted_deriv[3]).epsilon(floatTol) );
+        CHECK( allderivs[4] == Approx(shifted_deriv[4]).epsilon(floatTol) );
+        CHECK( allderivs2[0] == shifted_deriv2[0]);
+        CHECK( allderivs2[1] == shifted_deriv2[1]);
+        CHECK( allderivs2[2] == Approx(shifted_deriv2[2]).epsilon(floatTol) );
+        CHECK( allderivs2[3] == Approx(shifted_deriv2[3]).epsilon(floatTol) );
+        CHECK( allderivs2[4] == Approx(shifted_deriv2[4]).epsilon(floatTol) );
+    }
+}
 
 #if defined(KOKKOS_ENABLE_CUDA ) || defined(KOKKOS_ENABLE_SYCL)
 

--- a/tests/Test_UnivariateBases.cpp
+++ b/tests/Test_UnivariateBases.cpp
@@ -1,0 +1,118 @@
+#include <catch2/catch_all.hpp>
+
+#include "MParT/UnivariateBases.h"
+using namespace mpart;
+
+using namespace Catch::Matchers;
+
+TEST_CASE( "Testing Sine basis", "[SineBasis]" ) {
+
+    const double floatTol = 1e-12;
+
+    SineBasis sine;
+
+    std::vector<double> xs{0.0, 0.1, 0.5, 0.75, 1.0};
+    std::vector<double> allvals(5);
+    std::vector<double> allderivs(5);
+    std::vector<double> allderivs2(5);
+    auto sine_evaluation = [](double x){return std::vector<double> {
+            1.0,
+            sin(2*M_PI*x),
+            sin(2*M_PI*2*x),
+            sin(2*M_PI*3*x),
+            sin(2*M_PI*4*x)
+        };
+    };
+    // Check the evaluation
+    for(auto& x : xs){
+        auto sine_eval = sine_evaluation(x);
+        // CHECK_THAT(inv(0, i), WithinAbs(points(0, i), 1e-10));
+        CHECK     ( sine.Evaluate(0, x) ==        sine_eval[0]             ); 
+        CHECK_THAT( sine.Evaluate(1, x), WithinAbs(sine_eval[1], floatTol) );
+        CHECK_THAT( sine.Evaluate(2, x), WithinAbs(sine_eval[2], floatTol) );
+        CHECK_THAT( sine.Evaluate(3, x), WithinAbs(sine_eval[3], floatTol) );
+        CHECK_THAT( sine.Evaluate(4, x), WithinAbs(sine_eval[4], floatTol) );
+
+        sine.EvaluateAll(&allvals[0], 4, x);
+        CHECK     ( allvals[0] ==        sine_eval[0]             );
+        CHECK_THAT( allvals[1], WithinAbs(sine_eval[1], floatTol) );
+        CHECK_THAT( allvals[2], WithinAbs(sine_eval[2], floatTol) );
+        CHECK_THAT( allvals[3], WithinAbs(sine_eval[3], floatTol) );
+        CHECK_THAT( allvals[4], WithinAbs(sine_eval[4], floatTol) );
+    }
+    
+    auto sine_derivative = [](double x){return std::vector<double> {
+            0.0,
+            1*2*M_PI*cos(1*2*M_PI*x),
+            2*2*M_PI*cos(2*2*M_PI*x),
+            3*2*M_PI*cos(3*2*M_PI*x),
+            4*2*M_PI*cos(4*2*M_PI*x)
+        };
+    };
+    // CHECK_THAT the derivative
+    for(auto& x : xs){
+        auto sine_deriv = sine_derivative(x);
+        CHECK     ( sine.Derivative(0, x) ==        sine_deriv[0] ); 
+        CHECK     ( sine.Derivative(1, x) ==        sine_deriv[1] );
+        CHECK_THAT( sine.Derivative(2, x), WithinAbs(sine_deriv[2], floatTol) );
+        CHECK_THAT( sine.Derivative(3, x), WithinAbs(sine_deriv[3], floatTol) );
+        CHECK_THAT( sine.Derivative(4, x), WithinAbs(sine_deriv[4], floatTol) );
+
+        auto sine_eval = sine_evaluation(x);
+        sine.EvaluateDerivatives(&allvals[0], &allderivs[0], 4, x);
+        CHECK     ( allvals[0] ==        sine_eval[0] );
+        CHECK_THAT( allvals[1], WithinAbs(sine_eval[1], floatTol) );
+        CHECK_THAT( allvals[2], WithinAbs(sine_eval[2], floatTol) );
+        CHECK_THAT( allvals[3], WithinAbs(sine_eval[3], floatTol) );
+        CHECK_THAT( allvals[4], WithinAbs(sine_eval[4], floatTol) );
+        CHECK     ( allderivs[0] ==        sine_deriv[0] ); 
+        CHECK     ( allderivs[1] ==        sine_deriv[1] );
+        CHECK_THAT( allderivs[2], WithinAbs(sine_deriv[2], floatTol) );
+        CHECK_THAT( allderivs[3], WithinAbs(sine_deriv[3], floatTol) );
+        CHECK_THAT( allderivs[4], WithinAbs(sine_deriv[4], floatTol) );
+
+        sine.EvaluateDerivatives(&allderivs[0], 4, x);
+        CHECK     ( allderivs[0] ==        sine_deriv[0] );
+        CHECK     ( allderivs[1] ==        sine_deriv[1] );
+        CHECK_THAT( allderivs[2], WithinAbs(sine_deriv[2], floatTol) );
+        CHECK_THAT( allderivs[3], WithinAbs(sine_deriv[3], floatTol) );
+        CHECK_THAT( allderivs[4], WithinAbs(sine_deriv[4], floatTol) );
+    }
+    
+    auto sine_derivative2 = [](double x){return std::vector<double> {
+            0.0,
+            -(1*2*M_PI)*(1*2*M_PI)*sin(1*2*M_PI*x),
+            -(2*2*M_PI)*(2*2*M_PI)*sin(2*2*M_PI*x),
+            -(3*2*M_PI)*(3*2*M_PI)*sin(3*2*M_PI*x),
+            -(4*2*M_PI)*(4*2*M_PI)*sin(4*2*M_PI*x)
+        };
+    };
+    // CHECK_THAT the second derivatives
+    for(auto& x : xs){
+        auto sine_deriv2 = sine_derivative2(x);
+        CHECK     ( sine.SecondDerivative(0, x) ==        sine_deriv2[0]             );
+        CHECK     ( sine.SecondDerivative(1, x) ==        sine_deriv2[1]             );
+        CHECK_THAT( sine.SecondDerivative(2, x), WithinAbs(sine_deriv2[2], floatTol) );
+        CHECK_THAT( sine.SecondDerivative(3, x), WithinAbs(sine_deriv2[3], floatTol) );
+        CHECK_THAT( sine.SecondDerivative(4, x), WithinAbs(sine_deriv2[4], floatTol) );
+
+        auto sine_eval = sine_evaluation(x);
+        auto sine_deriv = sine_derivative(x);
+        sine.EvaluateSecondDerivatives(&allvals[0], &allderivs[0], &allderivs2[0], 4, x);
+        CHECK     ( allvals[0] ==        sine_eval[0]             );
+        CHECK_THAT( allvals[1], WithinAbs(sine_eval[1], floatTol) );
+        CHECK_THAT( allvals[2], WithinAbs(sine_eval[2], floatTol) );
+        CHECK_THAT( allvals[3], WithinAbs(sine_eval[3], floatTol) );
+        CHECK_THAT( allvals[4], WithinAbs(sine_eval[4], floatTol) );
+        CHECK     ( allderivs[0] ==        sine_deriv[0]             );
+        CHECK     ( allderivs[1] ==        sine_deriv[1]             );
+        CHECK_THAT( allderivs[2], WithinAbs(sine_deriv[2], floatTol) );
+        CHECK_THAT( allderivs[3], WithinAbs(sine_deriv[3], floatTol) );
+        CHECK_THAT( allderivs[4], WithinAbs(sine_deriv[4], floatTol) );
+        CHECK     ( allderivs2[0] ==        sine_deriv2[0]             );
+        CHECK     ( allderivs2[1] ==        sine_deriv2[1]             );
+        CHECK_THAT( allderivs2[2], WithinAbs(sine_deriv2[2], floatTol) );
+        CHECK_THAT( allderivs2[3], WithinAbs(sine_deriv2[3], floatTol) );
+        CHECK_THAT( allderivs2[4], WithinAbs(sine_deriv2[4], floatTol) );
+    }
+}


### PR DESCRIPTION
Similar to how Sven's work parameterizes the map, and using my favorite compile-time tooling, this is a ludicrous addition to `MonotoneComponent` that changes the parameterization to
$$T(\mathbf{x},y) = \frac{\int\limits_0^y g(\partial_2 f(\mathbf{x},t))\ dt}{\int\limits_0^1 g(\partial_2 f(\mathbf{x},t))\ dt},$$
where $g$ is a rectifier, $f$ is a MultivariateExpansionWorker. Points of note:
- Since this is virtually the same machinery as `MonotoneComponent`, I just added it as a compile-time feature there. I will (somewhat baselessly?) assert that there's no runtime overhead for "traditional" `MonotoneComponent` objects (at least, compiled with `RELEASE` flags).
- As a matter of logistics: note that this doesn't have the $f(\mathbf{x},0)$ in the "traditional" map, since that could escape the hypercube. I wracked my brain trying to allow for this flexibility, but couldn't figure it out.
- For some reason, I see that mixed coefficient jacobians are zero for multi-indices of the form $(k,0)$ _and_ $(k,1)$. I understand the former, but not sure why on the latter? I guess since there's a second derivative, the chain rule ends up eliminating a term, but I'm not sure.
- Since this is compile time, I added the ability to use the usual (non-linearized) bases with the "compactified" basis. I have no idea if this is useful or if I just added a bunch of compile-time cruft; I'm flexible if this should be removed.
- The major overhead added here is the fact that the integral needs to be evaluated twice, and now some derivatives need to get quotient-ruled. I suspect the overhead will be most visible in, e.g., `LogDeterminantCoeffGrad`, which will become
$$\nabla_w\log \partial_y T(x,y;w) = \frac{\nabla_w g(\partial_2 f(\mathbf{x},y,\mathbf{w}))}{g(\partial_2 f(\mathbf{x},y,\mathbf{w})} - \frac{\nabla_w \int_0^1 g(\partial_2 f(\mathbf{x},t,\mathbf{w})\ dt}{\int_0^1 g(\partial_2 f(\mathbf{x},t,\mathbf{w})\ dt}$$
note that this now has integrals, where it previously did not.
- By construction, $T:\ [0,1]^d\times[0,1]\to[0,1]$. As such, I also added a few new bases for the future.
- The only one available via `CreateComponent` at this point is [`ShiftedLegendre`](https://en.wikipedia.org/wiki/Legendre_polynomials#Shifted_Legendre_polynomials) (which corresponds to `BasisTypes::Legendre`), which is orthogonal on $U[0,1]$ (note that this is shifted and thus gives a slightly different TTRR than the traditional Legendre).
- I also added `SineBasis` for the time being, which represents $p_k(t) = sin(2\pi k t)$ but is calculated similar to a TTRR. This can be added, but the current PR is more of a proof of concept.
- While working through the different iterations of this parameterization, I ended up slightly changing the nomenclature for MapFactory's `REGISTER_MONO_COMP` to work better for future perhaps heterogeneous map types
- This doesn't have bindings. Since we have a developer's `main` branch, I'm going to make separate PRs for that kind of stuff. I'm also open to merging this into a completely separate branch.